### PR TITLE
test: optimize test suite for faster execution

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -4,6 +4,7 @@ import { setTimeout } from "node:timers/promises";
 import { getAdapter, type Adapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
+import { env } from "../env";
 import { generateAndWriteTypes } from "../lib/codegen";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { segmentTrackEnd, segmentTrackStart } from "../lib/segment";
@@ -11,7 +12,7 @@ import { dedent } from "../lib/string";
 import { findProjectRoot, getRepositoryName } from "../project";
 
 // 5 seconds balances responsiveness with API load
-const POLL_INTERVAL_MS = 5000;
+const POLL_INTERVAL_MS = env.TEST ? 500 : 5000;
 const MAX_BACKOFF_MS = 60000; // Cap backoff at 1 minute
 const MAX_CONSECUTIVE_ERRORS = 10;
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -42,11 +42,10 @@ it("initializes a project with --repo when logged in", async ({
 	expect(config.repositoryName).toBe(repo);
 }, 60_000);
 
-it("triggers login flow when not logged in, then initializes", async ({
+it("triggers login flow when not logged in", async ({
 	expect,
 	project,
 	prismic,
-	token,
 	logout,
 	repo,
 }) => {
@@ -56,23 +55,10 @@ it("triggers login flow when not logged in, then initializes", async ({
 	const proc = prismic("init", ["--repo", repo, "--no-browser"]);
 	const output = captureOutput(proc);
 
-	// Wait for the login server to start and print the URL with port
+	// Verify login flow starts, then kill — no need to complete it
 	await expect.poll(output, { timeout: 15_000 }).toMatch(/port=(\d+)/);
-
-	const port = output().match(/port=(\d+)/)![1];
-	await fetch(`http://localhost:${port}`, {
-		method: "POST",
-		headers: { "Content-Type": "application/json" },
-		body: JSON.stringify({
-			cookies: [`prismic-auth=${token}; path=/`],
-			email: process.env.E2E_PRISMIC_EMAIL,
-		}),
-	});
-
-	await expect
-		.poll(output, { timeout: 30_000 })
-		.toContain(`Initialized Prismic for repository "${repo}"`);
-}, 60_000);
+	proc.kill();
+});
 
 it("fails if repo is not in the user's account", async ({ expect, project, prismic }) => {
 	await rm(new URL("prismic.config.json", project));
@@ -91,9 +77,12 @@ it("migrates slicemachine.config.json", async ({ expect, project, prismic, repo 
 		}),
 	);
 
-	const { exitCode, stdout } = await prismic("init");
-	expect(exitCode).toBe(0);
-	expect(stdout).toContain("Migrated slicemachine.config.json");
+	const proc = prismic("init");
+	const output = captureOutput(proc);
+
+	// Wait for migration to complete, then kill — no need to wait for sync/install
+	await expect.poll(output, { timeout: 15_000 }).toContain("Migrated slicemachine.config.json");
+	proc.kill();
 
 	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
 	const config = JSON.parse(configRaw);
@@ -102,15 +91,14 @@ it("migrates slicemachine.config.json", async ({ expect, project, prismic, repo 
 
 	// Verify legacy config was deleted
 	await expect(access(new URL("slicemachine.config.json", project))).rejects.toThrow();
-}, 60_000);
+});
 
 it("installs dependencies", async ({ expect, project, prismic, repo }) => {
 	await rm(new URL("prismic.config.json", project));
 
-	const proc = prismic("init", ["--repo", repo]);
-	const output = captureOutput(proc);
+	const { exitCode } = await prismic("init", ["--repo", repo]);
+	expect(exitCode).toBe(0);
 
-	await expect.poll(output, { timeout: 60_000 }).toContain("Initialized Prismic");
-
+	// Verify the stubbed npm was invoked (it creates package-lock.json)
 	await expect(access(new URL("package-lock.json", project))).resolves.toBeUndefined();
-}, 60_000);
+});

--- a/test/it.ts
+++ b/test/it.ts
@@ -21,8 +21,6 @@ export type Fixtures = {
 	logout: () => Promise<void>;
 	token: string;
 	repo: string;
-	setupPackageJson: (args: { dependencies?: Record<string, string> }) => Promise<void>;
-	stubNodeModule: (name: string, version: string) => Promise<void>;
 };
 
 export const it = test.extend<Fixtures>({
@@ -36,23 +34,34 @@ export const it = test.extend<Fixtures>({
 		await use(pathToFileURL(dir + "/"));
 		await rm(dir, { recursive: true, force: true });
 	},
-	project: async ({ home }, use) => {
+	project: async ({ home, repo }, use) => {
 		const projectPath = new URL("project/", home);
 		await mkdir(projectPath, { recursive: true });
+
+		// Stub npm
+		const binDir = new URL("bin/", home);
+		await mkdir(binDir);
+		const lockfilePath = fileURLToPath(new URL("package-lock.json", projectPath));
+		await writeFile(
+			new URL("npm", binDir),
+			`#!/bin/sh\necho '{}' > "${lockfilePath}"\necho "added 0 packages"\n`,
+			{ mode: 0o755 },
+		);
+
+		// Stub Next.js installation
+		const packageJsonPath = new URL("package.json", projectPath);
+		await writeFile(packageJsonPath, JSON.stringify({ dependencies: { next: "latest" } }));
+		const nextPackageJsonPath = new URL("node_modules/next/package.json", projectPath);
+		await mkdir(new URL(".", nextPackageJsonPath), { recursive: true });
+		await writeFile(nextPackageJsonPath, JSON.stringify({ version: "16.0.0" }));
+		await mkdir(new URL("app/", projectPath));
+
+		await writeFile(
+			new URL("prismic.config.json", projectPath),
+			JSON.stringify({ repositoryName: repo }),
+		);
+
 		await use(projectPath);
-	},
-	setupPackageJson: async ({ project }, use) => {
-		const packageJsonPath = new URL("package.json", project);
-		await use(async ({ dependencies }) => {
-			await writeFile(packageJsonPath, JSON.stringify({ dependencies }));
-		});
-	},
-	stubNodeModule: async ({ project }, use) => {
-		await use(async (name, version) => {
-			const packageJsonPath = new URL(`node_modules/${name}/package.json`, project);
-			await mkdir(new URL(".", packageJsonPath), { recursive: true });
-			await writeFile(packageJsonPath, JSON.stringify({ version }));
-		});
 	},
 	// oxlint-disable-next-line no-empty-pattern
 	token: async ({}, use) => {
@@ -72,20 +81,15 @@ export const it = test.extend<Fixtures>({
 			await rm(new URL(".prismic", home), { recursive: true, force: true });
 		});
 	},
-	prismic: async ({ home, project, login, setupPackageJson, stubNodeModule, repo }, use) => {
+	prismic: async ({ home, project, login }, use) => {
 		await login();
-		await setupPackageJson({ dependencies: { next: "latest" } });
-		await stubNodeModule("next", "16.0.0");
-		await mkdir(new URL("app/", project));
-		await writeFile(
-			new URL("prismic.config.json", project),
-			JSON.stringify({ repositoryName: repo }),
-		);
+		const binDir = new URL("bin/", home);
 		const procs: Result[] = [];
 		await use((command, args = [], options) => {
 			const env = {
 				...process.env,
 				...options?.nodeOptions?.env,
+				PATH: `${fileURLToPath(binDir)}:${process.env.PATH}`,
 				HOME: fileURLToPath(home),
 			};
 			const proc = x("node", [BIN, command, ...args].filter(Boolean), {

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -22,8 +22,10 @@ it("syncs slices and custom types from remote", async ({
 	const customType = buildCustomType();
 	const slice = buildSlice();
 
-	await insertCustomType(customType, { repo, token, host });
-	await insertSlice(slice, { repo, token, host });
+	await Promise.all([
+		insertCustomType(customType, { repo, token, host }),
+		insertSlice(slice, { repo, token, host }),
+	]);
 
 	const { exitCode } = await prismic("sync", ["--repo", repo]);
 	expect(exitCode).toBe(0);
@@ -43,8 +45,10 @@ it("syncs multiple slices with correct structure", async ({
 	const sliceA = buildSlice();
 	const sliceB = buildSlice();
 
-	await insertSlice(sliceA, { repo, token, host });
-	await insertSlice(sliceB, { repo, token, host });
+	await Promise.all([
+		insertSlice(sliceA, { repo, token, host }),
+		insertSlice(sliceB, { repo, token, host }),
+	]);
 
 	const { exitCode } = await prismic("sync", ["--repo", repo]);
 	expect(exitCode).toBe(0);
@@ -91,8 +95,10 @@ it("removes deleted slice and updates index on re-sync", async ({
 	const sliceA = buildSlice();
 	const sliceB = buildSlice();
 
-	await insertSlice(sliceA, { repo, token, host });
-	await insertSlice(sliceB, { repo, token, host });
+	await Promise.all([
+		insertSlice(sliceA, { repo, token, host }),
+		insertSlice(sliceB, { repo, token, host }),
+	]);
 
 	// First sync — creates both slices
 	const first = await prismic("sync", ["--repo", repo]);
@@ -119,8 +125,10 @@ it("watches for changes and syncs", async ({ expect, project, prismic, repo, tok
 
 	await expect.poll(output, { timeout: 30_000 }).toContain("Watching for changes");
 
-	await insertCustomType(customType, { repo, token, host });
-	await insertSlice(slice, { repo, token, host });
+	await Promise.all([
+		insertCustomType(customType, { repo, token, host }),
+		insertSlice(slice, { repo, token, host }),
+	]);
 
 	await expect.poll(output, { timeout: 30_000 }).toContain("Changes detected");
 
@@ -128,7 +136,7 @@ it("watches for changes and syncs", async ({ expect, project, prismic, repo, tok
 	await expect(project).toContainSlice(slice);
 }, 60_000);
 
-it("adds route for synced page type", async ({ expect, project, prismic, repo, token, host }) => {
+it("syncs repeatable page type", async ({ expect, project, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "page", repeatable: true });
 	await insertCustomType(customType, { repo, token, host });
 
@@ -137,16 +145,12 @@ it("adds route for synced page type", async ({ expect, project, prismic, repo, t
 
 	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).toHaveRoute({ type: customType.id, path: `/${expectedSegment}/:uid` });
+	await expect(project).toHaveFile(`app/${expectedSegment}/[uid]/page.jsx`, {
+		contains: `getByUID("${customType.id}"`,
+	});
 });
 
-it("adds route without :uid for non-repeatable page type", async ({
-	expect,
-	project,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("syncs non-repeatable page type", async ({ expect, project, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "page", repeatable: false });
 	await insertCustomType(customType, { repo, token, host });
 
@@ -155,22 +159,21 @@ it("adds route without :uid for non-repeatable page type", async ({
 
 	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).toHaveRoute({ type: customType.id, path: `/${expectedSegment}` });
+	await expect(project).toHaveFile(`app/${expectedSegment}/page.jsx`, {
+		contains: `getSingle("${customType.id}"`,
+	});
 });
 
-it("does not add route for non-page custom type", async ({
-	expect,
-	project,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("syncs non-page custom type", async ({ expect, project, prismic, repo, token, host }) => {
 	const customType = buildCustomType();
 	await insertCustomType(customType, { repo, token, host });
 
 	const { exitCode } = await prismic("sync", ["--repo", repo]);
 	expect(exitCode).toBe(0);
+
+	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).not.toHaveRoute({ type: customType.id });
+	await expect(project).not.toHaveFile(`app/${expectedSegment}/page.jsx`);
 });
 
 it("removes route when page type is deleted", async ({
@@ -195,64 +198,6 @@ it("removes route when page type is deleted", async ({
 	const second = await prismic("sync", ["--repo", repo]);
 	expect(second.exitCode).toBe(0);
 	await expect(project).not.toHaveRoute({ type: customType.id });
-});
-
-it("generates page file for repeatable page type", async ({
-	expect,
-	project,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
-	const customType = buildCustomType({ format: "page", repeatable: true });
-	await insertCustomType(customType, { repo, token, host });
-
-	const { exitCode } = await prismic("sync", ["--repo", repo]);
-	expect(exitCode).toBe(0);
-
-	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
-	await expect(project).toHaveFile(`app/${expectedSegment}/[uid]/page.jsx`, {
-		contains: `getByUID("${customType.id}"`,
-	});
-});
-
-it("generates page file for non-repeatable page type", async ({
-	expect,
-	project,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
-	const customType = buildCustomType({ format: "page", repeatable: false });
-	await insertCustomType(customType, { repo, token, host });
-
-	const { exitCode } = await prismic("sync", ["--repo", repo]);
-	expect(exitCode).toBe(0);
-
-	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
-	await expect(project).toHaveFile(`app/${expectedSegment}/page.jsx`, {
-		contains: `getSingle("${customType.id}"`,
-	});
-});
-
-it("does not generate page file for non-page custom type", async ({
-	expect,
-	project,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
-	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
-
-	const { exitCode } = await prismic("sync", ["--repo", repo]);
-	expect(exitCode).toBe(0);
-
-	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
-	await expect(project).not.toHaveFile(`app/${expectedSegment}/page.jsx`);
 });
 
 it("does not overwrite existing page file", async ({


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Reduce test suite wall-clock time by eliminating unnecessary work:

- **Stub npm** in the test fixture so no test runs a real `npm install`
- **Faster watch polling** (500ms vs 5s) when `env.TEST` is true
- **Parallelize API inserts** where calls are independent
- **Early process kill** in init tests once the relevant step is verified (login flow, migration, install)
- **Combine sync tests** with identical setup — route + page file assertions merged (14 → 11 tests)

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

Run `node --run test` and compare total execution time against `main`.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily test harness optimizations plus a `sync --watch` polling tweak gated behind `env.TEST`. Production behavior remains the same unless `TEST` is set, but timing-sensitive watch tests may still be affected.
> 
> **Overview**
> Improves test suite runtime by stubbing `npm` in the shared `it` fixture (via a fake binary on `PATH`) so `init` doesn’t run a real install, and by allowing `sync --watch` to poll faster when `env.TEST` is true.
> 
> Tests are adjusted to do less work and finish earlier: independent Prismic API inserts run in parallel, `init` tests kill the process once login/migration is observed, and several sync assertions are consolidated (route + generated page file checks) to reduce duplicated setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84472cdf94b87fdcbd9ae55f56c0b954a65b4379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->