### PR TITLE
feat: use remote Custom Types API for type and slice commands

### DIFF
--- a/src/codegen-types.ts
+++ b/src/codegen-types.ts
@@ -29,6 +29,51 @@ EXAMPLES
   prismic codegen types --output custom.d.ts
 `.trim();
 
+export async function generateTypesFile(repo: string, output = "prismicio-types.d.ts"): Promise<void> {
+	try {
+		const [customTypesResult, slicesResult, localesResult] = await Promise.all([
+			fetchRemoteCustomTypes(repo),
+			fetchRemoteSlices(repo),
+			getLocales(repo),
+		]);
+
+		if (!customTypesResult.ok) {
+			console.warn(`Warning: Could not generate types: ${customTypesResult.error}`);
+			return;
+		}
+		if (!slicesResult.ok) {
+			console.warn(`Warning: Could not generate types: ${slicesResult.error}`);
+			return;
+		}
+		if (!localesResult.ok) {
+			console.warn(`Warning: Could not generate types: ${localesResult.error}`);
+			return;
+		}
+
+		const customTypes = customTypesResult.value as unknown as CustomTypeModel[];
+		const slices = slicesResult.value as unknown as SharedSliceModel[];
+		const localeIDs = localesResult.value.results.map((l) => l.id);
+
+		const types = generateTypes({
+			customTypeModels: customTypes,
+			sharedSliceModels: slices,
+			localeIDs,
+			typesProvider: "@prismicio/client",
+			clientIntegration: {
+				includeCreateClientInterface: customTypes.length > 0 || slices.length > 0,
+				includeContentNamespace: true,
+			},
+		});
+
+		const content = NON_EDITABLE_FILE_HEADER + "\n\n" + types;
+		await writeFile(output, content);
+		console.info(`Generated types written to ${output}`);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.warn(`Warning: Type generation failed: ${message}`);
+	}
+}
+
 export async function codegenTypes(): Promise<void> {
 	const {
 		values: { help, repo = await safeGetRepositoryFromConfig(), output = "prismicio-types.d.ts" },
@@ -59,47 +104,5 @@ export async function codegenTypes(): Promise<void> {
 		return;
 	}
 
-	const [customTypesResult, slicesResult, localesResult] = await Promise.all([
-		fetchRemoteCustomTypes(repo),
-		fetchRemoteSlices(repo),
-		getLocales(repo),
-	]);
-
-	if (!customTypesResult.ok) {
-		console.error(`Failed to fetch custom types: ${customTypesResult.error}`);
-		process.exitCode = 1;
-		return;
-	}
-
-	if (!slicesResult.ok) {
-		console.error(`Failed to fetch slices: ${slicesResult.error}`);
-		process.exitCode = 1;
-		return;
-	}
-
-	if (!localesResult.ok) {
-		console.error(`Failed to fetch locales: ${localesResult.error}`);
-		process.exitCode = 1;
-		return;
-	}
-
-	const customTypes = customTypesResult.value as unknown as CustomTypeModel[];
-	const slices = slicesResult.value as unknown as SharedSliceModel[];
-	const localeIDs = localesResult.value.results.map((l) => l.id);
-
-	const types = generateTypes({
-		customTypeModels: customTypes,
-		sharedSliceModels: slices,
-		localeIDs,
-		typesProvider: "@prismicio/client",
-		clientIntegration: {
-			includeCreateClientInterface: customTypes.length > 0 || slices.length > 0,
-			includeContentNamespace: true,
-		},
-	});
-
-	const content = NON_EDITABLE_FILE_HEADER + "\n\n" + types;
-
-	await writeFile(output, content);
-	console.info(`Generated types written to ${output}`);
+	await generateTypesFile(repo, output);
 }

--- a/src/custom-type-add-field-boolean.ts
+++ b/src/custom-type-add-field-boolean.ts
@@ -1,12 +1,12 @@
 import type { BooleanField, CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a boolean (toggle) field to an existing custom type.
@@ -19,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
       --default          Set default value to true
       --true-label string Label shown when toggle is on
       --false-label string Label shown when toggle is off
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -32,34 +35,31 @@ EXAMPLES
   prismic custom-type add-field boolean product available --true-label "In Stock" --false-label "Out of Stock"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldBoolean(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			default: defaultValue,
 			"true-label": trueLabel,
 			"false-label": falseLabel,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "boolean"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			default: { type: "boolean" },
 			"true-label": { type: "string" },
 			"false-label": { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -84,42 +84,28 @@ export async function customTypeAddFieldBoolean(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -153,20 +139,16 @@ export async function customTypeAddFieldBoolean(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Boolean) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Boolean) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-color.ts
+++ b/src/custom-type-add-field-color.ts
@@ -1,12 +1,12 @@
 import type { Color, CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a color picker field to an existing custom type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic custom-type add-field color homepage text_color --label "Text Color"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldColor(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "color"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function customTypeAddFieldColor(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function customTypeAddFieldColor(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Color) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Color) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-date.ts
+++ b/src/custom-type-add-field-date.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Date as DateField } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a date field to an existing custom type.
@@ -19,10 +19,13 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --default string   Default date value (YYYY-MM-DD format)
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,26 +34,20 @@ EXAMPLES
   prismic custom-type add-field date article date --label "Publication Date" --default "2024-01-01"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldDate(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "date"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -75,42 +72,28 @@ export async function customTypeAddFieldDate(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -143,20 +126,16 @@ export async function customTypeAddFieldDate(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Date) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Date) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-embed.ts
+++ b/src/custom-type-add-field-embed.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Embed } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an embed field to an existing custom type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic custom-type add-field embed homepage media --label "Media Embed"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldEmbed(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "embed"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function customTypeAddFieldEmbed(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function customTypeAddFieldEmbed(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Embed) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Embed) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-geo-point.ts
+++ b/src/custom-type-add-field-geo-point.ts
@@ -1,12 +1,12 @@
 import type { CustomType, GeoPoint } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a geo-point (location) field to an existing custom type.
@@ -19,8 +19,11 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -29,24 +32,18 @@ EXAMPLES
   prismic custom-type add-field geo-point event venue --label "Event Venue"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldGeoPoint(): Promise<void> {
 	const {
-		values: { help, tab, label },
+		values: { help, repo: repoFlag, tab, label, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "geo-point"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -71,42 +68,28 @@ export async function customTypeAddFieldGeoPoint(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -137,20 +120,16 @@ export async function customTypeAddFieldGeoPoint(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (GeoPoint) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (GeoPoint) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-image.ts
+++ b/src/custom-type-add-field-image.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Image } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an image field to an existing custom type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic custom-type add-field image product photo --label "Product Photo"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldImage(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "image"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function customTypeAddFieldImage(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function customTypeAddFieldImage(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Image) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Image) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-key-text.ts
+++ b/src/custom-type-add-field-key-text.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Text } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a key-text (single-line text) field to an existing custom type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic custom-type add-field key-text homepage subtitle --label "Subtitle" --placeholder "Enter subtitle"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldKeyText(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "key-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function customTypeAddFieldKeyText(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function customTypeAddFieldKeyText(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Text) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Text) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-link.ts
+++ b/src/custom-type-add-field-link.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Link } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a link field to an existing custom type.
@@ -19,6 +19,7 @@ ARGUMENTS
   field-id                 Field identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -t, --tab string         Target tab (default: first existing tab, or "Main")
   -l, --label string       Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
@@ -26,6 +27,8 @@ FLAGS
       --allow-text         Allow text with link
       --allow-target-blank Allow opening link in new tab
       --repeatable         Allow multiple links
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -35,19 +38,11 @@ EXAMPLES
   prismic custom-type add-field link homepage links --repeatable
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldLink(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			placeholder,
@@ -55,11 +50,14 @@ export async function customTypeAddFieldLink(): Promise<void> {
 			"allow-text": allowText,
 			"allow-target-blank": allowTargetBlank,
 			repeatable,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "link"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
@@ -67,6 +65,8 @@ export async function customTypeAddFieldLink(): Promise<void> {
 			"allow-text": { type: "boolean" },
 			"allow-target-blank": { type: "boolean" },
 			repeatable: { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -91,42 +91,28 @@ export async function customTypeAddFieldLink(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -162,20 +148,16 @@ export async function customTypeAddFieldLink(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Link) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Link) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-number.ts
+++ b/src/custom-type-add-field-number.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Number as NumberField } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a number field to an existing custom type.
@@ -19,12 +19,15 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --min number       Minimum value
       --max number       Maximum value
       --step number      Step increment
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -33,28 +36,22 @@ EXAMPLES
   prismic custom-type add-field number settings rating --min 1 --max 5 --step 1
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldNumber(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, min, max, step },
+		values: { help, repo: repoFlag, tab, label, placeholder, min, max, step, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "number"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			min: { type: "string" },
 			max: { type: "string" },
 			step: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -102,42 +99,28 @@ export async function customTypeAddFieldNumber(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -172,20 +155,16 @@ export async function customTypeAddFieldNumber(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Number) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Number) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-rich-text.ts
+++ b/src/custom-type-add-field-rich-text.ts
@@ -1,12 +1,12 @@
 import type { CustomType, RichText } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a rich text field to an existing custom type.
@@ -19,12 +19,15 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --single string    Allowed block types for single-line (comma-separated)
       --multi string     Allowed block types for multi-line (comma-separated)
       --allow-target-blank Allow opening links in new tab
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 BLOCK TYPES
@@ -39,36 +42,33 @@ EXAMPLES
   prismic custom-type add-field rich-text blog post --multi "paragraph,strong,em,hyperlink" --allow-target-blank
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldRichText(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			placeholder,
 			single,
 			multi,
 			"allow-target-blank": allowTargetBlank,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "rich-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			single: { type: "string" },
 			multi: { type: "string" },
 			"allow-target-blank": { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -93,42 +93,28 @@ export async function customTypeAddFieldRichText(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -163,20 +149,16 @@ export async function customTypeAddFieldRichText(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (StructuredText) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (StructuredText) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-select.ts
+++ b/src/custom-type-add-field-select.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Select } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a select (dropdown) field to an existing custom type.
@@ -19,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --option string    Add an option (can be used multiple times)
       --default string   Default selected value
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -32,27 +35,21 @@ EXAMPLES
   prismic custom-type add-field select article status --option "draft" --option "published" --label "Status"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldSelect(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, option, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, option, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "select"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			option: { type: "string", multiple: true },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -77,42 +74,28 @@ export async function customTypeAddFieldSelect(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -146,20 +129,16 @@ export async function customTypeAddFieldSelect(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Select) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Select) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-timestamp.ts
+++ b/src/custom-type-add-field-timestamp.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Timestamp } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a timestamp (date and time) field to an existing custom type.
@@ -19,10 +19,13 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --default string   Default timestamp value (ISO 8601 format)
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,26 +34,20 @@ EXAMPLES
   prismic custom-type add-field timestamp article published_at --label "Published At"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldTimestamp(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "timestamp"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -75,42 +72,28 @@ export async function customTypeAddFieldTimestamp(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -143,20 +126,16 @@ export async function customTypeAddFieldTimestamp(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Timestamp) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Timestamp) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-add-field-uid.ts
+++ b/src/custom-type-add-field-uid.ts
@@ -1,12 +1,12 @@
 import type { CustomType, UID } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a UID (unique identifier) field to an existing custom type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic custom-type add-field uid product sku --placeholder "Enter unique SKU"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeAddFieldUid(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "custom-type", "add-field", "uid"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function customTypeAddFieldUid(): Promise<void> {
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function customTypeAddFieldUid(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (UID) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (UID) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-connect-slice.ts
+++ b/src/custom-type-connect-slice.ts
@@ -4,13 +4,12 @@ import type {
 	SharedSliceRef,
 } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, fetchSlice, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Connect a shared slice to a custom type's slice zone.
@@ -23,7 +22,10 @@ ARGUMENTS
   slice-id               Slice identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -z, --slice-zone string  Target slice zone field ID (default: "slices")
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -32,23 +34,17 @@ EXAMPLES
   prismic custom-type connect-slice article HeroSection -z body
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeConnectSlice(): Promise<void> {
 	const {
-		values: { help, "slice-zone": sliceZoneId },
+		values: { help, repo: repoFlag, "slice-zone": sliceZoneId, types, "no-types": noTypes },
 		positionals: [typeId, sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "connect-slice"
 		options: {
+			repo: { type: "string", short: "r" },
 			"slice-zone": { type: "string", short: "z" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -61,73 +57,49 @@ export async function customTypeConnectSlice(): Promise<void> {
 
 	if (!typeId) {
 		console.error("Missing required argument: type-id\n");
-		console.error(
-			"Usage: prismic custom-type connect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic custom-type connect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic custom-type connect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic custom-type connect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Verify the slice exists
-	const sliceResult = await findSliceModel(sliceId);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
+		return;
+	}
+
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	// Verify the slice exists on remote
+	const sliceResult = await fetchSlice(repo, sliceId);
 	if (!sliceResult.ok) {
 		console.error(sliceResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	// Fetch the custom type
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(
-				`Create it first with: prismic custom-type create ${typeId}`,
-			);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
-		process.exitCode = 1;
-		return;
-	}
-
+	const model: CustomType = fetchResult.value;
 	const targetSliceZoneId = sliceZoneId ?? "slices";
 
 	// Find existing slice zone or create a new one
@@ -137,10 +109,7 @@ export async function customTypeConnectSlice(): Promise<void> {
 	// Search all tabs for a Slices field matching the target ID
 	for (const [, tabFields] of Object.entries(model.json)) {
 		for (const [fieldId, field] of Object.entries(tabFields)) {
-			if (
-				(field as { type?: string }).type === "Slices" &&
-				fieldId === targetSliceZoneId
-			) {
+			if ((field as { type?: string }).type === "Slices" && fieldId === targetSliceZoneId) {
 				sliceZone = field as DynamicSlices;
 				sliceZoneFieldId = fieldId;
 				break;
@@ -153,9 +122,7 @@ export async function customTypeConnectSlice(): Promise<void> {
 	if (!sliceZone) {
 		if (sliceZoneId) {
 			// User specified a slice zone that doesn't exist
-			console.error(
-				`Slice zone "${sliceZoneId}" not found in custom type "${typeId}"`,
-			);
+			console.error(`Slice zone "${sliceZoneId}" not found in custom type "${typeId}"`);
 			process.exitCode = 1;
 			return;
 		}
@@ -202,20 +169,16 @@ export async function customTypeConnectSlice(): Promise<void> {
 	const sliceRef: SharedSliceRef = { type: "SharedSlice" };
 	sliceZone.config.choices[sliceId] = sliceRef;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Connected slice "${sliceId}" to slice zone "${sliceZoneFieldId}" in ${typeId}`,
