### PR TITLE
ci: use prismicio organization

### DIFF
--- a/.github/workflows/prerelease-canary.yml
+++ b/.github/workflows/prerelease-canary.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository_owner == 'prismicio-community'
+    if: github.repository_owner == 'prismicio'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/prerelease-pr-cleanup.yml
+++ b/.github/workflows/prerelease-pr-cleanup.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cleanup:
-    if: github.repository_owner == 'prismicio-community'
+    if: github.repository_owner == 'prismicio'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/prerelease-pr.yml
+++ b/.github/workflows/prerelease-pr.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish:
-    if: github.repository_owner == 'prismicio-community'
+    if: github.repository_owner == 'prismicio'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: #14

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

Use the `prismicio` GitHub organization for the prerelease CI workflows.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that just alters when prerelease publish/cleanup workflows execute; main risk is accidental disabling/enabling of npm publishing in the wrong GitHub org.
> 
> **Overview**
> Updates prerelease GitHub Actions gating so `prerelease-canary`, `prerelease-pr`, and `prerelease-pr-cleanup` jobs run only when `github.repository_owner == 'prismicio'` (instead of `prismicio-community`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e21bde62d9ed0fa80ce21d2eae643b65330b285. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->