### PR TITLE
feat: add locale management commands

### DIFF
--- a/src/clients/locale.ts
+++ b/src/clients/locale.ts
@@ -1,0 +1,64 @@
+import * as z from "zod/mini";
+
+import { request } from "../lib/request";
+
+const LocaleSchema = z.object({
+	id: z.string(),
+	label: z.string(),
+	customName: z.nullable(z.string()),
+	isMaster: z.boolean(),
+});
+
+export type Locale = z.infer<typeof LocaleSchema>;
+
+export async function getLocales(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<Locale[]> {
+	const { repo, token, host } = config;
+	const url = new URL("repository/locales", getLocaleServiceUrl(host));
+	url.searchParams.set("repository", repo);
+	const response = await request(url, {
+		headers: { Authorization: `Bearer ${token}` },
+		schema: z.object({ results: z.array(LocaleSchema) }),
+	});
+	return response.results;
+}
+
+export async function upsertLocale(
+	locale: { id: string; isMaster?: boolean; customName?: string },
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<Locale> {
+	const { repo, token, host } = config;
+	const url = new URL("repository/locales", getLocaleServiceUrl(host));
+	url.searchParams.set("repository", repo);
+	const response = await request(url, {
+		method: "POST",
+		body: {
+			id: locale.id,
+			isMaster: locale.isMaster ?? false,
+			...(locale.customName ? { customName: locale.customName } : {}),
+		},
+		headers: { Authorization: `Bearer ${token}` },
+		schema: LocaleSchema,
+	});
+	return response;
+}
+
+export async function removeLocale(
+	code: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<void> {
+	const { repo, token, host } = config;
+	const url = new URL(`repository/locales/${encodeURIComponent(code)}`, getLocaleServiceUrl(host));
+	url.searchParams.set("repository", repo);
+	await request(url, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${token}` },
+	});
+}
+
+function getLocaleServiceUrl(host: string): URL {
+	return new URL(`https://api.internal.${host}/locale/`);
+}

--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -1,0 +1,47 @@
+import { getHost, getToken } from "../auth";
+import { upsertLocale } from "../clients/locale";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic locale add",
+	description: `
+		Add a locale to a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	positionals: {
+		code: { description: "Locale code (e.g. fr-fr, es-es)" },
+	},
+	options: {
+		master: { type: "boolean", description: "Set as the master locale" },
+		name: { type: "string", short: "n", description: "Custom display name (for custom locales)" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [code] = positionals;
+	const { repo = await getRepositoryName(), master = false, name } = values;
+
+	if (!code) {
+		throw new CommandError("Missing required argument: <code>");
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+
+	try {
+		await upsertLocale({ id: code, isMaster: master, customName: name }, { repo, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to add locale: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Locale added: ${code}`);
+});

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -1,0 +1,43 @@
+import { getHost, getToken } from "../auth";
+import { getLocales } from "../clients/locale";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic locale list",
+	description: `
+		List all locales in a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	options: {
+		json: { type: "boolean", description: "Output as JSON" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { repo = await getRepositoryName(), json } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+
+	const locales = await getLocales({ repo, token, host });
+
+	if (json) {
+		console.info(stringify(locales));
+		return;
+	}
+
+	if (locales.length === 0) {
+		console.info("No locales found.");
+		return;
+	}
+
+	for (const locale of locales) {
+		const masterLabel = locale.isMaster ? " (master)" : "";
+		console.info(`${locale.id}  ${locale.label}${masterLabel}`);
+	}
+});

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -1,0 +1,45 @@
+import { getHost, getToken } from "../auth";
+import { removeLocale } from "../clients/locale";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic locale remove",
+	description: `
+		Remove a locale from a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	positionals: {
+		code: { description: "Locale code (e.g. en-us, fr-fr)" },
+	},
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [code] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	if (!code) {
+		throw new CommandError("Missing required argument: <code>");
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+
+	try {
+		await removeLocale(code, { repo, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to remove locale: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Locale removed: ${code}`);
+});

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -1,0 +1,61 @@
+import { getHost, getToken } from "../auth";
+import { getLocales, upsertLocale } from "../clients/locale";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic locale set-master",
+	description: `
+		Set the master locale for a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	positionals: {
+		code: { description: "Locale code (e.g. en-us, fr-fr)" },
+	},
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [code] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	if (!code) {
+		throw new CommandError("Missing required argument: <code>");
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === code);
+
+	if (!locale) {
+		throw new CommandError(
+			`Locale "${code}" not found. Available locales: ${locales.map((l) => l.id).join(", ")}`,
+		);
+	}
+
+	if (locale.isMaster) {
+		throw new CommandError(`Locale "${code}" is already the master.`);
+	}
+
+	try {
+		await upsertLocale(
+			{ id: locale.id, isMaster: true, customName: locale.customName ?? undefined },
+			{ repo, token, host },
+		);
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to set master locale: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Master locale set: ${code}`);
+});

--- a/src/commands/locale.ts
+++ b/src/commands/locale.ts
@@ -1,0 +1,28 @@
+import { createCommandRouter } from "../lib/command";
+import localeAdd from "./locale-add";
+import localeList from "./locale-list";
+import localeRemove from "./locale-remove";
+import localeSetMaster from "./locale-set-master";
+
+export default createCommandRouter({
+	name: "prismic locale",
+	description: "Manage locales in a Prismic repository.",
+	commands: {
+		add: {
+			handler: localeAdd,
+			description: "Add a locale",
+		},
+		list: {
+			handler: localeList,
+			description: "List locales",
+		},
+		remove: {
+			handler: localeRemove,
+			description: "Remove a locale",
+		},
+		"set-master": {
+			handler: localeSetMaster,
+			description: "Set the master locale",
+		},
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getAdapter, NoSupportedFrameworkError } from "./adapters";
 import { getHost, refreshToken } from "./auth";
 import { getProfile } from "./clients/user";
 import init from "./commands/init";
+import locale from "./commands/locale";
 import login from "./commands/login";
 import logout from "./commands/logout";
 import preview from "./commands/preview";
@@ -46,6 +47,10 @@ const router = createCommandRouter({
 		sync: {
 			handler: sync,
 			description: "Sync types and slices from Prismic",
+		},
+		locale: {
+			handler: locale,
+			description: "Manage locales",
 		},
 		preview: {
 			handler: preview,

--- a/test/locale-add.serial.test.ts
+++ b/test/locale-add.serial.test.ts
@@ -1,0 +1,44 @@
+import { it } from "./it";
+import { getLocales, resetLocales } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale", ["add", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale add <code> [options]");
+});
+
+it("adds a locale", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["add", "fr-fr"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Locale added: fr-fr");
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === "fr-fr");
+	expect(locale).toBeDefined();
+});
+
+it("adds a locale with a custom name", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["add", "ab-cd", "--name", "Custom Locale"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Locale added: ab-cd");
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === "ab-cd");
+	expect(locale?.customName).toBe("Custom Locale");
+});
+
+it("adds a locale as master", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["add", "fr-fr", "--master"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Locale added: fr-fr");
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === "fr-fr");
+	expect(locale?.isMaster).toBe(true);
+});

--- a/test/locale-list.serial.test.ts
+++ b/test/locale-list.serial.test.ts
@@ -1,0 +1,27 @@
+import { it } from "./it";
+import { upsertLocale, resetLocales } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale", ["list", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale list [options]");
+});
+
+it("lists locales", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+	await upsertLocale("fr-fr", { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["list"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("fr-fr");
+});
+
+it("lists locales as JSON", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+	await upsertLocale("fr-fr", { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["list", "--json"]);
+	expect(exitCode).toBe(0);
+	const parsed = JSON.parse(stdout);
+	expect(parsed).toEqual(expect.arrayContaining([expect.objectContaining({ id: "fr-fr" })]));
+});

--- a/test/locale-remove.serial.test.ts
+++ b/test/locale-remove.serial.test.ts
@@ -1,0 +1,21 @@
+import { it } from "./it";
+import { upsertLocale, getLocales, resetLocales } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale", ["remove", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale remove <code> [options]");
+});
+
+it("removes a locale", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+	await upsertLocale("fr-fr", { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["remove", "fr-fr"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Locale removed: fr-fr");
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === "fr-fr");
+	expect(locale).toBeUndefined();
+});

--- a/test/locale-set-master.serial.test.ts
+++ b/test/locale-set-master.serial.test.ts
@@ -1,0 +1,32 @@
+import { it } from "./it";
+import { upsertLocale, getLocales, resetLocales } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale", ["set-master", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale set-master <code> [options]");
+});
+
+it("sets the master locale", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+	await upsertLocale("fr-fr", { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("locale", ["set-master", "fr-fr"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Master locale set: fr-fr");
+
+	const locales = await getLocales({ repo, token, host });
+	const locale = locales.find((l) => l.id === "fr-fr");
+	expect(locale?.isMaster).toBe(true);
+});
+
+it("errors when locale is already master", async ({ expect, prismic, repo, token, host }) => {
+	await resetLocales({ repo, token, host });
+	const locales = await getLocales({ repo, token, host });
+	const master = locales.find((l) => l.isMaster);
+	if (!master) return;
+
+	const { stderr, exitCode } = await prismic("locale", ["set-master", master.id]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("already the master");
+});

--- a/test/locale.serial.test.ts
+++ b/test/locale.serial.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale <command> [options]");
+});
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("locale", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic locale <command> [options]");
+});

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -103,7 +103,9 @@ export async function deleteSlice(sliceId: string, config: RepoConfig): Promise<
 	if (!res.ok) throw new Error(`Failed to delete slice: ${res.status} ${await res.text()}`);
 }
 
-export async function getWebhooks(config: RepoConfig): Promise<{ config: Record<string, unknown> }[]> {
+export async function getWebhooks(
+	config: RepoConfig,
+): Promise<{ config: Record<string, unknown> }[]> {
 	const host = config.host ?? DEFAULT_HOST;
 	const url = new URL("app/settings/webhooks", `https://${config.repo}.${host}/`);
 	const res = await fetch(url, {
@@ -136,7 +138,9 @@ export async function createWebhook(webhookUrl: string, config: RepoConfig): Pro
 	if (!res.ok) throw new Error(`Failed to create webhook: ${res.status} ${await res.text()}`);
 }
 
-export async function getPreviews(config: RepoConfig): Promise<{ id: string; label: string; url: string }[]> {
+export async function getPreviews(
+	config: RepoConfig,
+): Promise<{ id: string; label: string; url: string }[]> {
 	const host = config.host ?? DEFAULT_HOST;
 	const url = new URL("core/repository/preview_configs", `https://${config.repo}.${host}/`);
 	const res = await fetch(url, {
@@ -168,6 +172,62 @@ export async function addPreview(
 	if (!res.ok) throw new Error(`Failed to add preview: ${res.status} ${await res.text()}`);
 }
 
+export async function getLocales(
+	config: RepoConfig,
+): Promise<{ id: string; label: string; customName: string | null; isMaster: boolean }[]> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("locale/repository/locales", `https://api.internal.${host}/`);
+	url.searchParams.set("repository", config.repo);
+	const res = await fetch(url, {
+		headers: { Authorization: `Bearer ${config.token}` },
+	});
+	if (!res.ok) throw new Error(`Failed to get locales: ${res.status} ${await res.text()}`);
+	const data = await res.json();
+	return data.results;
+}
+
+export async function upsertLocale(
+	code: string,
+	config: RepoConfig & { isMaster?: boolean },
+): Promise<void> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("locale/repository/locales", `https://api.internal.${host}/`);
+	url.searchParams.set("repository", config.repo);
+	const res = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${config.token}`,
+		},
+		body: JSON.stringify({ id: code, isMaster: config.isMaster ?? false }),
+	});
+	if (!res.ok) throw new Error(`Failed to add locale ${code}: ${res.status} ${await res.text()}`);
+}
+
+export async function removeLocale(code: string, config: RepoConfig): Promise<void> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL(
+		`locale/repository/locales/${encodeURIComponent(code)}`,
+		`https://api.internal.${host}/`,
+	);
+	url.searchParams.set("repository", config.repo);
+	const res = await fetch(url, {
+		method: "DELETE",
+		headers: { Authorization: `Bearer ${config.token}` },
+	});
+	if (!res.ok && res.status !== 404)
+		throw new Error(`Failed to remove locale ${code}: ${res.status} ${await res.text()}`);
+}
+
+export async function resetLocales(config: RepoConfig): Promise<void> {
+	await upsertLocale("en-us", { isMaster: true, ...config });
+	const locales = await getLocales(config);
+	for (const locale of locales) {
+		if (locale.isMaster) continue;
+		await removeLocale(locale.id, config);
+	}
+}
+
 export async function getRepository(config: RepoConfig): Promise<{ simulator_url?: string }> {
 	const host = config.host ?? DEFAULT_HOST;
 	const url = new URL("core/repository", `https://${config.repo}.${host}/`);
@@ -177,4 +237,3 @@ export async function getRepository(config: RepoConfig): Promise<{ simulator_url
 	if (!res.ok) throw new Error(`Failed to get repository: ${res.status} ${await res.text()}`);
 	return await res.json();
 }
-

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,6 +1,6 @@
 import type { Vitest } from "vitest/node";
 
-import { createRepository, deleteRepository, login } from "./prismic";
+import { upsertLocale, createRepository, deleteRepository, login } from "./prismic";
 
 declare module "vitest" {
 	export interface ProvidedContext {
@@ -26,17 +26,18 @@ export default async function ({ provide }: Vitest): Promise<() => Promise<void>
 	const token = await login(email, password, { host });
 	provide("token", token);
 
-	const domain = `prismic-cli-test-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
-	console.info(`Creating shared test repository: ${domain}`);
-	await createRepository(domain, { token, host });
-	provide("repo", domain);
+	const repo = `prismic-cli-test-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
+	console.info(`Creating shared test repository: ${repo}`);
+	await createRepository(repo, { token, host });
+	await upsertLocale("en-us", { isMaster: true, repo, token, host });
+	provide("repo", repo);
 
 	return async () => {
 		try {
-			console.info(`Deleting shared test repository: ${domain}`);
-			await deleteRepository(domain, { token, password, host });
+			console.info(`Deleting shared test repository: ${repo}`);
+			await deleteRepository(repo, { token, password, host });
 		} catch {
-			console.warn(`Warning: failed to delete test repository ${domain}`);
+			console.warn(`Warning: failed to delete test repository ${repo}`);
 		}
 	};
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,15 +2,29 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
-		setupFiles: ["./test/setup.ts"],
 		globalSetup: ["./test/setup.global.ts"],
 		forceRerunTriggers: ["**/dist/index.mjs"],
-		typecheck: {
-			enabled: true,
-		},
-		sequence: {
-			concurrent: true,
-		},
+		typecheck: { enabled: true },
 		retry: 1,
+		projects: [
+			{
+				test: {
+					name: "concurrent",
+					setupFiles: ["./test/setup.ts"],
+					include: ["./test/**/*.test.ts"],
+					exclude: ["./test/*.serial.test.ts"],
+					sequence: { concurrent: true },
+				},
+			},
+			{
+				test: {
+					name: "serial",
+					setupFiles: ["./test/setup.ts"],
+					include: ["./test/*.serial.test.ts"],
+					sequence: { concurrent: false },
+					fileParallelism: false,
+				},
+			},
+		],
 	},
 });


### PR DESCRIPTION
Resolves: #17

### Description

Add `prismic locale` commands for managing repository locales: add, list, remove, and set-master. Locales are managed via the Prismic internal API.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that mutate repository locale configuration via an internal API; mistakes or API changes could impact repo settings and user workflows.
> 
> **Overview**
> Adds a new locale client (`src/clients/locale.ts`) and a `prismic locale` command group with `add`, `list`, `remove`, and `set-master`, wired into the top-level CLI router.
> 
> The commands call the internal locale API to fetch locales, upsert a locale (optionally setting master and custom name), delete a locale, and validate/set the master locale with user-friendly error messages.
> 
> Extends E2E coverage with new serial locale tests, adds locale test helpers to `test/prismic.ts`, and updates Vitest to run `*.serial.test.ts` in a dedicated non-concurrent project to avoid shared-repo state conflicts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2339750f49d74ca94a12f1916197cebb923e28e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->