### PR TITLE
fix: don't refresh token when there is no command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ if (version) {
 		sentrySetTag("framework", framework.id);
 	}
 
-	if (!SKIP_REFRESH_COMMANDS.has(command)) {
+	if (command && !SKIP_REFRESH_COMMANDS.has(command)) {
 		// Refreesh the token and identify the user in the background.
 		refreshToken()
 			.then(async (token) => {
@@ -97,7 +97,7 @@ if (version) {
 			.catch(() => {});
 	}
 
-	if (!UNTRACKED_COMMANDS.has(command)) {
+	if (command && !UNTRACKED_COMMANDS.has(command)) {
 		segmentTrackStart(command, { repository });
 	}
 
@@ -127,11 +127,11 @@ if (version) {
 			}
 		}
 
-		if (!UNTRACKED_COMMANDS.has(command)) {
+		if (command && !UNTRACKED_COMMANDS.has(command)) {
 			segmentTrackEnd(command, process.exitCode !== 1);
 		}
 	} catch (error) {
-		if (!UNTRACKED_COMMANDS.has(command)) {
+		if (command && !UNTRACKED_COMMANDS.has(command)) {
 			segmentTrackEnd(command, false, error);
 		}
 		process.exitCode = 1;


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Skip the background token refresh when no command is given (e.g. running `prismic` with no arguments). Previously, the token refresh and tracking logic would run even when only displaying help text, which is unnecessary.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple `command` presence guards around existing token refresh and Segment tracking calls, only affecting the no-argument/help path.
> 
> **Overview**
> When `prismic` is run without a command, the CLI now **skips** the background `refreshToken()` flow and Segment `trackStart`/`trackEnd` calls.
> 
> This prevents unnecessary auth/network work and analytics events when only printing help/usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76f5c94eb722c8fc3159c90d926845e22786b3d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->