### PR TITLE
feat: add gen commands

### DIFF
--- a/src/commands/gen-types.ts
+++ b/src/commands/gen-types.ts
@@ -1,0 +1,35 @@
+import { getAdapter } from "../adapters";
+import { generateAndWriteTypes } from "../lib/codegen";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { relativePathname } from "../lib/url";
+import { findProjectRoot } from "../project";
+
+const FILENAME = "prismicio-types.d.ts";
+
+const config = {
+	name: "prismic gen types",
+	description: `
+		Generate TypeScript types from local custom type and slice models.
+
+		Reads models from the customtypes/ and slices directories, then writes
+		a prismicio-types.d.ts file at the project root.
+	`,
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const adapter = await getAdapter();
+	const slices = await adapter.getSlices();
+	const customTypes = await adapter.getCustomTypes();
+	const projectRoot = await findProjectRoot();
+
+	const output = new URL(FILENAME, projectRoot);
+	const relativeOutput = relativePathname(projectRoot, output);
+
+	await generateAndWriteTypes({
+		customTypes: customTypes.map((customType) => customType.model),
+		slices: slices.map((slice) => slice.model),
+		output,
+	});
+
+	console.info(`Generated types at ${relativeOutput}`);
+});

--- a/src/commands/gen.ts
+++ b/src/commands/gen.ts
@@ -1,0 +1,13 @@
+import { createCommandRouter } from "../lib/command";
+import genTypes from "./gen-types";
+
+export default createCommandRouter({
+	name: "prismic gen",
+	description: "Generate files from local Prismic models.",
+	commands: {
+		types: {
+			handler: genTypes,
+			description: "Generate TypeScript types from local models",
+		},
+	},
+});

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -150,10 +150,11 @@ export default createCommand(config, async ({ values }) => {
 	const slices = await adapter.getSlices();
 	const customTypes = await adapter.getCustomTypes();
 	const projectRoot = await findProjectRoot();
+	const output = new URL("prismicio-types.d.ts", projectRoot);
 	await generateAndWriteTypes({
 		customTypes: customTypes.map((customType) => customType.model),
 		slices: slices.map((slice) => slice.model),
-		projectRoot,
+		output,
 	});
 
 	console.info(`\nInitialized Prismic for repository "${repo}".`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -227,9 +227,10 @@ async function regenerateTypes(adapter: Adapter): Promise<void> {
 	const slices = await adapter.getSlices();
 	const customTypes = await adapter.getCustomTypes();
 	const projectRoot = await findProjectRoot();
+	const output = new URL("prismicio-types.d.ts", projectRoot);
 	await generateAndWriteTypes({
 		customTypes: customTypes.map((customType) => customType.model),
 		slices: slices.map((slice) => slice.model),
-		projectRoot,
+		output,
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import packageJson from "../package.json" with { type: "json" };
 import { getAdapter, NoSupportedFrameworkError } from "./adapters";
 import { getHost, refreshToken } from "./auth";
 import { getProfile } from "./clients/user";
+import gen from "./commands/gen";
 import init from "./commands/init";
 import locale from "./commands/locale";
 import login from "./commands/login";
@@ -44,6 +45,10 @@ const router = createCommandRouter({
 		init: {
 			handler: init,
 			description: "Initialize a Prismic project",
+		},
+		gen: {
+			handler: gen,
+			description: "Generate files from local models",
 		},
 		sync: {
 			handler: sync,

--- a/src/lib/codegen.ts
+++ b/src/lib/codegen.ts
@@ -6,11 +6,13 @@ import { generateTypes } from "prismic-ts-codegen";
 export async function generateAndWriteTypes(args: {
 	customTypes: CustomType[];
 	slices: SharedSlice[];
-	projectRoot: URL;
+	output: URL;
 }): Promise<void> {
+	const { customTypes, slices, output } = args;
+
 	const types = generateTypes({
-		customTypeModels: args.customTypes,
-		sharedSliceModels: args.slices,
+		customTypeModels: customTypes,
+		sharedSliceModels: slices,
 		clientIntegration: {
 			includeContentNamespace: true,
 			includeCreateClientInterface: true,
@@ -18,6 +20,5 @@ export async function generateAndWriteTypes(args: {
 		cache: true,
 		typesProvider: "@prismicio/client",
 	});
-	const outputPath = new URL("prismicio-types.d.ts", args.projectRoot);
-	await writeFile(outputPath, types);
+	await writeFile(output, types);
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,5 +1,12 @@
+import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
 export function appendTrailingSlash(url: string | URL): URL {
 	const newURL = new URL(url);
 	if (!newURL.pathname.endsWith("/")) newURL.pathname += "/";
 	return newURL;
+}
+
+export function relativePathname(a: URL, b: URL): string {
+	return relative(fileURLToPath(a), fileURLToPath(b));
 }

--- a/test/gen-types.test.ts
+++ b/test/gen-types.test.ts
@@ -1,0 +1,69 @@
+import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+
+import { mkdir, writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("gen", ["types", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic gen types [options]");
+});
+
+it("generates types from local models", async ({ expect, project, prismic }) => {
+	const customType = buildCustomType();
+	const customTypePath = new URL(`customtypes/${customType.id}/index.json`, project);
+	await mkdir(new URL(".", customTypePath), { recursive: true });
+	await writeFile(customTypePath, JSON.stringify(customType));
+
+	const slice = buildSlice();
+	const slicePath = new URL(`slices/${slice.name}/model.json`, project);
+	await mkdir(new URL(".", slicePath), { recursive: true });
+	await writeFile(slicePath, JSON.stringify(slice));
+
+	const { exitCode, stdout } = await prismic("gen", ["types"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Generated types");
+
+	await expect(project).toHaveFile("prismicio-types.d.ts", {
+		contains: customType.id,
+	});
+});
+
+it("generates types with no models", async ({ expect, project, prismic }) => {
+	const { exitCode, stdout } = await prismic("gen", ["types"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Generated types");
+
+	await expect(project).toHaveFile("prismicio-types.d.ts");
+});
+
+function buildCustomType(): CustomType {
+	const id = crypto.randomUUID().split("-")[0];
+	return {
+		id: `type-T${id}`,
+		label: `TypeT${id}`,
+		repeatable: true,
+		status: true,
+		json: {},
+	};
+}
+
+function buildSlice(): SharedSlice {
+	const id = crypto.randomUUID().split("-")[0];
+	return {
+		id: `slice-S${id}`,
+		type: "SharedSlice",
+		name: `SliceS${id}`,
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+			},
+		],
+	};
+}

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("gen", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic gen <command> [options]");
+});
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("gen");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic gen <command> [options]");
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
 		globalSetup: ["./test/setup.global.ts"],
 		forceRerunTriggers: ["**/dist/index.mjs"],
 		typecheck: { enabled: true },
-		testTimeout: 10_000,
 		retry: 1,
 		projects: [
 			{
@@ -15,6 +14,7 @@ export default defineConfig({
 					include: ["./test/**/*.test.ts"],
 					exclude: ["./test/*.serial.test.ts"],
 					sequence: { concurrent: true },
+					testTimeout: 10_000,
 				},
 			},
 			{
@@ -24,6 +24,7 @@ export default defineConfig({
 					include: ["./test/*.serial.test.ts"],
 					sequence: { concurrent: false },
 					fileParallelism: false,
+					testTimeout: 10_000,
 				},
 			},
 		],


### PR DESCRIPTION
Resolves: #19

### Description

Re-enables codegen as the `prismic gen types` command. This generates TypeScript types from local custom type and slice models using `prismic-ts-codegen`.

Also refactors `generateAndWriteTypes` to accept an `output` URL instead of `projectRoot`, letting callers control the output path directly.

`prismic gen types` is used over something like `prismic codegen` since we may want to add other `gen` commands, like:

- `prismic gen routes`
- `prismic gen page-file blog-post`
- `prismic gen simulator`

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new CLI command wiring and changes the `generateAndWriteTypes` API, which could affect all call sites that generate `prismicio-types.d.ts` if output paths or URLs are incorrect.
> 
> **Overview**
> Adds a new `prismic gen` command group with `prismic gen types` to generate `prismicio-types.d.ts` from local `customtypes/` and `slices/` models, printing the generated file’s relative path.
> 
> Refactors `generateAndWriteTypes` to accept an explicit `output` URL (instead of `projectRoot`) and updates `init` and `sync` to pass the output file URL. Adds `relativePathname` URL utility, new Vitest coverage for the `gen`/`gen types` help output and type generation, and adjusts `vitest.config.ts` to set `testTimeout` per project.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4349f8162f30de800c5b4feefde841313ca52f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->