### PR TITLE
fix: lower minimum Node.js engine requirement to >=20

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 		"runtime": {
 			"name": "node",
 			"version": ">=24",
-			"onFail": "error"
+			"onFail": "warn"
 		}
 	}
 }


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Lower the `engines.node` requirement from `>=24` to `>=20` so consumers on older Node versions can install the package. The `>=24` constraint is preserved in `devEngines` to enforce it during development only.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to Node.js version constraints; no runtime logic changes, with primary risk being unintended support expectations on Node 20–23.
> 
> **Overview**
> Lowers the `package.json` `engines.node` constraint from `>=24` to `>=20` so the package can be installed on older Node.js versions.
> 
> Adds a `devEngines.runtime` entry to keep `>=24` as the recommended development runtime (warn-only on mismatch), separating consumer install requirements from contributor tooling expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23864b5e9948c4c2a8a048420478d86f70c3aa83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->