### PR TITLE
feat: re-implement init command with login, migration, and sync

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,10 @@ import { parseArgs } from "node:util";
 import packageJson from "../package.json" with { type: "json" };
 import { codegen } from "./codegen";
 import { customType } from "./custom-type";
-import { run as devtoolsRun } from "./devtools/cli";
 import { docs } from "./docs";
 import { initSegment, trackEnd, trackStart } from "./lib/segment";
 import { captureError, setupSentry } from "./lib/sentry";
+import { init } from "./init";
 import { locale } from "./locale";
 import { login } from "./login";
 import { logout } from "./logout";
@@ -83,7 +83,7 @@ if (version) {
 	try {
 		switch (command) {
 			case "init":
-				await devtoolsRun();
+				await init();
 				break;
 			case "sync":
 				await sync();

--- a/src/init.ts
+++ b/src/init.ts
@@ -1,23 +1,44 @@
+import { readFile, rm } from "node:fs/promises";
 import { parseArgs } from "node:util";
+import * as v from "valibot";
 
+import { createLoginSession, isAuthenticated } from "./lib/auth";
+import { openBrowser } from "./lib/browser";
 import { createConfig, readConfig, UnknownProjectRoot } from "./lib/config";
+import { findUpward } from "./lib/file";
+import { getFramework } from "./lib/framework-adapter";
+import { request } from "./lib/request";
+import { getUserServiceUrl } from "./lib/url";
+import { syncCustomTypes, syncSlices } from "./sync";
 
 const HELP = `
 Initialize a Prismic project by creating a prismic.config.json file.
 
-Use this command to connect an existing Prismic repository to your project.
-To create a new repository, use \`prismic repo create\` instead.
+Detects the project framework, installs dependencies, and syncs models
+from Prismic. If a slicemachine.config.json exists, it will be migrated.
 
 USAGE
   prismic init [flags]
 
 FLAGS
-  -r, --repo   Repository name (required)
-  -h, --help   Show help for command
+  -r, --repo string   Repository name
+  -h, --help          Show help for command
+
+EXAMPLES
+  prismic init --repo my-repo
 
 LEARN MORE
   Use \`prismic <command> --help\` for more information about a command.
 `.trim();
+
+const ProfileSchema = v.object({
+	repositories: v.array(
+		v.object({
+			domain: v.string(),
+			name: v.optional(v.string()),
+		}),
+	),
+});
 
 export async function init(): Promise<void> {
 	const { values } = parseArgs({
@@ -33,12 +54,7 @@ export async function init(): Promise<void> {
 		return;
 	}
 
-	if (!values.repo) {
-		console.error("Missing required flag: --repo");
-		process.exitCode = 1;
-		return;
-	}
-
+	// Check for existing prismic.config.json
 	const existingConfig = await readConfig();
 	if (existingConfig.ok) {
 		console.error("A prismic.config.json file already exists.");
@@ -46,10 +62,88 @@ export async function init(): Promise<void> {
 		return;
 	}
 
-	const result = await createConfig({ repositoryName: values.repo });
+	// Check for legacy slicemachine.config.json
+	const legacyConfigPath = await findUpward("slicemachine.config.json", {
+		stop: "package.json",
+	});
+	let legacyRepoName: string | undefined;
+	let legacyLibraries: string[] | undefined;
 
-	if (!result.ok) {
-		if (result.error instanceof UnknownProjectRoot) {
+	if (legacyConfigPath) {
+		try {
+			const contents = await readFile(legacyConfigPath, "utf8");
+			const legacyConfig = JSON.parse(contents);
+			legacyRepoName = legacyConfig.repositoryName;
+			legacyLibraries = legacyConfig.libraries;
+		} catch {
+			console.warn("Could not read slicemachine.config.json, ignoring.");
+		}
+	}
+
+	// Determine repo name: --repo flag > legacy config > error
+	const repo = values.repo ?? legacyRepoName;
+	if (!repo) {
+		console.error("Missing required flag: --repo");
+		process.exitCode = 1;
+		return;
+	}
+
+	// Login if needed
+	if (!(await isAuthenticated())) {
+		console.info("Not logged in. Starting login...");
+		const { email } = await createLoginSession({
+			onReady: (url) => {
+				console.info("Opening browser to complete login...");
+				console.info(`If the browser doesn't open, visit: ${url}`);
+				openBrowser(url);
+			},
+		});
+		console.info(`Logged in as ${email}`);
+	}
+
+	// Validate repo membership
+	const profileUrl = new URL("profile", await getUserServiceUrl());
+	const profileResponse = await request(profileUrl, {
+		schema: ProfileSchema,
+	});
+	if (!profileResponse.ok) {
+		console.error("Failed to fetch user profile.");
+		process.exitCode = 1;
+		return;
+	}
+
+	const repoData = profileResponse.value.repositories.find(
+		(r) => r.domain === repo,
+	);
+	if (!repoData) {
+		console.error(
+			`Repository "${repo}" not found in your account. Check the name or create it with \`prismic repo create\`.`,
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	// Detect framework
+	const framework = await getFramework();
+	if (!framework) {
+		console.error(
+			"Could not detect a supported framework (Next.js, Nuxt, or SvelteKit).",
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	// Create prismic.config.json
+	const configData: { repositoryName: string; libraries?: string[] } = {
+		repositoryName: repo,
+	};
+	if (legacyLibraries?.length) {
+		configData.libraries = legacyLibraries;
+	}
+
+	const configResult = await createConfig(configData);
+	if (!configResult.ok) {
+		if (configResult.error instanceof UnknownProjectRoot) {
 			console.error(
 				"Could not find a package.json file. Run this command from a project directory.",
 			);
@@ -60,5 +154,20 @@ export async function init(): Promise<void> {
 		return;
 	}
 
-	console.info(`Created prismic.config.json for repository "${values.repo}"`);
+	// Delete legacy config after new config is created
+	if (legacyConfigPath) {
+		await rm(legacyConfigPath);
+		console.info("Migrated slicemachine.config.json to prismic.config.json");
+	}
+
+	// Install dependencies and create framework files
+	await framework.initProject();
+
+	// Sync models from remote
+	await syncSlices(repo, framework);
+	await syncCustomTypes(repo, framework);
+
+	console.info(
+		`Initialized Prismic for repository "${repo}". Run \`npm install\` to install new dependencies.`,
+	);
 }

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -1,0 +1,11 @@
+import { exec } from "node:child_process";
+
+export function openBrowser(url: URL): void {
+	const cmd =
+		process.platform === "darwin"
+			? "open"
+			: process.platform === "win32"
+				? "start"
+				: "xdg-open";
+	exec(`${cmd} "${url.toString()}"`);
+}

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -166,7 +166,7 @@ async function watchForChanges(repo: string, framework: FrameworkAdapter) {
 	}
 }
 
-async function syncSlices(repo: string, framework: FrameworkAdapter) {
+export async function syncSlices(repo: string, framework: FrameworkAdapter): Promise<void> {
 	const remoteSlicesResult = await fetchRemoteSlices(repo);
 	if (!remoteSlicesResult.ok) {
 		console.error(`Failed to fetch remote slices: ${remoteSlicesResult.error}`);
@@ -202,7 +202,7 @@ async function syncSlices(repo: string, framework: FrameworkAdapter) {
 	}
 }
 
-async function syncCustomTypes(repo: string, framework: FrameworkAdapter) {
+export async function syncCustomTypes(repo: string, framework: FrameworkAdapter): Promise<void> {
 	const remoteCustomTypesResult = await fetchRemoteCustomTypes(repo);
 	if (!remoteCustomTypesResult.ok) {
 		console.error(`Failed to fetch remote custom types: ${remoteCustomTypesResult.error}`);


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Re-implements the `init` command natively, replacing the devtools-based implementation. The new command authenticates the user (with inline login flow), detects the project framework, validates repo membership, migrates legacy `slicemachine.config.json` if present, and syncs models from Prismic — providing a single-step onboarding experience.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the `init` flow with new auth/network calls, framework bootstrapping, and automated file migration/deletion, which can affect onboarding behavior and local project state. Also introduces a shell-based browser opener (`exec`) and reuses sync logic in a new context, so regressions are possible if edge cases aren’t covered.
> 
> **Overview**
> **`prismic init` is rewritten to run natively** (no longer delegating to the devtools CLI) and now performs a full onboarding flow: checks for an existing `prismic.config.json`, optionally reads/migrates `slicemachine.config.json`, ensures the user is logged in via a browser-based session, validates the repo exists in the user’s account, detects the framework, then initializes framework files and syncs slices/custom types from Prismic.
> 
> Adds a small `openBrowser()` helper to launch the login URL, and updates `sync.ts` to export `syncSlices`/`syncCustomTypes` so `init` can reuse the same remote-to-local sync logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4dff190ac3b67d67eeba8d148ef5ce459652a8d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->