-	);
+	console.info(`Connected slice "${sliceId}" to slice zone "${sliceZoneFieldId}" in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-create.ts
+++ b/src/custom-type-create.ts
@@ -1,10 +1,11 @@
 import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { mkdir, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { insertCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Create a new custom type in a Prismic repository.
@@ -16,8 +17,11 @@ ARGUMENTS
   id       Custom type identifier (required)
 
 FLAGS
+  -r, --repo string   Repository domain
   -n, --name string   Display name for the custom type
       --single        Create as a singleton (non-repeatable) type
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help          Show help for command
 
 LEARN MORE
@@ -26,13 +30,16 @@ LEARN MORE
 
 export async function customTypeCreate(): Promise<void> {
 	const {
-		values: { help, name, single },
+		values: { help, name, single, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [id],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "create"
 		options: {
+			repo: { type: "string", short: "r" },
 			name: { type: "string", short: "n" },
 			single: { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -49,6 +56,20 @@ export async function customTypeCreate(): Promise<void> {
 		return;
 	}
 
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
+		return;
+	}
+
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
 	const model = {
 		id,
 		label: name ?? pascalCase(id),
@@ -60,31 +81,18 @@ export async function customTypeCreate(): Promise<void> {
 		},
 	} satisfies CustomType;
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const result = await insertCustomType(repo, model);
+	if (!result.ok) {
+		console.error(`Failed to create custom type: ${result.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	const customTypesDirectory = new URL("customtypes/", projectRoot);
-	const typeDirectory = new URL(id + "/", customTypesDirectory);
-	const modelPath = new URL("index.json", typeDirectory);
+	console.info(`Created custom type "${id}" in repository "${repo}"`);
 
-	try {
-		await mkdir(new URL(".", modelPath), { recursive: true });
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to create custom type: ${error.message}`);
-		} else {
-			console.error(`Failed to create custom type`);
-		}
-		process.exitCode = 1;
-		return;
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
 	}
-
-	console.info(`Created custom type at ${modelPath.href}`);
 }
 
 export function pascalCase(input: string): string {

--- a/src/custom-type-disconnect-slice.ts
+++ b/src/custom-type-disconnect-slice.ts
@@ -1,14 +1,11 @@
-import type {
-	CustomType,
-	DynamicSlices,
-} from "@prismicio/types-internal/lib/customtypes";
+import type { CustomType, DynamicSlices } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Disconnect a shared slice from a custom type's slice zone.
@@ -21,7 +18,10 @@ ARGUMENTS
   slice-id               Slice identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -z, --slice-zone string  Target slice zone field ID (default: "slices")
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -30,23 +30,17 @@ EXAMPLES
   prismic custom-type disconnect-slice article HeroSection -z body
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function customTypeDisconnectSlice(): Promise<void> {
 	const {
-		values: { help, "slice-zone": sliceZoneId },
+		values: { help, repo: repoFlag, "slice-zone": sliceZoneId, types, "no-types": noTypes },
 		positionals: [typeId, sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "disconnect-slice"
 		options: {
+			repo: { type: "string", short: "r" },
 			"slice-zone": { type: "string", short: "z" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -59,65 +53,40 @@ export async function customTypeDisconnectSlice(): Promise<void> {
 
 	if (!typeId) {
 		console.error("Missing required argument: type-id\n");
-		console.error(
-			"Usage: prismic custom-type disconnect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic custom-type disconnect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic custom-type disconnect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic custom-type disconnect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Find the custom type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(
-				`Create it first with: prismic custom-type create ${typeId}`,
-			);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 	const targetSliceZoneId = sliceZoneId ?? "slices";
 
 	// Find existing slice zone
@@ -127,10 +96,7 @@ export async function customTypeDisconnectSlice(): Promise<void> {
 	// Search all tabs for a Slices field matching the target ID
 	for (const [, tabFields] of Object.entries(model.json)) {
 		for (const [fieldId, field] of Object.entries(tabFields)) {
-			if (
-				(field as { type?: string }).type === "Slices" &&
-				fieldId === targetSliceZoneId
-			) {
+			if ((field as { type?: string }).type === "Slices" && fieldId === targetSliceZoneId) {
 				sliceZone = field as DynamicSlices;
 				sliceZoneFieldId = fieldId;
 				break;
@@ -141,9 +107,7 @@ export async function customTypeDisconnectSlice(): Promise<void> {
 
 	// Slice zone must exist for disconnect
 	if (!sliceZone) {
-		console.error(
-			`Slice zone "${targetSliceZoneId}" not found in custom type "${typeId}"`,
-		);
+		console.error(`Slice zone "${targetSliceZoneId}" not found in custom type "${typeId}"`);
 		process.exitCode = 1;
 		return;
 	}
@@ -160,15 +124,9 @@ export async function customTypeDisconnectSlice(): Promise<void> {
 	// Remove the slice reference
 	delete sliceZone.config.choices[sliceId];
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -176,4 +134,8 @@ export async function customTypeDisconnectSlice(): Promise<void> {
 	console.info(
 		`Disconnected slice "${sliceId}" from slice zone "${sliceZoneFieldId}" in ${typeId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-list.ts
+++ b/src/custom-type-list.ts
@@ -1,39 +1,33 @@
-import { readdir, readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteNonPageCustomTypes } from "./lib/custom-types-api";
 
 const HELP = `
-List all custom types in a Prismic project.
+List all custom types in a Prismic repository.
 
 USAGE
   prismic custom-type list [flags]
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --json          Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic custom-type list
   prismic custom-type list --json
+  prismic custom-type list --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function customTypeList(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "list"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -45,49 +39,28 @@ export async function customTypeList(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const customTypesDirectory = new URL("customtypes/", projectRoot);
-
-	let entries: string[];
-	try {
-		entries = (await readdir(customTypesDirectory, {
-			withFileTypes: false,
-		})) as unknown as string[];
-	} catch {
-		if (json) {
-			console.info(JSON.stringify([]));
-		} else {
-			console.info("No custom types found.");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
 		return;
 	}
 
-	const customTypes: { id: string; label: string; repeatable: boolean }[] = [];
-
-	for (const entry of entries) {
-		const modelPath = new URL(`${entry}/index.json`, customTypesDirectory);
-		try {
-			const contents = await readFile(modelPath, "utf8");
-			const parsed = JSON.parse(contents);
-			const result = v.safeParse(CustomTypeSchema, parsed);
-			// Custom types have format !== "page" (either "custom" or undefined)
-			if (result.success && result.output.format !== "page") {
-				customTypes.push({
-					id: result.output.id,
-					label: result.output.label,
-					repeatable: result.output.repeatable,
-				});
-			}
-		} catch {
-			// Skip directories without valid index.json
-		}
+	const result = await fetchRemoteNonPageCustomTypes(repo);
+	if (!result.ok) {
+		console.error(result.error);
+		process.exitCode = 1;
+		return;
 	}
+
+	const customTypes = result.value;
 
 	if (customTypes.length === 0) {
 		if (json) {
@@ -99,7 +72,17 @@ export async function customTypeList(): Promise<void> {
 	}
 
 	if (json) {
-		console.info(JSON.stringify(customTypes, null, 2));
+		console.info(
+			JSON.stringify(
+				customTypes.map((ct) => ({
+					id: ct.id,
+					label: ct.label,
+					repeatable: ct.repeatable,
+				})),
+				null,
+				2,
+			),
+		);
 	} else {
 		console.info("ID\tLABEL\tTYPE");
 		for (const customType of customTypes) {

--- a/src/custom-type-remove-field.ts
+++ b/src/custom-type-remove-field.ts
@@ -1,11 +1,9 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Remove a field from a custom type.
@@ -18,31 +16,29 @@ ARGUMENTS
   field-id     Field identifier (required)
 
 FLAGS
-  --tab string  Specific tab (searches all tabs if not specified)
-  -h, --help    Show help for command
+  -r, --repo string   Repository domain
+      --tab string    Specific tab (searches all tabs if not specified)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic custom-type remove-field settings title
   prismic custom-type remove-field settings description --tab "Content"
+  prismic custom-type remove-field settings title --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function customTypeRemoveField(): Promise<void> {
 	const {
-		values: { help, tab },
+		values: { help, tab, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "remove-field"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -67,48 +63,28 @@ export async function customTypeRemoveField(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a custom type (not a page type)
-	if (model.format === "page") {
-		console.error(`"${typeId}" is not a custom type (format: page)`);
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
+
+	const model = fetchResult.value;
 
 	// Find and remove the field
 	let foundTab: string | undefined;
@@ -144,18 +120,16 @@ export async function customTypeRemoveField(): Promise<void> {
 		}
 	}
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	console.info(`Removed field "${fieldId}" from tab "${foundTab}" in custom type "${typeId}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-remove.ts
+++ b/src/custom-type-remove.ts
@@ -1,13 +1,12 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { deleteCustomType, fetchRemoteCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
-Remove a custom type from the project.
+Remove a custom type from the repository.
 
 USAGE
   prismic custom-type remove <type-id> [flags]
@@ -16,31 +15,29 @@ ARGUMENTS
   type-id      Custom type identifier (required)
 
 FLAGS
-  -y           Confirm removal
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  -y                   Confirm removal
+      --types string   Generate types to file (default: "prismicio-types.d.ts")
+      --no-types       Skip type generation
+  -h, --help           Show help for command
 
 EXAMPLES
   prismic custom-type remove settings
   prismic custom-type remove settings -y
+  prismic custom-type remove settings --repo my-repo -y
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function customTypeRemove(): Promise<void> {
 	const {
-		values: { help, y },
+		values: { help, y, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "remove"
 		options: {
+			repo: { type: "string", short: "r" },
 			y: { type: "boolean", short: "y" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -58,69 +55,46 @@ export async function customTypeRemove(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const typeDirectory = new URL(`customtypes/${typeId}/`, projectRoot);
-	const modelPath = new URL("index.json", typeDirectory);
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
 
 	// Verify the custom type exists and is actually a custom type
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
-		process.exitCode = 1;
-		return;
-	}
-
-	// Check if this is actually a custom type (not a page type)
-	if (model.format === "page") {
-		console.error(`"${typeId}" is not a custom type (format: page)`);
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
 	// Require -y flag to confirm deletion
 	if (!y) {
-		console.error(`Refusing to remove custom type "${typeId}" (this will delete the entire directory).`);
+		console.error(`Refusing to remove custom type "${typeId}" (this is a destructive action).`);
 		console.error("Re-run with -y to confirm.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Delete the custom type directory
-	try {
-		await rm(typeDirectory, { recursive: true });
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to remove custom type: ${error.message}`);
-		} else {
-			console.error("Failed to remove custom type");
-		}
+	const deleteResult = await deleteCustomType(repo, typeId);
+	if (!deleteResult.ok) {
+		console.error(`Failed to remove custom type: ${deleteResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(`Removed custom type "${typeId}"`);
+	console.info(`Removed custom type "${typeId}" from repository "${repo}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-set-name.ts
+++ b/src/custom-type-set-name.ts
@@ -1,11 +1,9 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Change a custom type's display name (label).
@@ -18,29 +16,27 @@ ARGUMENTS
   new-name     New display name (required)
 
 FLAGS
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic custom-type set-name settings "Site Settings"
   prismic custom-type set-name menu "Navigation Menu"
+  prismic custom-type set-name settings "Site Settings" --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function customTypeSetName(): Promise<void> {
 	const {
-		values: { help },
+		values: { help, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId, newName],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "set-name"
 		options: {
+			repo: { type: "string", short: "r" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -65,64 +61,40 @@ export async function customTypeSetName(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a custom type (not a page type)
-	if (model.format === "page") {
-		console.error(`"${typeId}" is not a custom type (format: page)`);
+	const fetchResult = await fetchRemoteCustomType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	// Update the model
+	const model = fetchResult.value;
 	model.label = newName;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update custom type: ${error.message}`);
-		} else {
-			console.error("Failed to update custom type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update custom type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	console.info(`Renamed custom type "${typeId}" to "${newName}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/custom-type-view.ts
+++ b/src/custom-type-view.ts
@@ -1,10 +1,8 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteCustomType } from "./lib/custom-types-api";
 
 const HELP = `
 View details of a specific custom type.
@@ -16,30 +14,24 @@ ARGUMENTS
   type-id      Custom type identifier (required)
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --json          Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic custom-type view settings
   prismic custom-type view settings --json
+  prismic custom-type view settings --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function customTypeView(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 		positionals: [typeId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "custom-type", "view"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -58,47 +50,28 @@ export async function customTypeView(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid custom type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Custom type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic custom-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read custom type: ${error.message}`);
-		} else {
-			console.error("Failed to read custom type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a custom type (not a page type)
-	if (model.format === "page") {
-		console.error(`"${typeId}" is not a custom type (format: page)`);
+	const result = await fetchRemoteCustomType(repo, typeId);
+	if (!result.ok) {
+		console.error(result.error);
 		process.exitCode = 1;
 		return;
 	}
+
+	const model = result.value;
 
 	if (json) {
 		console.info(JSON.stringify(model, null, 2));

--- a/src/custom-type.ts
+++ b/src/custom-type.ts
@@ -11,7 +11,7 @@ import { customTypeSetName } from "./custom-type-set-name";
 import { customTypeView } from "./custom-type-view";
 
 const HELP = `
-Manage custom types in a Prismic repository.
+Manage custom types in a Prismic repository. Commands operate on the remote repository.
 
 USAGE
   prismic custom-type <command> [flags]

--- a/src/init.ts
+++ b/src/init.ts
@@ -50,7 +50,9 @@ export async function init(): Promise<void> {
 
 	if (!result.ok) {
 		if (result.error instanceof UnknownProjectRoot) {
-			console.error("Could not find a package.json file. Run this command from a project directory.");
+			console.error(
+				"Could not find a package.json file. Run this command from a project directory.",
+			);
 		} else {
 			console.error("Failed to create config file.");
 		}

--- a/src/lib/custom-types-api.ts
+++ b/src/lib/custom-types-api.ts
@@ -43,10 +43,16 @@ export async function fetchRemoteCustomTypes(repo: string): Promise<FetchResult<
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -82,10 +88,16 @@ export async function fetchRemoteSlices(repo: string): Promise<FetchResult<Share
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -102,6 +114,160 @@ export async function fetchRemoteSlices(repo: string): Promise<FetchResult<Share
 	}
 }
 
+export async function fetchCustomType(repo: string, id: string): Promise<FetchResult<CustomType>> {
+	const token = await readToken();
+	if (!token) {
+		return { ok: false, error: "Not authenticated" };
+	}
+
+	const baseUrl = await getCustomTypesApiUrl();
+	const url = new URL(`customtypes/${encodeURIComponent(id)}`, baseUrl);
+
+	try {
+		const response = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				repository: repo,
+			},
+		});
+
+		if (!response.ok) {
+			if (response.status === 401) {
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
+			}
+			if (response.status === 403) {
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
+			}
+			if (response.status === 404) {
+				return { ok: false, error: `Custom type "${id}" not found in repository "${repo}".` };
+			}
+			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
+		}
+
+		const data = await response.json();
+		const result = v.safeParse(CustomTypeSchema, data);
+		if (!result.success) {
+			return { ok: false, error: "Invalid response from Custom Types API" };
+		}
+
+		return { ok: true, value: result.output as CustomType };
+	} catch (error) {
+		return { ok: false, error: `Network error: ${error instanceof Error ? error.message : error}` };
+	}
+}
+
+export async function fetchSlice(repo: string, id: string): Promise<FetchResult<SharedSlice>> {
+	const token = await readToken();
+	if (!token) {
+		return { ok: false, error: "Not authenticated" };
+	}
+
+	const baseUrl = await getCustomTypesApiUrl();
+	const url = new URL(`slices/${encodeURIComponent(id)}`, baseUrl);
+
+	try {
+		const response = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${token}`,
+				repository: repo,
+			},
+		});
+
+		if (!response.ok) {
+			if (response.status === 401) {
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
+			}
+			if (response.status === 403) {
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
+			}
+			if (response.status === 404) {
+				return { ok: false, error: `Slice "${id}" not found in repository "${repo}".` };
+			}
+			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
+		}
+
+		const data = await response.json();
+		const result = v.safeParse(SharedSliceSchema, data);
+		if (!result.success) {
+			return { ok: false, error: "Invalid response from Custom Types API" };
+		}
+
+		return { ok: true, value: result.output as SharedSlice };
+	} catch (error) {
+		return { ok: false, error: `Network error: ${error instanceof Error ? error.message : error}` };
+	}
+}
+
+export async function fetchRemoteCustomType(
+	repo: string,
+	id: string,
+): Promise<FetchResult<CustomType>> {
+	const result = await fetchCustomType(repo, id);
+	if (!result.ok) {
+		return result;
+	}
+
+	if (result.value.format === "page") {
+		return {
+			ok: false,
+			error: `"${id}" is not a custom type (format: page)`,
+		};
+	}
+
+	return result;
+}
+
+export async function fetchRemoteNonPageCustomTypes(
+	repo: string,
+): Promise<FetchResult<CustomType[]>> {
+	const result = await fetchRemoteCustomTypes(repo);
+	if (!result.ok) {
+		return result;
+	}
+
+	return { ok: true, value: result.value.filter((ct) => ct.format !== "page") };
+}
+
+export async function fetchRemotePageType(
+	repo: string,
+	id: string,
+): Promise<FetchResult<CustomType>> {
+	const result = await fetchCustomType(repo, id);
+	if (!result.ok) {
+		return result;
+	}
+
+	if (result.value.format !== "page") {
+		return {
+			ok: false,
+			error: `"${id}" is not a page type (format: ${result.value.format ?? "custom"})`,
+		};
+	}
+
+	return result;
+}
+
+export async function fetchRemotePageTypes(repo: string): Promise<FetchResult<CustomType[]>> {
+	const result = await fetchRemoteCustomTypes(repo);
+	if (!result.ok) {
+		return result;
+	}
+
+	return { ok: true, value: result.value.filter((ct) => ct.format === "page") };
+}
+
 export async function readLocalCustomTypes(): Promise<FetchResult<CustomType[]>> {
 	const projectRoot = await findUpward("package.json");
 	if (!projectRoot) {
@@ -113,7 +279,7 @@ export async function readLocalCustomTypes(): Promise<FetchResult<CustomType[]>>
 
 	let entries: string[];
 	try {
-		entries = await readdir(customTypesDir, { withFileTypes: false }) as unknown as string[];
+		entries = (await readdir(customTypesDir, { withFileTypes: false })) as unknown as string[];
 	} catch {
 		// No customtypes directory means no local custom types
 		return { ok: true, value: [] };
@@ -147,7 +313,7 @@ export async function readLocalSlices(): Promise<FetchResult<SharedSlice[]>> {
 
 	let entries: string[];
 	try {
-		entries = await readdir(slicesDir, { withFileTypes: false }) as unknown as string[];
+		entries = (await readdir(slicesDir, { withFileTypes: false })) as unknown as string[];
 	} catch {
 		// No slices directory means no local slices
 		return { ok: true, value: [] };
@@ -171,7 +337,10 @@ export async function readLocalSlices(): Promise<FetchResult<SharedSlice[]>> {
 	return { ok: true, value: slices };
 }
 
-export async function insertCustomType(repo: string, model: CustomType): Promise<FetchResult<void>> {
+export async function insertCustomType(
+	repo: string,
+	model: CustomType,
+): Promise<FetchResult<void>> {
 	const token = await readToken();
 	if (!token) {
 		return { ok: false, error: "Not authenticated" };
@@ -193,10 +362,16 @@ export async function insertCustomType(repo: string, model: CustomType): Promise
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -207,7 +382,10 @@ export async function insertCustomType(repo: string, model: CustomType): Promise
 	}
 }
 
-export async function updateCustomType(repo: string, model: CustomType): Promise<FetchResult<void>> {
+export async function updateCustomType(
+	repo: string,
+	model: CustomType,
+): Promise<FetchResult<void>> {
 	const token = await readToken();
 	if (!token) {
 		return { ok: false, error: "Not authenticated" };
@@ -229,10 +407,16 @@ export async function updateCustomType(repo: string, model: CustomType): Promise
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -263,10 +447,16 @@ export async function deleteCustomType(repo: string, id: string): Promise<FetchR
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -299,10 +489,16 @@ export async function insertSlice(repo: string, model: SharedSlice): Promise<Fet
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -335,10 +531,16 @@ export async function updateSlice(repo: string, model: SharedSlice): Promise<Fet
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}
@@ -369,10 +571,16 @@ export async function deleteSlice(repo: string, id: string): Promise<FetchResult
 
 		if (!response.ok) {
 			if (response.status === 401) {
-				return { ok: false, error: "Unauthorized. Your session may have expired. Run `prismic login` again." };
+				return {
+					ok: false,
+					error: "Unauthorized. Your session may have expired. Run `prismic login` again.",
+				};
 			}
 			if (response.status === 403) {
-				return { ok: false, error: `Access denied. You may not have access to repository "${repo}".` };
+				return {
+					ok: false,
+					error: `Access denied. You may not have access to repository "${repo}".`,
+				};
 			}
 			return { ok: false, error: `API error: ${response.status} ${response.statusText}` };
 		}

--- a/src/lib/slice.ts
+++ b/src/lib/slice.ts
@@ -39,7 +39,7 @@ export async function findSliceModel(sliceId: string): Promise<SliceModelResult>
 	// List all directories in slices folder
 	let entries: string[];
 	try {
-		entries = await readdir(slicesDirectory, { withFileTypes: false }) as unknown as string[];
+		entries = (await readdir(slicesDirectory, { withFileTypes: false })) as unknown as string[];
 	} catch {
 		return { ok: false, error: `No slices directory found at ${slicesDirectory.href}` };
 	}
@@ -62,7 +62,10 @@ export async function findSliceModel(sliceId: string): Promise<SliceModelResult>
 		}
 	}
 
-	return { ok: false, error: `Slice not found: ${sliceId}\n\nCreate it first with: prismic slice create ${sliceId}` };
+	return {
+		ok: false,
+		error: `Slice not found: ${sliceId}\n\nCreate it first with: prismic slice create ${sliceId}`,
+	};
 }
 
 export async function getSlicesDirectory(): Promise<URL> {

--- a/src/page-type-add-field-boolean.ts
+++ b/src/page-type-add-field-boolean.ts
@@ -1,12 +1,12 @@
 import type { BooleanField, CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a boolean (toggle) field to an existing page type.
@@ -19,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
       --default          Set default value to true
       --true-label string Label shown when toggle is on
       --false-label string Label shown when toggle is off
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -32,34 +35,31 @@ EXAMPLES
   prismic page-type add-field boolean product available --true-label "In Stock" --false-label "Out of Stock"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldBoolean(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			default: defaultValue,
 			"true-label": trueLabel,
 			"false-label": falseLabel,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "boolean"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			default: { type: "boolean" },
 			"true-label": { type: "string" },
 			"false-label": { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -84,42 +84,28 @@ export async function pageTypeAddFieldBoolean(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -153,20 +139,16 @@ export async function pageTypeAddFieldBoolean(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Boolean) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Boolean) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-color.ts
+++ b/src/page-type-add-field-color.ts
@@ -1,12 +1,12 @@
 import type { Color, CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a color picker field to an existing page type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic page-type add-field color homepage text_color --label "Text Color"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldColor(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "color"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function pageTypeAddFieldColor(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function pageTypeAddFieldColor(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Color) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Color) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-date.ts
+++ b/src/page-type-add-field-date.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Date as DateField } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a date field to an existing page type.
@@ -19,10 +19,13 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --default string   Default date value (YYYY-MM-DD format)
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,26 +34,20 @@ EXAMPLES
   prismic page-type add-field date article date --label "Publication Date" --default "2024-01-01"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldDate(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "date"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -75,42 +72,28 @@ export async function pageTypeAddFieldDate(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -143,20 +126,16 @@ export async function pageTypeAddFieldDate(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Date) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Date) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-embed.ts
+++ b/src/page-type-add-field-embed.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Embed } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an embed field to an existing page type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic page-type add-field embed homepage media --label "Media Embed"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldEmbed(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "embed"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function pageTypeAddFieldEmbed(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function pageTypeAddFieldEmbed(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Embed) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Embed) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-geo-point.ts
+++ b/src/page-type-add-field-geo-point.ts
@@ -1,12 +1,12 @@
 import type { CustomType, GeoPoint } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a geo-point (location) field to an existing page type.
@@ -19,8 +19,11 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -29,24 +32,18 @@ EXAMPLES
   prismic page-type add-field geo-point event venue --label "Event Venue"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldGeoPoint(): Promise<void> {
 	const {
-		values: { help, tab, label },
+		values: { help, repo: repoFlag, tab, label, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "geo-point"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -71,42 +68,28 @@ export async function pageTypeAddFieldGeoPoint(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -137,20 +120,16 @@ export async function pageTypeAddFieldGeoPoint(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (GeoPoint) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (GeoPoint) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-image.ts
+++ b/src/page-type-add-field-image.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Image } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an image field to an existing page type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic page-type add-field image product photo --label "Product Photo"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldImage(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "image"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function pageTypeAddFieldImage(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function pageTypeAddFieldImage(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Image) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Image) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-key-text.ts
+++ b/src/page-type-add-field-key-text.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Text } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a key-text (single-line text) field to an existing page type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic page-type add-field key-text homepage subtitle --label "Subtitle" --placeholder "Enter subtitle"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldKeyText(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "key-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function pageTypeAddFieldKeyText(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function pageTypeAddFieldKeyText(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Text) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Text) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-link.ts
+++ b/src/page-type-add-field-link.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Link } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a link field to an existing page type.
@@ -19,6 +19,7 @@ ARGUMENTS
   field-id                 Field identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -t, --tab string         Target tab (default: first existing tab, or "Main")
   -l, --label string       Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
@@ -26,6 +27,8 @@ FLAGS
       --allow-text         Allow text with link
       --allow-target-blank Allow opening link in new tab
       --repeatable         Allow multiple links
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -35,19 +38,11 @@ EXAMPLES
   prismic page-type add-field link homepage links --repeatable
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldLink(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			placeholder,
@@ -55,11 +50,14 @@ export async function pageTypeAddFieldLink(): Promise<void> {
 			"allow-text": allowText,
 			"allow-target-blank": allowTargetBlank,
 			repeatable,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "link"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
@@ -67,6 +65,8 @@ export async function pageTypeAddFieldLink(): Promise<void> {
 			"allow-text": { type: "boolean" },
 			"allow-target-blank": { type: "boolean" },
 			repeatable: { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -91,42 +91,28 @@ export async function pageTypeAddFieldLink(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -162,20 +148,16 @@ export async function pageTypeAddFieldLink(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Link) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Link) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-number.ts
+++ b/src/page-type-add-field-number.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Number as NumberField } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a number field to an existing page type.
@@ -19,12 +19,15 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --min number       Minimum value
       --max number       Maximum value
       --step number      Step increment
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -33,28 +36,22 @@ EXAMPLES
   prismic page-type add-field number settings rating --min 1 --max 5 --step 1
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldNumber(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, min, max, step },
+		values: { help, repo: repoFlag, tab, label, placeholder, min, max, step, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "number"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			min: { type: "string" },
 			max: { type: "string" },
 			step: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -102,42 +99,28 @@ export async function pageTypeAddFieldNumber(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -172,20 +155,16 @@ export async function pageTypeAddFieldNumber(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Number) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Number) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-rich-text.ts
+++ b/src/page-type-add-field-rich-text.ts
@@ -1,12 +1,12 @@
 import type { CustomType, RichText } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a rich text field to an existing page type.
@@ -19,12 +19,15 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --single string    Allowed block types for single-line (comma-separated)
       --multi string     Allowed block types for multi-line (comma-separated)
       --allow-target-blank Allow opening links in new tab
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 BLOCK TYPES
@@ -39,36 +42,33 @@ EXAMPLES
   prismic page-type add-field rich-text blog post --multi "paragraph,strong,em,hyperlink" --allow-target-blank
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldRichText(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			tab,
 			label,
 			placeholder,
 			single,
 			multi,
 			"allow-target-blank": allowTargetBlank,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "rich-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			single: { type: "string" },
 			multi: { type: "string" },
 			"allow-target-blank": { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -93,42 +93,28 @@ export async function pageTypeAddFieldRichText(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -163,20 +149,16 @@ export async function pageTypeAddFieldRichText(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (StructuredText) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (StructuredText) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-select.ts
+++ b/src/page-type-add-field-select.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Select } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a select (dropdown) field to an existing page type.
@@ -19,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --option string    Add an option (can be used multiple times)
       --default string   Default selected value
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -32,27 +35,21 @@ EXAMPLES
   prismic page-type add-field select article status --option "draft" --option "published" --label "Status"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldSelect(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, option, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, option, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "select"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			option: { type: "string", multiple: true },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -77,42 +74,28 @@ export async function pageTypeAddFieldSelect(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -146,20 +129,16 @@ export async function pageTypeAddFieldSelect(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Select) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Select) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-timestamp.ts
+++ b/src/page-type-add-field-timestamp.ts
@@ -1,12 +1,12 @@
 import type { CustomType, Timestamp } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a timestamp (date and time) field to an existing page type.
@@ -19,10 +19,13 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --default string   Default timestamp value (ISO 8601 format)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,26 +34,20 @@ EXAMPLES
   prismic page-type add-field timestamp article published_at --label "Published At"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldTimestamp(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder, default: defaultValue },
+		values: { help, repo: repoFlag, tab, label, placeholder, default: defaultValue, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "timestamp"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -75,42 +72,28 @@ export async function pageTypeAddFieldTimestamp(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -143,20 +126,16 @@ export async function pageTypeAddFieldTimestamp(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (Timestamp) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (Timestamp) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-add-field-uid.ts
+++ b/src/page-type-add-field-uid.ts
@@ -1,12 +1,12 @@
 import type { CustomType, UID } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a UID (unique identifier) field to an existing page type.
@@ -19,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -t, --tab string       Target tab (default: first existing tab, or "Main")
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,25 +33,19 @@ EXAMPLES
   prismic page-type add-field uid product sku --placeholder "Enter unique SKU"
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeAddFieldUid(): Promise<void> {
 	const {
-		values: { help, tab, label, placeholder },
+		values: { help, repo: repoFlag, tab, label, placeholder, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "page-type", "add-field", "uid"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string", short: "t" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,42 +70,28 @@ export async function pageTypeAddFieldUid(): Promise<void> {
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
+
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 
 	// Determine target tab
 	const existingTabs = Object.keys(model.json);
@@ -140,20 +123,16 @@ export async function pageTypeAddFieldUid(): Promise<void> {
 	// Add field to model
 	model.json[targetTab][fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added field "${fieldId}" (UID) to "${targetTab}" tab in ${typeId}`,
-	);
+	console.info(`Added field "${fieldId}" (UID) to "${targetTab}" tab in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-connect-slice.ts
+++ b/src/page-type-connect-slice.ts
@@ -4,13 +4,12 @@ import type {
 	SharedSliceRef,
 } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, fetchSlice, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Connect a shared slice to a page type's slice zone.
@@ -23,7 +22,10 @@ ARGUMENTS
   slice-id               Slice identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -z, --slice-zone string  Target slice zone field ID (default: "slices")
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -32,23 +34,17 @@ EXAMPLES
   prismic page-type connect-slice article HeroSection -z body
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeConnectSlice(): Promise<void> {
 	const {
-		values: { help, "slice-zone": sliceZoneId },
+		values: { help, repo: repoFlag, "slice-zone": sliceZoneId, types, "no-types": noTypes },
 		positionals: [typeId, sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "connect-slice"
 		options: {
+			repo: { type: "string", short: "r" },
 			"slice-zone": { type: "string", short: "z" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -61,73 +57,49 @@ export async function pageTypeConnectSlice(): Promise<void> {
 
 	if (!typeId) {
 		console.error("Missing required argument: type-id\n");
-		console.error(
-			"Usage: prismic page-type connect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic page-type connect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic page-type connect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic page-type connect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Verify the slice exists
-	const sliceResult = await findSliceModel(sliceId);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
+		return;
+	}
+
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	// Verify the slice exists on remote
+	const sliceResult = await fetchSlice(repo, sliceId);
 	if (!sliceResult.ok) {
 		console.error(sliceResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	// Fetch the page type
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(
-				`Create it first with: prismic page-type create ${typeId}`,
-			);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
-		process.exitCode = 1;
-		return;
-	}
-
+	const model: CustomType = fetchResult.value;
 	const targetSliceZoneId = sliceZoneId ?? "slices";
 
 	// Find existing slice zone or create a new one
@@ -137,10 +109,7 @@ export async function pageTypeConnectSlice(): Promise<void> {
 	// Search all tabs for a Slices field matching the target ID
 	for (const [, tabFields] of Object.entries(model.json)) {
 		for (const [fieldId, field] of Object.entries(tabFields)) {
-			if (
-				(field as { type?: string }).type === "Slices" &&
-				fieldId === targetSliceZoneId
-			) {
+			if ((field as { type?: string }).type === "Slices" && fieldId === targetSliceZoneId) {
 				sliceZone = field as DynamicSlices;
 				sliceZoneFieldId = fieldId;
 				break;
@@ -153,9 +122,7 @@ export async function pageTypeConnectSlice(): Promise<void> {
 	if (!sliceZone) {
 		if (sliceZoneId) {
 			// User specified a slice zone that doesn't exist
-			console.error(
-				`Slice zone "${sliceZoneId}" not found in page type "${typeId}"`,
-			);
+			console.error(`Slice zone "${sliceZoneId}" not found in page type "${typeId}"`);
 			process.exitCode = 1;
 			return;
 		}
@@ -202,20 +169,16 @@ export async function pageTypeConnectSlice(): Promise<void> {
 	const sliceRef: SharedSliceRef = { type: "SharedSlice" };
 	sliceZone.config.choices[sliceId] = sliceRef;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Connected slice "${sliceId}" to slice zone "${sliceZoneFieldId}" in ${typeId}`,
-	);
+	console.info(`Connected slice "${sliceId}" to slice zone "${sliceZoneFieldId}" in ${typeId}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-create.ts
+++ b/src/page-type-create.ts
@@ -1,10 +1,11 @@
 import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
-import { mkdir, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { insertCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Create a new page type in a Prismic repository.
@@ -16,8 +17,11 @@ ARGUMENTS
   id       Page type identifier (required)
 
 FLAGS
+  -r, --repo string   Repository domain
   -n, --name string   Display name for the page type
       --single        Create as a singleton (non-repeatable) type
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help          Show help for command
 
 LEARN MORE
@@ -26,13 +30,16 @@ LEARN MORE
 
 export async function pageTypeCreate(): Promise<void> {
 	const {
-		values: { help, name, single },
+		values: { help, name, single, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [id],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "create"
 		options: {
+			repo: { type: "string", short: "r" },
 			name: { type: "string", short: "n" },
 			single: { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -49,6 +56,20 @@ export async function pageTypeCreate(): Promise<void> {
 		return;
 	}
 
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
+		return;
+	}
+
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
 	const model = {
 		id,
 		label: name ?? pascalCase(id),
@@ -61,31 +82,18 @@ export async function pageTypeCreate(): Promise<void> {
 		},
 	} satisfies CustomType;
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const result = await insertCustomType(repo, model);
+	if (!result.ok) {
+		console.error(`Failed to create page type: ${result.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	const customTypesDirectory = new URL("customtypes/", projectRoot);
-	const typeDirectory = new URL(id + "/", customTypesDirectory);
-	const modelPath = new URL("index.json", typeDirectory);
+	console.info(`Created page type "${id}" in repository "${repo}"`);
 
-	try {
-		await mkdir(new URL(".", modelPath), { recursive: true });
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to create page type: ${error.message}`);
-		} else {
-			console.error(`Failed to create page type`);
-		}
-		process.exitCode = 1;
-		return;
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
 	}
-
-	console.info(`Created page type at ${modelPath.href}`);
 }
 
 export function pascalCase(input: string): string {

--- a/src/page-type-disconnect-slice.ts
+++ b/src/page-type-disconnect-slice.ts
@@ -1,14 +1,11 @@
-import type {
-	CustomType,
-	DynamicSlices,
-} from "@prismicio/types-internal/lib/customtypes";
+import type { CustomType, DynamicSlices } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Disconnect a shared slice from a page type's slice zone.
@@ -21,7 +18,10 @@ ARGUMENTS
   slice-id               Slice identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -z, --slice-zone string  Target slice zone field ID (default: "slices")
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -30,23 +30,17 @@ EXAMPLES
   prismic page-type disconnect-slice article HeroSection -z body
 `.trim();
 
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.string(),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
-
 export async function pageTypeDisconnectSlice(): Promise<void> {
 	const {
-		values: { help, "slice-zone": sliceZoneId },
+		values: { help, repo: repoFlag, "slice-zone": sliceZoneId, types, "no-types": noTypes },
 		positionals: [typeId, sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "disconnect-slice"
 		options: {
+			repo: { type: "string", short: "r" },
 			"slice-zone": { type: "string", short: "z" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -59,65 +53,40 @@ export async function pageTypeDisconnectSlice(): Promise<void> {
 
 	if (!typeId) {
 		console.error("Missing required argument: type-id\n");
-		console.error(
-			"Usage: prismic page-type disconnect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic page-type disconnect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic page-type disconnect-slice <type-id> <slice-id>",
-		);
+		console.error("Usage: prismic page-type disconnect-slice <type-id> <slice-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Find the page type file
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			error.code === "ENOENT"
-		) {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(
-				`Create it first with: prismic page-type create ${typeId}`,
-			);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model: CustomType = fetchResult.value;
 	const targetSliceZoneId = sliceZoneId ?? "slices";
 
 	// Find existing slice zone
@@ -127,10 +96,7 @@ export async function pageTypeDisconnectSlice(): Promise<void> {
 	// Search all tabs for a Slices field matching the target ID
 	for (const [, tabFields] of Object.entries(model.json)) {
 		for (const [fieldId, field] of Object.entries(tabFields)) {
-			if (
-				(field as { type?: string }).type === "Slices" &&
-				fieldId === targetSliceZoneId
-			) {
+			if ((field as { type?: string }).type === "Slices" && fieldId === targetSliceZoneId) {
 				sliceZone = field as DynamicSlices;
 				sliceZoneFieldId = fieldId;
 				break;
@@ -141,9 +107,7 @@ export async function pageTypeDisconnectSlice(): Promise<void> {
 
 	// Slice zone must exist for disconnect
 	if (!sliceZone) {
-		console.error(
-			`Slice zone "${targetSliceZoneId}" not found in page type "${typeId}"`,
-		);
+		console.error(`Slice zone "${targetSliceZoneId}" not found in page type "${typeId}"`);
 		process.exitCode = 1;
 		return;
 	}
@@ -160,15 +124,9 @@ export async function pageTypeDisconnectSlice(): Promise<void> {
 	// Remove the slice reference
 	delete sliceZone.config.choices[sliceId];
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -176,4 +134,8 @@ export async function pageTypeDisconnectSlice(): Promise<void> {
 	console.info(
 		`Disconnected slice "${sliceId}" from slice zone "${sliceZoneFieldId}" in ${typeId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-list.ts
+++ b/src/page-type-list.ts
@@ -1,39 +1,33 @@
-import { readdir, readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageTypes } from "./lib/custom-types-api";
 
 const HELP = `
-List all page types in a Prismic project.
+List all page types in a Prismic repository.
 
 USAGE
   prismic page-type list [flags]
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --json          Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic page-type list
   prismic page-type list --json
+  prismic page-type list --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeList(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "list"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -45,48 +39,28 @@ export async function pageTypeList(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const customTypesDirectory = new URL("customtypes/", projectRoot);
-
-	let entries: string[];
-	try {
-		entries = (await readdir(customTypesDirectory, {
-			withFileTypes: false,
-		})) as unknown as string[];
-	} catch {
-		if (json) {
-			console.info(JSON.stringify([]));
-		} else {
-			console.info("No page types found.");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
 		return;
 	}
 
-	const pageTypes: { id: string; label: string; repeatable: boolean }[] = [];
-
-	for (const entry of entries) {
-		const modelPath = new URL(`${entry}/index.json`, customTypesDirectory);
-		try {
-			const contents = await readFile(modelPath, "utf8");
-			const parsed = JSON.parse(contents);
-			const result = v.safeParse(CustomTypeSchema, parsed);
-			if (result.success && result.output.format === "page") {
-				pageTypes.push({
-					id: result.output.id,
-					label: result.output.label,
-					repeatable: result.output.repeatable,
-				});
-			}
-		} catch {
-			// Skip directories without valid index.json
-		}
+	const result = await fetchRemotePageTypes(repo);
+	if (!result.ok) {
+		console.error(result.error);
+		process.exitCode = 1;
+		return;
 	}
+
+	const pageTypes = result.value;
 
 	if (pageTypes.length === 0) {
 		if (json) {
@@ -98,7 +72,17 @@ export async function pageTypeList(): Promise<void> {
 	}
 
 	if (json) {
-		console.info(JSON.stringify(pageTypes, null, 2));
+		console.info(
+			JSON.stringify(
+				pageTypes.map((pt) => ({
+					id: pt.id,
+					label: pt.label,
+					repeatable: pt.repeatable,
+				})),
+				null,
+				2,
+			),
+		);
 	} else {
 		console.info("ID\tLABEL\tTYPE");
 		for (const pageType of pageTypes) {

--- a/src/page-type-remove-field.ts
+++ b/src/page-type-remove-field.ts
@@ -1,11 +1,9 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Remove a field from a page type.
@@ -18,31 +16,29 @@ ARGUMENTS
   field-id     Field identifier (required)
 
 FLAGS
-  --tab string  Specific tab (searches all tabs if not specified)
-  -h, --help    Show help for command
+  -r, --repo string   Repository domain
+      --tab string    Specific tab (searches all tabs if not specified)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic page-type remove-field homepage title
   prismic page-type remove-field homepage meta_title --tab "SEO & Metadata"
+  prismic page-type remove-field homepage title --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeRemoveField(): Promise<void> {
 	const {
-		values: { help, tab },
+		values: { help, tab, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "remove-field"
 		options: {
+			repo: { type: "string", short: "r" },
 			tab: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -67,48 +63,28 @@ export async function pageTypeRemoveField(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a page type
-	if (model.format !== "page") {
-		console.error(`"${typeId}" is not a page type (format: ${model.format ?? "custom"})`);
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
+
+	const model = fetchResult.value;
 
 	// Find and remove the field
 	let foundTab: string | undefined;
@@ -144,18 +120,16 @@ export async function pageTypeRemoveField(): Promise<void> {
 		}
 	}
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	console.info(`Removed field "${fieldId}" from tab "${foundTab}" in page type "${typeId}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-remove.ts
+++ b/src/page-type-remove.ts
@@ -1,13 +1,12 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { deleteCustomType, fetchRemotePageType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
-Remove a page type from the project.
+Remove a page type from the repository.
 
 USAGE
   prismic page-type remove <type-id> [flags]
@@ -16,31 +15,29 @@ ARGUMENTS
   type-id      Page type identifier (required)
 
 FLAGS
-  -y           Confirm removal
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  -y                   Confirm removal
+      --types string   Generate types to file (default: "prismicio-types.d.ts")
+      --no-types       Skip type generation
+  -h, --help           Show help for command
 
 EXAMPLES
   prismic page-type remove homepage
   prismic page-type remove homepage -y
+  prismic page-type remove homepage --repo my-repo -y
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeRemove(): Promise<void> {
 	const {
-		values: { help, y },
+		values: { help, y, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "remove"
 		options: {
+			repo: { type: "string", short: "r" },
 			y: { type: "boolean", short: "y" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -58,69 +55,46 @@ export async function pageTypeRemove(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const typeDirectory = new URL(`customtypes/${typeId}/`, projectRoot);
-	const modelPath = new URL("index.json", typeDirectory);
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
 
 	// Verify the page type exists and is actually a page type
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
-		process.exitCode = 1;
-		return;
-	}
-
-	// Check if this is actually a page type
-	if (model.format !== "page") {
-		console.error(`"${typeId}" is not a page type (format: ${model.format ?? "custom"})`);
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
 	// Require -y flag to confirm deletion
 	if (!y) {
-		console.error(`Refusing to remove page type "${typeId}" (this will delete the entire directory).`);
+		console.error(`Refusing to remove page type "${typeId}" (this is a destructive action).`);
 		console.error("Re-run with -y to confirm.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Delete the page type directory
-	try {
-		await rm(typeDirectory, { recursive: true });
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to remove page type: ${error.message}`);
-		} else {
-			console.error("Failed to remove page type");
-		}
+	const deleteResult = await deleteCustomType(repo, typeId);
+	if (!deleteResult.ok) {
+		console.error(`Failed to remove page type: ${deleteResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(`Removed page type "${typeId}"`);
+	console.info(`Removed page type "${typeId}" from repository "${repo}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-set-name.ts
+++ b/src/page-type-set-name.ts
@@ -1,11 +1,9 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Change a page type's display name (label).
@@ -18,29 +16,27 @@ ARGUMENTS
   new-name     New display name (required)
 
 FLAGS
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic page-type set-name homepage "Home Page"
   prismic page-type set-name blog_post "Blog Post"
+  prismic page-type set-name homepage "Home Page" --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeSetName(): Promise<void> {
 	const {
-		values: { help },
+		values: { help, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId, newName],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "set-name"
 		options: {
+			repo: { type: "string", short: "r" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -65,64 +61,40 @@ export async function pageTypeSetName(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a page type
-	if (model.format !== "page") {
-		console.error(`"${typeId}" is not a page type (format: ${model.format ?? "custom"})`);
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	// Update the model
+	const model = fetchResult.value;
 	model.label = newName;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	console.info(`Renamed page type "${typeId}" to "${newName}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-set-repeatable.ts
+++ b/src/page-type-set-repeatable.ts
@@ -1,11 +1,9 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType, updateCustomType } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Set whether a page type is repeatable.
@@ -18,29 +16,27 @@ ARGUMENTS
   true|false    Repeatable value (required)
 
 FLAGS
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic page-type set-repeatable homepage true
   prismic page-type set-repeatable settings false
+  prismic page-type set-repeatable homepage true --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeSetRepeatable(): Promise<void> {
 	const {
-		values: { help },
+		values: { help, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [typeId, repeatableValue],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "set-repeatable"
 		options: {
+			repo: { type: "string", short: "r" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -73,65 +69,41 @@ export async function pageTypeSetRepeatable(): Promise<void> {
 
 	const repeatable = repeatableValue === "true";
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	// Read and parse the model
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a page type
-	if (model.format !== "page") {
-		console.error(`"${typeId}" is not a page type (format: ${model.format ?? "custom"})`);
+	const fetchResult = await fetchRemotePageType(repo, typeId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
 		process.exitCode = 1;
 		return;
 	}
 
-	// Update the model
+	const model = fetchResult.value;
 	model.repeatable = repeatable;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update page type: ${error.message}`);
-		} else {
-			console.error("Failed to update page type");
-		}
+	const updateResult = await updateCustomType(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update page type: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	const typeLabel = repeatable ? "repeatable" : "singleton";
 	console.info(`Set page type "${typeId}" to ${typeLabel}`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/page-type-view.ts
+++ b/src/page-type-view.ts
@@ -1,10 +1,8 @@
-import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
-
-import { readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { findUpward } from "./lib/file";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemotePageType } from "./lib/custom-types-api";
 
 const HELP = `
 View details of a specific page type.
@@ -16,30 +14,24 @@ ARGUMENTS
   type-id      Page type identifier (required)
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --json          Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic page-type view homepage
   prismic page-type view homepage --json
+  prismic page-type view homepage --repo my-repo
 `.trim();
-
-const CustomTypeSchema = v.object({
-	id: v.string(),
-	label: v.string(),
-	repeatable: v.boolean(),
-	status: v.boolean(),
-	format: v.optional(v.string()),
-	json: v.record(v.string(), v.record(v.string(), v.unknown())),
-});
 
 export async function pageTypeView(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 		positionals: [typeId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "page-type", "view"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -58,47 +50,28 @@ export async function pageTypeView(): Promise<void> {
 		return;
 	}
 
-	const projectRoot = await findUpward("package.json");
-	if (!projectRoot) {
-		console.error("Could not find project root (no package.json found)");
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const modelPath = new URL(`customtypes/${typeId}/index.json`, projectRoot);
-
-	let model: CustomType;
-	try {
-		const contents = await readFile(modelPath, "utf8");
-		const result = v.safeParse(CustomTypeSchema, JSON.parse(contents));
-		if (!result.success) {
-			console.error(`Invalid page type model: ${modelPath.href}`);
-			process.exitCode = 1;
-			return;
-		}
-		model = result.output as CustomType;
-	} catch (error) {
-		if (error instanceof Error && "code" in error && error.code === "ENOENT") {
-			console.error(`Page type not found: ${typeId}\n`);
-			console.error(`Create it first with: prismic page-type create ${typeId}`);
-			process.exitCode = 1;
-			return;
-		}
-		if (error instanceof Error) {
-			console.error(`Failed to read page type: ${error.message}`);
-		} else {
-			console.error("Failed to read page type");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Check if this is actually a page type
-	if (model.format !== "page") {
-		console.error(`"${typeId}" is not a page type (format: ${model.format ?? "custom"})`);
+	const result = await fetchRemotePageType(repo, typeId);
+	if (!result.ok) {
+		console.error(result.error);
 		process.exitCode = 1;
 		return;
 	}
+
+	const model = result.value;
 
 	if (json) {
 		console.info(JSON.stringify(model, null, 2));

--- a/src/page-type.ts
+++ b/src/page-type.ts
@@ -12,7 +12,7 @@ import { pageTypeSetRepeatable } from "./page-type-set-repeatable";
 import { pageTypeView } from "./page-type-view";
 
 const HELP = `
-Manage page types in a Prismic repository.
+Manage page types in a Prismic repository. Commands operate on the remote repository.
 
 USAGE
   prismic page-type <command> [flags]

--- a/src/preview-get-simulator.ts
+++ b/src/preview-get-simulator.ts
@@ -93,9 +93,7 @@ const RepositoryResponseSchema = v.object({
 });
 type RepositoryResponse = v.InferOutput<typeof RepositoryResponseSchema>;
 
-async function getSimulatorUrl(
-	repo: string,
-): Promise<ParsedRequestResponse<RepositoryResponse>> {
+async function getSimulatorUrl(repo: string): Promise<ParsedRequestResponse<RepositoryResponse>> {
 	const url = new URL("/core/repository", await getRepoUrl(repo));
 	return await request(url, { schema: RepositoryResponseSchema });
 }

--- a/src/pull.ts
+++ b/src/pull.ts
@@ -34,7 +34,14 @@ EXAMPLES
 
 export async function pull(): Promise<void> {
 	const {
-		values: { help, repo = await safeGetRepositoryFromConfig(), "dry-run": dryRun, "types-only": typesOnly, "slices-only": slicesOnly, json },
+		values: {
+			help,
+			repo = await safeGetRepositoryFromConfig(),
+			"dry-run": dryRun,
+			"types-only": typesOnly,
+			"slices-only": slicesOnly,
+			json,
+		},
 	} = parseArgs({
 		args: process.argv.slice(3), // skip: node, script, "pull"
 		options: {
@@ -75,7 +82,9 @@ export async function pull(): Promise<void> {
 	const shouldFetchSlices = !typesOnly;
 
 	const [customTypesResult, slicesResult] = await Promise.all([
-		shouldFetchTypes ? fetchRemoteCustomTypes(repo) : Promise.resolve({ ok: true, value: [] } as const),
+		shouldFetchTypes
+			? fetchRemoteCustomTypes(repo)
+			: Promise.resolve({ ok: true, value: [] } as const),
 		shouldFetchSlices ? fetchRemoteSlices(repo) : Promise.resolve({ ok: true, value: [] } as const),
 	]);
 
@@ -123,7 +132,9 @@ export async function pull(): Promise<void> {
 					console.info(`  ${relativeSlicesDir}${pascalCase(slice.name)}/model.json`);
 				}
 			}
-			console.info(`\nDry run complete: ${customTypes.length} custom types, ${slices.length} slices`);
+			console.info(
+				`\nDry run complete: ${customTypes.length} custom types, ${slices.length} slices`,
+			);
 		}
 		return;
 	}
@@ -160,7 +171,9 @@ export async function pull(): Promise<void> {
 					console.info(`  ${relativePath}`);
 				}
 			} catch (error) {
-				console.error(`Failed to write custom type ${ct.id}: ${error instanceof Error ? error.message : error}`);
+				console.error(
+					`Failed to write custom type ${ct.id}: ${error instanceof Error ? error.message : error}`,
+				);
 				process.exitCode = 1;
 				return;
 			}
@@ -187,7 +200,9 @@ export async function pull(): Promise<void> {
 					console.info(`  ${relativePath}`);
 				}
 			} catch (error) {
-				console.error(`Failed to write slice ${slice.name}: ${error instanceof Error ? error.message : error}`);
+				console.error(
+					`Failed to write slice ${slice.name}: ${error instanceof Error ? error.message : error}`,
+				);
 				process.exitCode = 1;
 				return;
 			}
@@ -198,7 +213,9 @@ export async function pull(): Promise<void> {
 	if (json) {
 		console.info(stringify({ writtenTypes, writtenSlices }));
 	} else {
-		console.info(`\nPull complete: ${writtenTypes.length} custom types, ${writtenSlices.length} slices`);
+		console.info(
+			`\nPull complete: ${writtenTypes.length} custom types, ${writtenSlices.length} slices`,
+		);
 	}
 }
 

--- a/src/push.ts
+++ b/src/push.ts
@@ -129,12 +129,17 @@ export async function push(): Promise<void> {
 	const shouldPushSlices = !typesOnly;
 
 	// Read local and fetch remote data in parallel
-	const [localTypesResult, localSlicesResult, remoteTypesResult, remoteSlicesResult] = await Promise.all([
-		shouldPushTypes ? readLocalCustomTypes() : Promise.resolve({ ok: true, value: [] } as const),
-		shouldPushSlices ? readLocalSlices() : Promise.resolve({ ok: true, value: [] } as const),
-		shouldPushTypes ? fetchRemoteCustomTypes(repo) : Promise.resolve({ ok: true, value: [] } as const),
-		shouldPushSlices ? fetchRemoteSlices(repo) : Promise.resolve({ ok: true, value: [] } as const),
-	]);
+	const [localTypesResult, localSlicesResult, remoteTypesResult, remoteSlicesResult] =
+		await Promise.all([
+			shouldPushTypes ? readLocalCustomTypes() : Promise.resolve({ ok: true, value: [] } as const),
+			shouldPushSlices ? readLocalSlices() : Promise.resolve({ ok: true, value: [] } as const),
+			shouldPushTypes
+				? fetchRemoteCustomTypes(repo)
+				: Promise.resolve({ ok: true, value: [] } as const),
+			shouldPushSlices
+				? fetchRemoteSlices(repo)
+				: Promise.resolve({ ok: true, value: [] } as const),
+		]);
 
 	if (!localTypesResult.ok) {
 		console.error(`Failed to read local custom types: ${localTypesResult.error}`);
@@ -177,8 +182,12 @@ export async function push(): Promise<void> {
 	}
 
 	// Compute diffs
-	const typesDiff = shouldPushTypes ? computeDiff([...localTypes], [...remoteTypes]) : { toInsert: [], toUpdate: [], toDelete: [] };
-	const slicesDiff = shouldPushSlices ? computeDiff([...localSlices], [...remoteSlices]) : { toInsert: [], toUpdate: [], toDelete: [] };
+	const typesDiff = shouldPushTypes
+		? computeDiff([...localTypes], [...remoteTypes])
+		: { toInsert: [], toUpdate: [], toDelete: [] };
+	const slicesDiff = shouldPushSlices
+		? computeDiff([...localSlices], [...remoteSlices])
+		: { toInsert: [], toUpdate: [], toDelete: [] };
 
 	// If --delete is not specified, clear the toDelete arrays
 	if (!deleteRemote) {
@@ -196,7 +205,12 @@ export async function push(): Promise<void> {
 
 	if (totalChanges === 0) {
 		if (json) {
-			console.info(stringify({ customTypes: { inserted: [], updated: [], deleted: [] }, slices: { inserted: [], updated: [], deleted: [] } }));
+			console.info(
+				stringify({
+					customTypes: { inserted: [], updated: [], deleted: [] },
+					slices: { inserted: [], updated: [], deleted: [] },
+				}),
+			);
 		} else {
 			console.info("\nNo changes to push.");
 		}
@@ -275,7 +289,12 @@ export async function push(): Promise<void> {
 
 	// Push custom types
 	if (shouldPushTypes) {
-		if (!json && (typesDiff.toInsert.length > 0 || typesDiff.toUpdate.length > 0 || typesDiff.toDelete.length > 0)) {
+		if (
+			!json &&
+			(typesDiff.toInsert.length > 0 ||
+				typesDiff.toUpdate.length > 0 ||
+				typesDiff.toDelete.length > 0)
+		) {
 			console.info("\nPushing custom types:");
 		}
 
@@ -321,7 +340,12 @@ export async function push(): Promise<void> {
 
 	// Push slices
 	if (shouldPushSlices) {
-		if (!json && (slicesDiff.toInsert.length > 0 || slicesDiff.toUpdate.length > 0 || slicesDiff.toDelete.length > 0)) {
+		if (
+			!json &&
+			(slicesDiff.toInsert.length > 0 ||
+				slicesDiff.toUpdate.length > 0 ||
+				slicesDiff.toDelete.length > 0)
+		) {
 			console.info("\nPushing slices:");
 		}
 

--- a/src/repo-get-access.ts
+++ b/src/repo-get-access.ts
@@ -1,5 +1,4 @@
 import { parseArgs } from "node:util";
-
 import * as v from "valibot";
 
 import { isAuthenticated } from "./lib/auth";
@@ -65,9 +64,7 @@ export async function repoGetAccess(): Promise<void> {
 		if (response.error instanceof ForbiddenRequestError) {
 			handleUnauthenticated();
 		} else {
-			console.error(
-				`Failed to get repository access: ${stringify(response.value)}`,
-			);
+			console.error(`Failed to get repository access: ${stringify(response.value)}`);
 			process.exitCode = 1;
 		}
 		return;

--- a/src/repo-set-access.ts
+++ b/src/repo-set-access.ts
@@ -53,9 +53,7 @@ export async function repoSetAccess(): Promise<void> {
 	}
 
 	if (!VALID_LEVELS.includes(level as (typeof VALID_LEVELS)[number])) {
-		console.error(
-			`Invalid access level: ${level}. Must be one of: ${VALID_LEVELS.join(", ")}`,
-		);
+		console.error(`Invalid access level: ${level}. Must be one of: ${VALID_LEVELS.join(", ")}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -77,9 +75,7 @@ export async function repoSetAccess(): Promise<void> {
 		if (response.error instanceof ForbiddenRequestError) {
 			handleUnauthenticated();
 		} else {
-			console.error(
-				`Failed to set repository access: ${stringify(response.value)}`,
-			);
+			console.error(`Failed to set repository access: ${stringify(response.value)}`);
 			process.exitCode = 1;
 		}
 		return;

--- a/src/slice-add-field-boolean.ts
+++ b/src/slice-add-field-boolean.ts
@@ -1,11 +1,12 @@
-import type { BooleanField, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { BooleanField } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a boolean (toggle) field to an existing slice.
@@ -18,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
       --default          Set default value to true
       --true-label string Label shown when toggle is on
       --false-label string Label shown when toggle is off
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -35,21 +39,27 @@ export async function sliceAddFieldBoolean(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			variation,
 			label,
 			default: defaultValue,
 			"true-label": trueLabel,
 			"false-label": falseLabel,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "boolean"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			default: { type: "boolean" },
 			"true-label": { type: "string" },
 			"false-label": { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -74,15 +84,28 @@ export async function sliceAddFieldBoolean(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -132,15 +155,10 @@ export async function sliceAddFieldBoolean(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -148,4 +166,8 @@ export async function sliceAddFieldBoolean(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Boolean) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-color.ts
+++ b/src/slice-add-field-color.ts
@@ -1,11 +1,12 @@
-import type { Color, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Color } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a color picker field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldColor(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "color"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldColor(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldColor(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldColor(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Color) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-date.ts
+++ b/src/slice-add-field-date.ts
@@ -1,11 +1,12 @@
-import type { Date as DateField, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Date as DateField } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a date picker field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string     Generate types to file (default: "prismicio-types.d.ts")
+      --no-types         Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldDate(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "date"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldDate(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldDate(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldDate(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Date) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-embed.ts
+++ b/src/slice-add-field-embed.ts
@@ -1,11 +1,12 @@
-import type { Embed, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Embed } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an embed (oEmbed) field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldEmbed(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "embed"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldEmbed(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldEmbed(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldEmbed(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Embed) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-geo-point.ts
+++ b/src/slice-add-field-geo-point.ts
@@ -1,11 +1,12 @@
-import type { GeoPoint, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { GeoPoint } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a geographic coordinates field to an existing slice.
@@ -18,8 +19,11 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,13 +34,16 @@ EXAMPLES
 
 export async function sliceAddFieldGeoPoint(): Promise<void> {
 	const {
-		values: { help, variation, label },
+		values: { help, repo: repoFlag, variation, label, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "geo-point"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -61,15 +68,28 @@ export async function sliceAddFieldGeoPoint(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -116,15 +136,10 @@ export async function sliceAddFieldGeoPoint(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -132,4 +147,8 @@ export async function sliceAddFieldGeoPoint(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (GeoPoint) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-image.ts
+++ b/src/slice-add-field-image.ts
@@ -1,11 +1,12 @@
-import type { Image, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Image } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add an image field to an existing slice.
@@ -18,8 +19,11 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -30,13 +34,16 @@ EXAMPLES
 
 export async function sliceAddFieldImage(): Promise<void> {
 	const {
-		values: { help, variation, label },
+		values: { help, repo: repoFlag, variation, label, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "image"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -61,15 +68,28 @@ export async function sliceAddFieldImage(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -116,15 +136,10 @@ export async function sliceAddFieldImage(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -132,4 +147,8 @@ export async function sliceAddFieldImage(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Image) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-key-text.ts
+++ b/src/slice-add-field-key-text.ts
@@ -1,11 +1,12 @@
-import type { SharedSlice, Text } from "@prismicio/types-internal/lib/customtypes";
+import type { Text } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a key-text (single-line text) field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldKeyText(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "key-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldKeyText(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldKeyText(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldKeyText(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Text) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-link.ts
+++ b/src/slice-add-field-link.ts
@@ -1,11 +1,12 @@
-import type { Link, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Link } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a link field to an existing slice.
@@ -18,12 +19,15 @@ ARGUMENTS
   field-id                 Field identifier (required)
 
 FLAGS
+  -r, --repo string        Repository domain
   -v, --variation string   Target variation (default: first variation)
   -l, --label string       Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --allow-text         Allow text with link
       --allow-target-blank Allow opening link in new tab
       --repeatable         Allow multiple links
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help               Show help for command
 
 EXAMPLES
@@ -37,23 +41,29 @@ export async function sliceAddFieldLink(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			variation,
 			label,
 			placeholder,
 			"allow-text": allowText,
 			"allow-target-blank": allowTargetBlank,
 			repeatable,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "link"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			"allow-text": { type: "boolean" },
 			"allow-target-blank": { type: "boolean" },
 			repeatable: { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -78,15 +88,28 @@ export async function sliceAddFieldLink(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -137,15 +160,10 @@ export async function sliceAddFieldLink(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -153,4 +171,8 @@ export async function sliceAddFieldLink(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Link) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-number.ts
+++ b/src/slice-add-field-number.ts
@@ -1,11 +1,12 @@
-import type { Number, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Number } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a number field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldNumber(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "number"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldNumber(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldNumber(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldNumber(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Number) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-rich-text.ts
+++ b/src/slice-add-field-rich-text.ts
@@ -1,11 +1,12 @@
-import type { RichText, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { RichText } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a rich text field to an existing slice.
@@ -18,12 +19,15 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --single string    Allowed block types for single-line (comma-separated)
       --multi string     Allowed block types for multi-line (comma-separated)
       --allow-target-blank Allow opening links in new tab
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 BLOCK TYPES
@@ -42,23 +46,29 @@ export async function sliceAddFieldRichText(): Promise<void> {
 	const {
 		values: {
 			help,
+			repo: repoFlag,
 			variation,
 			label,
 			placeholder,
 			single,
 			multi,
 			"allow-target-blank": allowTargetBlank,
+			types,
+			"no-types": noTypes,
 		},
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "rich-text"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			single: { type: "string" },
 			multi: { type: "string" },
 			"allow-target-blank": { type: "boolean" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -83,15 +93,28 @@ export async function sliceAddFieldRichText(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -142,15 +165,10 @@ export async function sliceAddFieldRichText(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -158,4 +176,8 @@ export async function sliceAddFieldRichText(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (StructuredText) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-select.ts
+++ b/src/slice-add-field-select.ts
@@ -1,11 +1,12 @@
-import type { Select, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import type { Select } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a select (dropdown) field to an existing slice.
@@ -18,11 +19,14 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
       --option string    Add an option (can be used multiple times)
       --default string   Default selected value
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -33,16 +37,19 @@ EXAMPLES
 
 export async function sliceAddFieldSelect(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder, option, default: defaultValue },
+		values: { help, repo: repoFlag, variation, label, placeholder, option, default: defaultValue, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "select"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
 			option: { type: "string", multiple: true },
 			default: { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -67,15 +74,28 @@ export async function sliceAddFieldSelect(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -125,15 +145,10 @@ export async function sliceAddFieldSelect(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -141,4 +156,8 @@ export async function sliceAddFieldSelect(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Select) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-field-timestamp.ts
+++ b/src/slice-add-field-timestamp.ts
@@ -1,11 +1,12 @@
-import type { SharedSlice, Timestamp } from "@prismicio/types-internal/lib/customtypes";
+import type { Timestamp } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
 import { humanReadable } from "./lib/string";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a timestamp (date and time) field to an existing slice.
@@ -18,9 +19,12 @@ ARGUMENTS
   field-id               Field identifier (required)
 
 FLAGS
+  -r, --repo string      Repository domain
   -v, --variation string Target variation (default: first variation)
   -l, --label string     Display label for the field (inferred from field-id if omitted)
   -p, --placeholder string Placeholder text
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help             Show help for command
 
 EXAMPLES
@@ -31,14 +35,17 @@ EXAMPLES
 
 export async function sliceAddFieldTimestamp(): Promise<void> {
 	const {
-		values: { help, variation, label, placeholder },
+		values: { help, repo: repoFlag, variation, label, placeholder, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(5), // skip: node, script, "slice", "add-field", "timestamp"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", short: "v" },
 			label: { type: "string", short: "l" },
 			placeholder: { type: "string", short: "p" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -63,15 +70,28 @@ export async function sliceAddFieldTimestamp(): Promise<void> {
 		return;
 	}
 
-	// Find the slice model
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check for variations
 	if (model.variations.length === 0) {
@@ -119,15 +139,10 @@ export async function sliceAddFieldTimestamp(): Promise<void> {
 	// Add field to variation
 	targetVariation.primary[fieldId] = fieldDefinition;
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	// Update remote slice
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -135,4 +150,8 @@ export async function sliceAddFieldTimestamp(): Promise<void> {
 	console.info(
 		`Added field "${fieldId}" (Timestamp) to "${targetVariation.id}" variation in ${sliceId}`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-add-variation.ts
+++ b/src/slice-add-variation.ts
@@ -1,10 +1,12 @@
 import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel, pascalCase } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
+import { pascalCase } from "./lib/slice";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Add a new variation to a slice.
@@ -17,25 +19,32 @@ ARGUMENTS
   variation-id   New variation identifier (required)
 
 FLAGS
-  --name string       Display name for the variation
-  --copy-from string  Copy fields from an existing variation
-  -h, --help          Show help for command
+  -r, --repo string        Repository domain
+  --name string            Display name for the variation
+  --copy-from string       Copy fields from an existing variation
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
+  -h, --help               Show help for command
 
 EXAMPLES
   prismic slice add-variation MySlice withImage
   prismic slice add-variation MySlice withImage --name "With Image"
   prismic slice add-variation MySlice withImage --copy-from default
+  prismic slice add-variation MySlice withImage --repo my-repo
 `.trim();
 
 export async function sliceAddVariation(): Promise<void> {
 	const {
-		values: { help, name, "copy-from": copyFrom },
+		values: { help, name, "copy-from": copyFrom, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [sliceId, variationId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "add-variation"
 		options: {
+			repo: { type: "string", short: "r" },
 			name: { type: "string" },
 			"copy-from": { type: "string" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -48,30 +57,40 @@ export async function sliceAddVariation(): Promise<void> {
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic slice add-variation <slice-id> <variation-id>",
-		);
+		console.error("Usage: prismic slice add-variation <slice-id> <variation-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!variationId) {
 		console.error("Missing required argument: variation-id\n");
-		console.error(
-			"Usage: prismic slice add-variation <slice-id> <variation-id>",
-		);
+		console.error("Usage: prismic slice add-variation <slice-id> <variation-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check if variation already exists
 	if (model.variations.some((v) => v.id === variationId)) {
@@ -87,9 +106,7 @@ export async function sliceAddVariation(): Promise<void> {
 		const sourceVariation = model.variations.find((v) => v.id === copyFrom);
 		if (!sourceVariation) {
 			console.error(`Source variation not found: ${copyFrom}`);
-			console.error(
-				`Available variations: ${model.variations.map((v) => v.id).join(", ")}`,
-			);
+			console.error(`Available variations: ${model.variations.map((v) => v.id).join(", ")}`);
 			process.exitCode = 1;
 			return;
 		}
@@ -118,20 +135,16 @@ export async function sliceAddVariation(): Promise<void> {
 		variations: [...model.variations, newVariation],
 	};
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(updatedModel as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	const updateResult = await updateSlice(repo, updatedModel as SharedSlice);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(
-		`Added variation "${variationId}" to slice "${sliceId}"`,
-	);
+	console.info(`Added variation "${variationId}" to slice "${sliceId}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-create.ts
+++ b/src/slice-create.ts
@@ -1,14 +1,14 @@
 import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { exists, findUpward } from "./lib/file";
-import { stringify } from "./lib/json";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { insertSlice } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
-Create a new slice in a Prismic project.
+Create a new slice in a Prismic repository.
 
 USAGE
   prismic slice create <id> [flags]
@@ -17,7 +17,10 @@ ARGUMENTS
   id       Slice identifier (required)
 
 FLAGS
+  -r, --repo string   Repository domain
   -n, --name string   Display name for the slice
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
   -h, --help          Show help for command
 
 LEARN MORE
@@ -26,12 +29,15 @@ LEARN MORE
 
 export async function sliceCreate(): Promise<void> {
 	const {
-		values: { help, name },
+		values: { help, name, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [id],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "create"
 		options: {
+			repo: { type: "string", short: "r" },
 			name: { type: "string", short: "n" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -44,6 +50,20 @@ export async function sliceCreate(): Promise<void> {
 
 	if (!id) {
 		console.error("Missing required argument: id");
+		process.exitCode = 1;
+		return;
+	}
+
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
+		return;
+	}
+
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
@@ -67,61 +87,18 @@ export async function sliceCreate(): Promise<void> {
 		],
 	};
 
-	const slicesDirectory = await getSlicesDirectory();
-	const sliceDirectory = new URL(pascalCase(model.name) + "/", slicesDirectory);
-	const modelPath = new URL("model.json", sliceDirectory);
-
-	try {
-		await mkdir(new URL(".", modelPath), { recursive: true });
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to create slice: ${error.message}`);
-		} else {
-			console.error(`Failed to create slice`);
-		}
+	const insertResult = await insertSlice(repo, model);
+	if (!insertResult.ok) {
+		console.error(`Failed to create slice: ${insertResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(`Created slice at ${modelPath.href}`);
-}
+	console.info(`Created slice "${id}" in repository "${repo}"`);
 
-async function getSlicesDirectory(): Promise<URL> {
-	const framework = await detectFramework();
-	const projectRoot = await findUpward("package.json");
-	switch (framework) {
-		case "next": {
-			const hasSrcDir = await exists(new URL("src", projectRoot));
-			if (hasSrcDir) return new URL("src/slices/", projectRoot);
-		}
-		case "nuxt": {
-			const hasAppDir = await exists(new URL("app", projectRoot));
-			if (hasAppDir) return new URL("app/slices/", projectRoot);
-		}
-		case "sveltekit": {
-			return new URL("src/slices/", projectRoot);
-		}
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
 	}
-	return new URL("slices/", projectRoot);
-}
-
-const PackageJsonSchema = v.object({
-	dependencies: v.optional(v.record(v.string(), v.string())),
-});
-
-type Framework = "next" | "nuxt" | "sveltekit";
-
-async function detectFramework(): Promise<Framework | undefined> {
-	const packageJsonPath = await findUpward("package.json");
-	if (!packageJsonPath) return;
-	try {
-		const contents = await readFile(packageJsonPath, "utf8");
-		const { dependencies = {} } = v.parse(PackageJsonSchema, JSON.parse(contents));
-		if ("next" in dependencies) return "next";
-		if ("nuxt" in dependencies) return "nuxt";
-		if ("@sveltejs/kit" in dependencies) return "sveltekit";
-	} catch {}
 }
 
 function pascalCase(input: string): string {

--- a/src/slice-list-variations.ts
+++ b/src/slice-list-variations.ts
@@ -1,6 +1,8 @@
 import { parseArgs } from "node:util";
 
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice } from "./lib/custom-types-api";
 
 const HELP = `
 List all variations for a slice.
@@ -12,21 +14,24 @@ ARGUMENTS
   slice-id     Slice identifier (required)
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  --json              Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic slice list-variations MySlice
   prismic slice list-variations MySlice --json
+  prismic slice list-variations MySlice --repo my-repo
 `.trim();
 
 export async function sliceListVariations(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 		positionals: [sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "list-variations"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -45,14 +50,28 @@ export async function sliceListVariations(): Promise<void> {
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 	const variations = model.variations.map((v) => ({ id: v.id, name: v.name }));
 
 	if (json) {

--- a/src/slice-list.ts
+++ b/src/slice-list.ts
@@ -1,30 +1,33 @@
-import { readdir, readFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
-import * as v from "valibot";
 
-import { getSlicesDirectory, SharedSliceSchema } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchRemoteSlices } from "./lib/custom-types-api";
 
 const HELP = `
-List all slices in a Prismic project.
+List all slices in a Prismic repository.
 
 USAGE
   prismic slice list [flags]
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  --json              Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic slice list
   prismic slice list --json
+  prismic slice list --repo my-repo
 `.trim();
 
 export async function sliceList(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "list"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -36,37 +39,28 @@ export async function sliceList(): Promise<void> {
 		return;
 	}
 
-	const slicesDirectory = await getSlicesDirectory();
-
-	let entries: string[];
-	try {
-		entries = (await readdir(slicesDirectory, {
-			withFileTypes: false,
-		})) as unknown as string[];
-	} catch {
-		if (json) {
-			console.info(JSON.stringify([]));
-		} else {
-			console.info("No slices found.");
-		}
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
+		process.exitCode = 1;
 		return;
 	}
 
-	const slices: { id: string; name: string }[] = [];
-
-	for (const entry of entries) {
-		const modelPath = new URL(`${entry}/model.json`, slicesDirectory);
-		try {
-			const contents = await readFile(modelPath, "utf8");
-			const parsed = JSON.parse(contents);
-			const result = v.safeParse(SharedSliceSchema, parsed);
-			if (result.success) {
-				slices.push({ id: result.output.id, name: result.output.name });
-			}
-		} catch {
-			// Skip directories without valid model.json
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
 	}
+
+	const fetchResult = await fetchRemoteSlices(repo);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const slices = fetchResult.value.map((s) => ({ id: s.id, name: s.name }));
 
 	if (slices.length === 0) {
 		if (json) {

--- a/src/slice-remove-field.ts
+++ b/src/slice-remove-field.ts
@@ -1,8 +1,9 @@
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Remove a field from a slice variation.
@@ -15,25 +16,32 @@ ARGUMENTS
   field-id     Field identifier (required)
 
 FLAGS
-  --variation string  Target variation (default: "default")
-  --zone string       Field zone: "primary" or "items" (default: "primary")
-  -h, --help          Show help for command
+  -r, --repo string        Repository domain
+  --variation string       Target variation (default: "default")
+  --zone string            Field zone: "primary" or "items" (default: "primary")
+      --types string       Generate types to file (default: "prismicio-types.d.ts")
+      --no-types           Skip type generation
+  -h, --help               Show help for command
 
 EXAMPLES
   prismic slice remove-field MySlice title
   prismic slice remove-field MySlice title --variation withImage
   prismic slice remove-field MySlice item_title --zone items
+  prismic slice remove-field MySlice title --repo my-repo
 `.trim();
 
 export async function sliceRemoveField(): Promise<void> {
 	const {
-		values: { help, variation, zone },
+		values: { help, variation, zone, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [sliceId, fieldId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "remove-field"
 		options: {
+			repo: { type: "string", short: "r" },
 			variation: { type: "string", default: "default" },
 			zone: { type: "string", default: "primary" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -64,33 +72,42 @@ export async function sliceRemoveField(): Promise<void> {
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Find the variation
 	const targetVariation = model.variations.find((v) => v.id === variation);
 	if (!targetVariation) {
 		console.error(`Variation not found: ${variation}`);
-		console.error(
-			`Available variations: ${model.variations.map((v) => v.id).join(", ")}`,
-		);
+		console.error(`Available variations: ${model.variations.map((v) => v.id).join(", ")}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	// Check if field exists
-	const zoneFields =
-		zone === "primary" ? targetVariation.primary : targetVariation.items;
+	const zoneFields = zone === "primary" ? targetVariation.primary : targetVariation.items;
 	if (!zoneFields || !(fieldId in zoneFields)) {
-		console.error(
-			`Field "${fieldId}" not found in ${zone} zone of variation "${variation}"`,
-		);
+		console.error(`Field "${fieldId}" not found in ${zone} zone of variation "${variation}"`);
 		process.exitCode = 1;
 		return;
 	}
@@ -98,15 +115,9 @@ export async function sliceRemoveField(): Promise<void> {
 	// Remove the field
 	delete zoneFields[fieldId];
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	const updateResult = await updateSlice(repo, model);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -114,4 +125,8 @@ export async function sliceRemoveField(): Promise<void> {
 	console.info(
 		`Removed field "${fieldId}" from ${zone} zone in variation "${variation}" of slice "${sliceId}"`,
 	);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-remove-variation.ts
+++ b/src/slice-remove-variation.ts
@@ -1,10 +1,11 @@
 import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
 Remove a variation from a slice.
@@ -17,19 +18,26 @@ ARGUMENTS
   variation-id   Variation to remove (required)
 
 FLAGS
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic slice remove-variation MySlice withImage
+  prismic slice remove-variation MySlice withImage --repo my-repo
 `.trim();
 
 export async function sliceRemoveVariation(): Promise<void> {
 	const {
-		values: { help },
+		values: { help, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [sliceId, variationId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "remove-variation"
 		options: {
+			repo: { type: "string", short: "r" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -42,38 +50,46 @@ export async function sliceRemoveVariation(): Promise<void> {
 
 	if (!sliceId) {
 		console.error("Missing required argument: slice-id\n");
-		console.error(
-			"Usage: prismic slice remove-variation <slice-id> <variation-id>",
-		);
+		console.error("Usage: prismic slice remove-variation <slice-id> <variation-id>");
 		process.exitCode = 1;
 		return;
 	}
 
 	if (!variationId) {
 		console.error("Missing required argument: variation-id\n");
-		console.error(
-			"Usage: prismic slice remove-variation <slice-id> <variation-id>",
-		);
+		console.error("Usage: prismic slice remove-variation <slice-id> <variation-id>");
 		process.exitCode = 1;
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	// Check if variation exists
 	const variationExists = model.variations.some((v) => v.id === variationId);
 	if (!variationExists) {
 		console.error(`Variation not found: ${variationId}`);
-		console.error(
-			`Available variations: ${model.variations.map((v) => v.id).join(", ")}`,
-		);
+		console.error(`Available variations: ${model.variations.map((v) => v.id).join(", ")}`);
 		process.exitCode = 1;
 		return;
 	}
@@ -91,18 +107,16 @@ export async function sliceRemoveVariation(): Promise<void> {
 		variations: model.variations.filter((v) => v.id !== variationId),
 	};
 
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(updatedModel as SharedSlice));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	const updateResult = await updateSlice(repo, updatedModel as SharedSlice);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
 	console.info(`Removed variation "${variationId}" from slice "${sliceId}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-remove.ts
+++ b/src/slice-remove.ts
@@ -1,10 +1,12 @@
-import { rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { deleteSlice, fetchSlice } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
-Remove a slice from the project.
+Remove a slice from the repository.
 
 USAGE
   prismic slice remove <slice-id> [flags]
@@ -13,22 +15,29 @@ ARGUMENTS
   slice-id     Slice identifier (required)
 
 FLAGS
-  -y           Confirm removal
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  -y                   Confirm removal
+      --types string   Generate types to file (default: "prismicio-types.d.ts")
+      --no-types       Skip type generation
+  -h, --help           Show help for command
 
 EXAMPLES
   prismic slice remove MySlice
   prismic slice remove MySlice -y
+  prismic slice remove MySlice --repo my-repo -y
 `.trim();
 
 export async function sliceRemove(): Promise<void> {
 	const {
-		values: { help, y },
+		values: { help, y, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "remove"
 		options: {
+			repo: { type: "string", short: "r" },
 			y: { type: "boolean", short: "y" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -46,36 +55,46 @@ export async function sliceRemove(): Promise<void> {
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { modelPath } = result;
-	const sliceDirectory = new URL(".", modelPath);
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	// Verify the slice exists
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
 
 	// Require -y flag to confirm deletion
 	if (!y) {
-		console.error(`Refusing to remove slice "${sliceId}" (this will delete the entire directory).`);
+		console.error(`Refusing to remove slice "${sliceId}" (this is a destructive action).`);
 		console.error("Re-run with -y to confirm.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// Delete the slice directory
-	try {
-		await rm(sliceDirectory, { recursive: true });
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to remove slice: ${error.message}`);
-		} else {
-			console.error("Failed to remove slice");
-		}
+	const deleteResult = await deleteSlice(repo, sliceId);
+	if (!deleteResult.ok) {
+		console.error(`Failed to remove slice: ${deleteResult.error}`);
 		process.exitCode = 1;
 		return;
 	}
 
-	console.info(`Removed slice "${sliceId}"`);
+	console.info(`Removed slice "${sliceId}" from repository "${repo}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
+	}
 }

--- a/src/slice-rename.ts
+++ b/src/slice-rename.ts
@@ -1,36 +1,41 @@
-import { rename, writeFile } from "node:fs/promises";
 import { parseArgs } from "node:util";
 
-import { stringify } from "./lib/json";
-import { findSliceModel, getSlicesDirectory, pascalCase } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice, updateSlice } from "./lib/custom-types-api";
+import { generateTypesFile } from "./codegen-types";
 
 const HELP = `
-Rename a slice (updates name field, optionally id and directory).
+Rename a slice (updates the display name).
 
 USAGE
   prismic slice rename <slice-id> <new-name> [flags]
 
 ARGUMENTS
-  slice-id     Current slice identifier (required)
+  slice-id     Slice identifier (required)
   new-name     New display name (required)
 
 FLAGS
-  --id string  Also change the slice ID (renames directory)
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+      --types string  Generate types to file (default: "prismicio-types.d.ts")
+      --no-types      Skip type generation
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic slice rename MySlice "My New Name"
-  prismic slice rename MySlice "My New Name" --id NewSliceId
+  prismic slice rename MySlice "My New Name" --repo my-repo
 `.trim();
 
 export async function sliceRename(): Promise<void> {
 	const {
-		values: { help, id: newId },
+		values: { help, repo: repoFlag, types, "no-types": noTypes },
 		positionals: [sliceId, newName],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "rename"
 		options: {
-			id: { type: "string" },
+			repo: { type: "string", short: "r" },
+			types: { type: "string" },
+			"no-types": { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
 		allowPositionals: true,
@@ -55,58 +60,42 @@ export async function sliceRename(): Promise<void> {
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model, modelPath } = result;
-
-	// Update the model
-	model.name = newName;
-	if (newId) {
-		model.id = newId;
-	}
-
-	// Write updated model
-	try {
-		await writeFile(modelPath, stringify(model));
-	} catch (error) {
-		if (error instanceof Error) {
-			console.error(`Failed to update slice: ${error.message}`);
-		} else {
-			console.error("Failed to update slice");
-		}
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
 		process.exitCode = 1;
 		return;
 	}
 
-	// If changing ID, also rename the directory
-	if (newId) {
-		const slicesDirectory = await getSlicesDirectory();
-		const currentDir = new URL(".", modelPath);
-		const newDir = new URL(pascalCase(newName) + "/", slicesDirectory);
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
 
-		if (currentDir.href !== newDir.href) {
-			try {
-				await rename(currentDir, newDir);
-				console.info(`Renamed slice "${sliceId}" to "${newId}" (${newName})`);
-				console.info(`Moved directory to ${newDir.href}`);
-			} catch (error) {
-				if (error instanceof Error) {
-					console.error(`Failed to rename directory: ${error.message}`);
-				} else {
-					console.error("Failed to rename directory");
-				}
-				process.exitCode = 1;
-				return;
-			}
-		} else {
-			console.info(`Renamed slice "${sliceId}" to "${newId}" (${newName})`);
-		}
-	} else {
-		console.info(`Renamed slice "${sliceId}" to "${newName}"`);
+	const model = fetchResult.value;
+
+	// Update the name
+	const updatedModel = { ...model, name: newName };
+
+	const updateResult = await updateSlice(repo, updatedModel);
+	if (!updateResult.ok) {
+		console.error(`Failed to update slice: ${updateResult.error}`);
+		process.exitCode = 1;
+		return;
+	}
+
+	console.info(`Renamed slice "${sliceId}" to "${newName}"`);
+
+	if (!noTypes) {
+		await generateTypesFile(repo, types || undefined);
 	}
 }

--- a/src/slice-view.ts
+++ b/src/slice-view.ts
@@ -1,6 +1,8 @@
 import { parseArgs } from "node:util";
 
-import { findSliceModel } from "./lib/slice";
+import { isAuthenticated } from "./lib/auth";
+import { safeGetRepositoryFromConfig } from "./lib/config";
+import { fetchSlice } from "./lib/custom-types-api";
 
 const HELP = `
 View details of a specific slice.
@@ -12,21 +14,24 @@ ARGUMENTS
   slice-id     Slice identifier (required)
 
 FLAGS
-  --json       Output as JSON
-  -h, --help   Show help for command
+  -r, --repo string   Repository domain
+  --json              Output as JSON
+  -h, --help          Show help for command
 
 EXAMPLES
   prismic slice view MySlice
   prismic slice view MySlice --json
+  prismic slice view MySlice --repo my-repo
 `.trim();
 
 export async function sliceView(): Promise<void> {
 	const {
-		values: { help, json },
+		values: { help, json, repo: repoFlag },
 		positionals: [sliceId],
 	} = parseArgs({
 		args: process.argv.slice(4), // skip: node, script, "slice", "view"
 		options: {
+			repo: { type: "string", short: "r" },
 			json: { type: "boolean" },
 			help: { type: "boolean", short: "h" },
 		},
@@ -45,14 +50,28 @@ export async function sliceView(): Promise<void> {
 		return;
 	}
 
-	const result = await findSliceModel(sliceId);
-	if (!result.ok) {
-		console.error(result.error);
+	const repo = repoFlag ?? (await safeGetRepositoryFromConfig());
+	if (!repo) {
+		console.error("Missing prismic.config.json or --repo option");
 		process.exitCode = 1;
 		return;
 	}
 
-	const { model } = result;
+	const authenticated = await isAuthenticated();
+	if (!authenticated) {
+		console.error("Not logged in. Run `prismic login` first.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const fetchResult = await fetchSlice(repo, sliceId);
+	if (!fetchResult.ok) {
+		console.error(fetchResult.error);
+		process.exitCode = 1;
+		return;
+	}
+
+	const model = fetchResult.value;
 
 	if (json) {
 		console.info(JSON.stringify(model, null, 2));

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -12,7 +12,7 @@ import { sliceRename } from "./slice-rename";
 import { sliceView } from "./slice-view";
 
 const HELP = `
-Manage slices in a Prismic project.
+Manage slices in a Prismic repository. Commands operate on the remote repository.
 
 USAGE
   prismic slice <command> [flags]

--- a/src/token-create.ts
+++ b/src/token-create.ts
@@ -6,7 +6,15 @@ import { safeGetRepositoryFromConfig } from "./lib/config";
 import { stringify } from "./lib/json";
 import { ForbiddenRequestError, request, UnauthorizedRequestError } from "./lib/request";
 import { getRepoUrl } from "./lib/url";
-import { type AccessToken, AccessTokenSchema, getAccessTokens, type OAuthApp, OAuthAppSchema, type WriteToken, WriteTokenSchema } from "./token-list";
+import {
+	type AccessToken,
+	AccessTokenSchema,
+	getAccessTokens,
+	type OAuthApp,
+	OAuthAppSchema,
+	type WriteToken,
+	WriteTokenSchema,
+} from "./token-list";
 
 const HELP = `
 Create a new API token for a Prismic repository.
@@ -80,10 +88,15 @@ export async function tokenCreate(): Promise<void> {
 	if (write) {
 		const result = await createWriteToken(repo, name);
 		if (!result.ok) {
-			if (result.error instanceof ForbiddenRequestError || result.error instanceof UnauthorizedRequestError) {
+			if (
+				result.error instanceof ForbiddenRequestError ||
+				result.error instanceof UnauthorizedRequestError
+			) {
 				handleUnauthenticated();
 			} else if (v.isValiError(result.error)) {
-				console.error(`Failed to create write token: Invalid response: ${stringify(result.error.issues)}`);
+				console.error(
+					`Failed to create write token: Invalid response: ${stringify(result.error.issues)}`,
+				);
 				process.exitCode = 1;
 			} else {
 				console.error(`Failed to create write token: ${stringify(result.value)}`);
@@ -101,10 +114,15 @@ export async function tokenCreate(): Promise<void> {
 		const scope = allowReleases ? "master+releases" : "master";
 		const result = await createAccessToken(repo, name, scope);
 		if (!result.ok) {
-			if (result.error instanceof ForbiddenRequestError || result.error instanceof UnauthorizedRequestError) {
+			if (
+				result.error instanceof ForbiddenRequestError ||
+				result.error instanceof UnauthorizedRequestError
+			) {
 				handleUnauthenticated();
 			} else if (v.isValiError(result.error)) {
-				console.error(`Failed to create access token: Invalid response: ${stringify(result.error.issues)}`);
+				console.error(
+					`Failed to create access token: Invalid response: ${stringify(result.error.issues)}`,
+				);
 				process.exitCode = 1;
 			} else {
 				console.error(`Failed to create access token: ${stringify(result.value)}`);

--- a/src/token-delete.ts
+++ b/src/token-delete.ts
@@ -71,10 +71,15 @@ export async function tokenDelete(): Promise<void> {
 	]);
 
 	if (!accessResponse.ok) {
-		if (accessResponse.error instanceof ForbiddenRequestError || accessResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			accessResponse.error instanceof ForbiddenRequestError ||
+			accessResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(accessResponse.error)) {
-			console.error(`Failed to list access tokens: Invalid response: ${stringify(accessResponse.error.issues)}`);
+			console.error(
+				`Failed to list access tokens: Invalid response: ${stringify(accessResponse.error.issues)}`,
+			);
 			process.exitCode = 1;
 		} else {
 			console.error(`Failed to list access tokens: ${stringify(accessResponse.value)}`);
@@ -84,10 +89,15 @@ export async function tokenDelete(): Promise<void> {
 	}
 
 	if (!writeResponse.ok) {
-		if (writeResponse.error instanceof ForbiddenRequestError || writeResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			writeResponse.error instanceof ForbiddenRequestError ||
+			writeResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(writeResponse.error)) {
-			console.error(`Failed to list write tokens: Invalid response: ${stringify(writeResponse.error.issues)}`);
+			console.error(
+				`Failed to list write tokens: Invalid response: ${stringify(writeResponse.error.issues)}`,
+			);
 			process.exitCode = 1;
 		} else {
 			console.error(`Failed to list write tokens: ${stringify(writeResponse.value)}`);
@@ -100,7 +110,11 @@ export async function tokenDelete(): Promise<void> {
 	let foundAuth: AccessToken | undefined;
 	for (const app of accessResponse.value) {
 		for (const auth of app.wroom_auths) {
-			if (auth.token === tokenValue || auth.token.startsWith(tokenValue) || auth.token.endsWith(tokenValue)) {
+			if (
+				auth.token === tokenValue ||
+				auth.token.startsWith(tokenValue) ||
+				auth.token.endsWith(tokenValue)
+			) {
 				foundAuth = auth;
 				break;
 			}
@@ -114,7 +128,10 @@ export async function tokenDelete(): Promise<void> {
 		const response = await request(url, { method: "DELETE" });
 
 		if (!response.ok) {
-			if (response.error instanceof ForbiddenRequestError || response.error instanceof UnauthorizedRequestError) {
+			if (
+				response.error instanceof ForbiddenRequestError ||
+				response.error instanceof UnauthorizedRequestError
+			) {
 				handleUnauthenticated();
 			} else {
 				console.error(`Failed to delete token: ${stringify(response.value)}`);
@@ -129,7 +146,8 @@ export async function tokenDelete(): Promise<void> {
 
 	// Find in write tokens
 	const foundWriteToken = writeResponse.value.tokens.find(
-		(t: WriteToken) => t.token === tokenValue || t.token.startsWith(tokenValue) || t.token.endsWith(tokenValue),
+		(t: WriteToken) =>
+			t.token === tokenValue || t.token.startsWith(tokenValue) || t.token.endsWith(tokenValue),
 	);
 
 	if (foundWriteToken) {
@@ -138,7 +156,10 @@ export async function tokenDelete(): Promise<void> {
 		const response = await request(url, { method: "DELETE" });
 
 		if (!response.ok) {
-			if (response.error instanceof ForbiddenRequestError || response.error instanceof UnauthorizedRequestError) {
+			if (
+				response.error instanceof ForbiddenRequestError ||
+				response.error instanceof UnauthorizedRequestError
+			) {
 				handleUnauthenticated();
 			} else {
 				console.error(`Failed to delete token: ${stringify(response.value)}`);

--- a/src/token-list.ts
+++ b/src/token-list.ts
@@ -4,7 +4,12 @@ import * as v from "valibot";
 import { isAuthenticated } from "./lib/auth";
 import { safeGetRepositoryFromConfig } from "./lib/config";
 import { stringify } from "./lib/json";
-import { ForbiddenRequestError, type ParsedRequestResponse, request, UnauthorizedRequestError } from "./lib/request";
+import {
+	ForbiddenRequestError,
+	type ParsedRequestResponse,
+	request,
+	UnauthorizedRequestError,
+} from "./lib/request";
 import { getRepoUrl } from "./lib/url";
 
 const HELP = `
@@ -61,7 +66,10 @@ export async function tokenList(): Promise<void> {
 	]);
 
 	if (!accessResponse.ok) {
-		if (accessResponse.error instanceof ForbiddenRequestError || accessResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			accessResponse.error instanceof ForbiddenRequestError ||
+			accessResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(accessResponse.error)) {
 			console.error(
@@ -76,7 +84,10 @@ export async function tokenList(): Promise<void> {
 	}
 
 	if (!writeResponse.ok) {
-		if (writeResponse.error instanceof ForbiddenRequestError || writeResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			writeResponse.error instanceof ForbiddenRequestError ||
+			writeResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(writeResponse.error)) {
 			console.error(

--- a/src/token-set-name.ts
+++ b/src/token-set-name.ts
@@ -6,7 +6,13 @@ import { safeGetRepositoryFromConfig } from "./lib/config";
 import { stringify } from "./lib/json";
 import { ForbiddenRequestError, request, UnauthorizedRequestError } from "./lib/request";
 import { getRepoUrl } from "./lib/url";
-import { getAccessTokens, getWriteTokens, type OAuthApp, OAuthAppSchema, type WriteToken } from "./token-list";
+import {
+	getAccessTokens,
+	getWriteTokens,
+	type OAuthApp,
+	OAuthAppSchema,
+	type WriteToken,
+} from "./token-list";
 
 const HELP = `
 Set the name of a token in a Prismic repository.
@@ -81,10 +87,15 @@ export async function tokenSetName(): Promise<void> {
 	]);
 
 	if (!accessResponse.ok) {
-		if (accessResponse.error instanceof ForbiddenRequestError || accessResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			accessResponse.error instanceof ForbiddenRequestError ||
+			accessResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(accessResponse.error)) {
-			console.error(`Failed to list access tokens: Invalid response: ${stringify(accessResponse.error.issues)}`);
+			console.error(
+				`Failed to list access tokens: Invalid response: ${stringify(accessResponse.error.issues)}`,
+			);
 			process.exitCode = 1;
 		} else {
 			console.error(`Failed to list access tokens: ${stringify(accessResponse.value)}`);
@@ -94,10 +105,15 @@ export async function tokenSetName(): Promise<void> {
 	}
 
 	if (!writeResponse.ok) {
-		if (writeResponse.error instanceof ForbiddenRequestError || writeResponse.error instanceof UnauthorizedRequestError) {
+		if (
+			writeResponse.error instanceof ForbiddenRequestError ||
+			writeResponse.error instanceof UnauthorizedRequestError
+		) {
 			handleUnauthenticated();
 		} else if (v.isValiError(writeResponse.error)) {
-			console.error(`Failed to list write tokens: Invalid response: ${stringify(writeResponse.error.issues)}`);
+			console.error(
+				`Failed to list write tokens: Invalid response: ${stringify(writeResponse.error.issues)}`,
+			);
 			process.exitCode = 1;
 		} else {
 			console.error(`Failed to list write tokens: ${stringify(writeResponse.value)}`);
@@ -110,7 +126,11 @@ export async function tokenSetName(): Promise<void> {
 	let foundApp: OAuthApp | undefined;
 	for (const app of accessResponse.value) {
 		for (const auth of app.wroom_auths) {
-			if (auth.token === tokenValue || auth.token.startsWith(tokenValue) || auth.token.endsWith(tokenValue)) {
+			if (
+				auth.token === tokenValue ||
+				auth.token.startsWith(tokenValue) ||
+				auth.token.endsWith(tokenValue)
+			) {
 				foundApp = app;
 				break;
 			}
@@ -128,10 +148,15 @@ export async function tokenSetName(): Promise<void> {
 		});
 
 		if (!response.ok) {
-			if (response.error instanceof ForbiddenRequestError || response.error instanceof UnauthorizedRequestError) {
+			if (
+				response.error instanceof ForbiddenRequestError ||
+				response.error instanceof UnauthorizedRequestError
+			) {
 				handleUnauthenticated();
 			} else if (v.isValiError(response.error)) {
-				console.error(`Failed to rename token: Invalid response: ${stringify(response.error.issues)}`);
+				console.error(
+					`Failed to rename token: Invalid response: ${stringify(response.error.issues)}`,
+				);
 				process.exitCode = 1;
 			} else {
 				console.error(`Failed to rename token: ${stringify(response.value)}`);
@@ -146,11 +171,14 @@ export async function tokenSetName(): Promise<void> {
 
 	// Check if it's a write token
 	const foundWriteToken = writeResponse.value.tokens.find(
-		(t: WriteToken) => t.token === tokenValue || t.token.startsWith(tokenValue) || t.token.endsWith(tokenValue),
+		(t: WriteToken) =>
+			t.token === tokenValue || t.token.startsWith(tokenValue) || t.token.endsWith(tokenValue),
 	);
 
 	if (foundWriteToken) {
-		console.error("Write tokens cannot be renamed. Delete and create a new token with the desired name.");
+		console.error(
+			"Write tokens cannot be renamed. Delete and create a new token with the desired name.",
+		);
 		process.exitCode = 1;
 		return;
 	}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config"
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
@@ -13,4 +13,4 @@ export default defineConfig({
 			include: ["src"],
 		},
 	},
-})
+});


### PR DESCRIPTION
> [!IMPORTANT]
> This PR won't be merged. It diverged too much from `main` and will likely need a lot of work. It will be reimplemented, but remains open as a reminder.

### Description

Refactor custom-type, page-type, and slice commands to operate against the remote Prismic Custom Types API instead of local model files.

- Add individual fetch/update/insert/delete functions to `custom-types-api.ts` (`fetchCustomType`, `fetchSlice`, `fetchRemotePageType`, `fetchRemoteNonPageCustomTypes`, etc.)
- Wire `--repo` and `--types`/`--no-types` flags into all leaf commands
- Update `pull` and `push` to use the new API functions

### How to QA

- Run custom-type, page-type, and slice CRUD commands against a live repository
- Verify `--types` generates a types file and `--no-types` skips generation
- Verify `pull` and `push` still function correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to broad CLI behavior changes and new remote API calls for CRUD operations; failures now depend on auth/repo configuration and API responses rather than local filesystem state.
> 
> **Overview**
> Custom-type and page-type commands are refactored to **operate on the remote repository** via the Custom Types API rather than reading/writing local `customtypes/*` JSON files (add/remove fields, connect/disconnect slices, create/remove, list/view, rename).
> 
> Adds centralized `generateTypesFile()` in `codegen-types.ts` and wires `--repo` plus `--types`/`--no-types` flags into these commands to optionally regenerate `prismicio-types.d.ts` after mutations. `custom-types-api.ts` is expanded with per-resource fetch helpers (`fetchCustomType`, `fetchSlice`) and remote-only wrappers that enforce page-type vs custom-type semantics and improve error messaging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 320ad4ab63b5161a296de9a6ee3d413c33261c1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->