### PR TITLE
feat: generate TypeScript types after sync and init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -14,6 +14,7 @@ import {
 } from "../config";
 import { getFramework } from "../frameworks";
 import { openBrowser } from "../lib/browser";
+import { generateAndWriteTypes } from "../lib/codegen";
 import { ForbiddenRequestError, UnauthorizedRequestError } from "../lib/request";
 import { syncCustomTypes, syncSlices } from "./sync";
 
@@ -153,6 +154,16 @@ export async function init(): Promise<void> {
 	// Sync models from remote
 	await syncSlices(repo, framework);
 	await syncCustomTypes(repo, framework);
+
+	// Generate TypeScript types from synced models
+	const slices = await framework.getSlices();
+	const customTypes = await framework.getCustomTypes();
+	const projectRoot = await framework.getProjectRoot();
+	await generateAndWriteTypes({
+		customTypes: customTypes.map((customType) => customType.model),
+		slices: slices.map((slice) => slice.model),
+		projectRoot,
+	});
 
 	console.info(
 		`Initialized Prismic for repository "${repo}". Run \`npm install\` to install new dependencies.`,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { safeGetRepositoryFromConfig } from "../config";
 import { type FrameworkAdapter, NoSupportedFrameworkError, requireFramework } from "../frameworks";
+import { generateAndWriteTypes } from "../lib/codegen";
 import { segmentSetRepository, segmentTrackEnd, segmentTrackStart } from "../lib/segment";
 import { sentrySetContext, sentrySetTag } from "../lib/sentry";
 import { dedent } from "../lib/string";
@@ -80,6 +81,7 @@ export async function sync(): Promise<void> {
 	} else {
 		await syncSlices(repo, framework);
 		await syncCustomTypes(repo, framework);
+		await regenerateTypes(framework);
 		segmentTrackEnd("sync", true, undefined, { watch: false });
 
 		console.info("Sync complete");
@@ -95,6 +97,7 @@ async function watchForChanges(repo: string, framework: FrameworkAdapter) {
 
 	await syncSlices(repo, framework);
 	await syncCustomTypes(repo, framework);
+	await regenerateTypes(framework);
 
 	console.info(dedent`
 		Initial sync completed!
@@ -142,6 +145,8 @@ async function watchForChanges(repo: string, framework: FrameworkAdapter) {
 					lastRemoteCustomTypesHash = remoteCustomTypesHash;
 					changed.push("custom types");
 				}
+
+				await regenerateTypes(framework);
 
 				const timestamp = new Date().toLocaleTimeString();
 				console.info(`[${timestamp}] Changes detected in ${changed.join(" and ")}`);
@@ -253,4 +258,15 @@ function exponentialMs(base: number): number {
 
 function hash(data: unknown): string {
 	return createHash("sha256").update(JSON.stringify(data)).digest("hex");
+}
+
+async function regenerateTypes(framework: FrameworkAdapter): Promise<void> {
+	const slices = await framework.getSlices();
+	const customTypes = await framework.getCustomTypes();
+	const projectRoot = await framework.getProjectRoot();
+	await generateAndWriteTypes({
+		customTypes: customTypes.map((customType) => customType.model),
+		slices: slices.map((slice) => slice.model),
+		projectRoot,
+	});
 }

--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -1,0 +1,23 @@
+import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+
+import { writeFile } from "node:fs/promises";
+import { generateTypes } from "prismic-ts-codegen";
+
+export async function generateAndWriteTypes(args: {
+	customTypes: CustomType[];
+	slices: SharedSlice[];
+	projectRoot: URL;
+}): Promise<void> {
+	const types = generateTypes({
+		customTypeModels: args.customTypes,
+		sharedSliceModels: args.slices,
+		clientIntegration: {
+			includeContentNamespace: true,
+			includeCreateClientInterface: true,
+		},
+		cache: true,
+		typesProvider: "@prismicio/client",
+	});
+	const outputPath = new URL("prismicio-types.d.ts", args.projectRoot);
+	await writeFile(outputPath, types);
+}


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Automatically generates `prismicio-types.d.ts` using `prismic-ts-codegen` after syncing models from Prismic. This runs after both `sync` (including watch mode) and `init`, so type definitions stay in sync with remote content models without a separate manual step.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automatically writing `prismicio-types.d.ts` after model sync adds a new side effect that can overwrite local type definitions and may impact projects with custom type generation workflows.
> 
> **Overview**
> After `prismic init` and `prismic sync`, the CLI now auto-generates `prismicio-types.d.ts` from the freshly synced remote Custom Type and Slice models using `prismic-ts-codegen`.
> 
> In `sync --watch`, type generation is also re-run whenever remote model changes are detected, via a new shared `generateAndWriteTypes` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 898226581c6124183bbb6097f94519f8ea4c6511. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->