### PR TITLE
feat: limit CLI to `init`, `sync`, and auth commands

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,26 +3,26 @@
 import { parseArgs } from "node:util";
 
 import packageJson from "../package.json" with { type: "json" };
-import { codegen } from "./codegen";
-import { customType } from "./custom-type";
-import { docs } from "./docs";
+import { init } from "./init";
 import { initSegment, trackEnd, trackStart } from "./lib/segment";
 import { captureError, setupSentry } from "./lib/sentry";
-import { init } from "./init";
-import { locale } from "./locale";
 import { login } from "./login";
 import { logout } from "./logout";
-import { pageType } from "./page-type";
-import { preview } from "./preview";
-import { pull } from "./pull";
-import { push } from "./push";
-import { repo } from "./repo";
-import { slice } from "./slice";
-import { status } from "./status";
 import { sync } from "./sync";
-import { token } from "./token";
-import { webhook } from "./webhook";
 import { whoami } from "./whoami";
+// import { codegen } from "./codegen";
+// import { customType } from "./custom-type";
+// import { docs } from "./docs";
+// import { locale } from "./locale";
+// import { pageType } from "./page-type";
+// import { preview } from "./preview";
+// import { pull } from "./pull";
+// import { push } from "./push";
+// import { repo } from "./repo";
+// import { slice } from "./slice";
+// import { status } from "./status";
+// import { token } from "./token";
+// import { webhook } from "./webhook";
 
 const HELP = `
 Prismic CLI for managing repositories and configurations.
@@ -36,19 +36,6 @@ COMMANDS
   login       Log in to Prismic
   logout      Log out of Prismic
   whoami      Show the currently logged in user
-  status      Show the status of the current project
-  repo        Manage Prismic repositories
-  locale      Manage locales in a repository
-  page-type   Manage page types in a repository
-  custom-type Manage custom types in a repository
-  slice       Manage slices in a project
-  pull        Pull types and slices from Prismic
-  push        Push types and slices to Prismic
-  codegen     Generate code from Prismic models
-  docs        Fetch and list documentation from Prismic
-  preview     Manage preview configurations
-  token       Manage API tokens in a repository
-  webhook     Manage webhooks in a repository
 
 FLAGS
   -v, --version  Show CLI version
@@ -97,45 +84,45 @@ if (version) {
 			case "whoami":
 				await whoami();
 				break;
-			case "status":
-				await status();
-				break;
-			case "repo":
-				await repo();
-				break;
-			case "locale":
-				await locale();
-				break;
-			case "page-type":
-				await pageType();
-				break;
-			case "custom-type":
-				await customType();
-				break;
-			case "slice":
-				await slice();
-				break;
-			case "pull":
-				await pull();
-				break;
-			case "push":
-				await push();
-				break;
-			case "codegen":
-				await codegen();
-				break;
-			case "docs":
-				await docs();
-				break;
-			case "preview":
-				await preview();
-				break;
-			case "token":
-				await token();
-				break;
-			case "webhook":
-				await webhook();
-				break;
+			// case "status":
+			// 	await status();
+			// 	break;
+			// case "repo":
+			// 	await repo();
+			// 	break;
+			// case "locale":
+			// 	await locale();
+			// 	break;
+			// case "page-type":
+			// 	await pageType();
+			// 	break;
+			// case "custom-type":
+			// 	await customType();
+			// 	break;
+			// case "slice":
+			// 	await slice();
+			// 	break;
+			// case "pull":
+			// 	await pull();
+			// 	break;
+			// case "push":
+			// 	await push();
+			// 	break;
+			// case "codegen":
+			// 	await codegen();
+			// 	break;
+			// case "docs":
+			// 	await docs();
+			// 	break;
+			// case "preview":
+			// 	await preview();
+			// 	break;
+			// case "token":
+			// 	await token();
+			// 	break;
+			// case "webhook":
+			// 	await webhook();
+			// 	break;
 			default: {
 				if (command) {
 					console.error(`Unknown command: ${command}`);


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: #11

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR limits the CLI to the following commands:

- `init`
- `sync`
- `login`
- `logout`
- `whoami`

The broader Prismic management commands, like `repo` and `webhook` will be restored in a future release.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to intentional breaking changes in the CLI contract (many commands no longer work), though the code change itself is small and localized to the entrypoint routing/help text.
> 
> **Overview**
> Limits the CLI surface area by removing most Prismic management commands from `src/index.ts` (and the help output), leaving only `init`, `sync`, `login`, `logout`, and `whoami` wired into the command dispatcher.
> 
> The removed commands are left in place as commented-out imports and `switch` cases, so invoking them now falls through to the *Unknown command* path and prints the reduced help text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83715b1cc40b357982c36e9292a839fa7d154c3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->