### PR TITLE
feat: add repo commands

### DIFF
--- a/src/clients/user.ts
+++ b/src/clients/user.ts
@@ -10,6 +10,7 @@ const ProfileSchema = z.object({
 		z.object({
 			domain: z.string(),
 			name: z.optional(z.string()),
+			role: z.optional(z.string()),
 		}),
 	),
 });

--- a/src/clients/wroom.ts
+++ b/src/clients/wroom.ts
@@ -226,6 +226,98 @@ export async function deleteWriteToken(
 	});
 }
 
+export async function checkIsDomainAvailable(config: {
+	domain: string;
+	token: string | undefined;
+	host: string;
+}): Promise<boolean> {
+	const { domain, token, host } = config;
+	const url = new URL(`app/dashboard/repositories/${domain}/exists`, getDashboardUrl(host));
+	const response = await request(url, {
+		credentials: { "prismic-auth": token },
+		schema: z.boolean(),
+	});
+	return response;
+}
+
+export async function createRepository(config: {
+	domain: string;
+	name: string;
+	framework: string;
+	token: string | undefined;
+	host: string;
+}): Promise<void> {
+	const { domain, name, framework, token, host } = config;
+	const url = new URL("app/dashboard/repositories", getDashboardUrl(host));
+	await request(url, {
+		method: "POST",
+		body: { domain, name, framework, plan: "personal" },
+		credentials: { "prismic-auth": token },
+	});
+}
+
+const SyncStateSchema = z.object({
+	repository: z.object({
+		api_access: z.string(),
+	}),
+});
+
+export async function getRepositoryAccess(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<string> {
+	const { repo, token, host } = config;
+	const url = new URL("syncState", getWroomUrl(repo, host));
+	const response = await request(url, {
+		credentials: { "prismic-auth": token },
+		schema: SyncStateSchema,
+	});
+	return response.repository.api_access;
+}
+
+export type RepositoryAccessLevel = "private" | "public" | "open";
+
+export async function setRepositoryAccess(
+	level: RepositoryAccessLevel,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<void> {
+	const { repo, token, host } = config;
+	const url = new URL("settings/security/apiaccess", getWroomUrl(repo, host));
+	await request(url, {
+		method: "POST",
+		body: { api_access: level },
+		credentials: { "prismic-auth": token },
+	});
+}
+
+const SetNameResponseSchema = z.object({
+	repository: z.object({
+		name: z.string(),
+	}),
+});
+
+export async function setRepositoryName(
+	name: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<string> {
+	const { repo, token, host } = config;
+	const url = new URL("app/settings/repository", getWroomUrl(repo, host));
+	const formData = new FormData();
+	formData.set("displayname", name);
+	const response = await request(url, {
+		method: "POST",
+		body: formData,
+		credentials: { "prismic-auth": token },
+		schema: SetNameResponseSchema,
+	});
+	return response.repository.name;
+}
+
+function getDashboardUrl(host: string): URL {
+	return new URL(`https://${host}/`);
+}
+
 function getWroomUrl(repo: string, host: string): URL {
 	return new URL(`https://${repo}.${host}/`);
 }

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -1,0 +1,60 @@
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { checkIsDomainAvailable, createRepository } from "../clients/wroom";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+
+const MAX_DOMAIN_TRIES = 5;
+
+const config = {
+	name: "prismic repo create",
+	description: "Create a new Prismic repository.",
+	options: {
+		name: { type: "string", short: "n", description: "Display name for the repository" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { name } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+
+	const domain = await findAvailableDomain({ token, host });
+	if (!domain) {
+		throw new CommandError("Failed to create a repository. Please try again.");
+	}
+
+	const adapter = await getAdapter().catch(() => undefined);
+	const framework = adapter?.id ?? "other";
+
+	try {
+		await createRepository({ domain, name: name ?? domain, framework, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to create repository: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Repository created: ${domain}`);
+	console.info(`URL: https://${domain}.${host}/`);
+});
+
+async function findAvailableDomain(config: {
+	token: string | undefined;
+	host: string;
+}): Promise<string | undefined> {
+	const { token, host } = config;
+	let domain;
+	for (let i = 0; i < MAX_DOMAIN_TRIES; i++) {
+		const candidate = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+		const available = await checkIsDomainAvailable({ domain: candidate, token, host });
+		if (available) {
+			domain = candidate;
+			break;
+		}
+	}
+	return domain;
+}

--- a/src/commands/repo-list.ts
+++ b/src/commands/repo-list.ts
@@ -1,0 +1,58 @@
+import { getHost, getToken } from "../auth";
+import { getProfile } from "../clients/user";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { UnknownRequestError } from "../lib/request";
+
+const config = {
+	name: "prismic repo list",
+	description: "List all Prismic repositories associated with your account.",
+	options: {
+		json: { type: "boolean", description: "Output as JSON" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { json } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+
+	let profile;
+	try {
+		profile = await getProfile({ token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to list repositories: ${message}`);
+		}
+		throw error;
+	}
+
+	const repos = profile.repositories;
+
+	if (json) {
+		console.info(
+			stringify(
+				repos.map((repo) => ({
+					domain: repo.domain,
+					name: repo.name ?? null,
+					role: repo.role ?? null,
+					url: `https://${repo.domain}.${host}/`,
+				})),
+			),
+		);
+		return;
+	}
+
+	if (repos.length === 0) {
+		console.info("No repositories found.");
+		return;
+	}
+
+	for (const repo of repos) {
+		const name = repo.name || "(no name)";
+		const role = repo.role ? `  ${repo.role}` : "";
+		console.info(`${repo.domain}  ${name}${role}`);
+	}
+});

--- a/src/commands/repo-set-api-access.ts
+++ b/src/commands/repo-set-api-access.ts
@@ -1,0 +1,53 @@
+import { getHost, getToken } from "../auth";
+import { type RepositoryAccessLevel, setRepositoryAccess } from "../clients/wroom";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const VALID_LEVELS: RepositoryAccessLevel[] = ["private", "public", "open"];
+
+const config = {
+	name: "prismic repo set-api-access",
+	description: `
+		Set the Content API access level of a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	positionals: {
+		level: { description: `Access level (${VALID_LEVELS.join(", ")})` },
+	},
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [level] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	if (!level) {
+		throw new CommandError("Missing required argument: <level>");
+	}
+
+	if (!VALID_LEVELS.includes(level as RepositoryAccessLevel)) {
+		throw new CommandError(
+			`Invalid access level: ${level}. Must be one of: ${VALID_LEVELS.join(", ")}`,
+		);
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+
+	try {
+		await setRepositoryAccess(level as RepositoryAccessLevel, { repo, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to set repository access: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Repository access set to: ${level}`);
+});

--- a/src/commands/repo-set-name.ts
+++ b/src/commands/repo-set-name.ts
@@ -1,0 +1,46 @@
+import { getHost, getToken } from "../auth";
+import { setRepositoryName } from "../clients/wroom";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic repo set-name",
+	description: `
+		Set the display name of a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	positionals: {
+		name: { description: "Display name for the repository" },
+	},
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [displayName] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	if (!displayName) {
+		throw new CommandError("Missing required argument: <name>");
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+
+	let confirmedName;
+	try {
+		confirmedName = await setRepositoryName(displayName, { repo, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to set repository name: ${message}`);
+		}
+		throw error;
+	}
+
+	console.info(`Repository name set to: ${confirmedName}`);
+});

--- a/src/commands/repo-view.ts
+++ b/src/commands/repo-view.ts
@@ -1,0 +1,74 @@
+import { getHost, getToken } from "../auth";
+import { openBrowser } from "../lib/browser";
+import { getProfile } from "../clients/user";
+import { getRepositoryAccess } from "../clients/wroom";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic repo view",
+	description: `
+		View details of a Prismic repository.
+
+		By default, this command reads the repository from prismic.config.json at the
+		project root.
+	`,
+	options: {
+		web: { type: "boolean", short: "w", description: "Open repository in browser" },
+		json: { type: "boolean", description: "Output as JSON" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { repo = await getRepositoryName(), web, json } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+	const url = `https://${repo}.${host}/`;
+
+	if (web) {
+		openBrowser(new URL(url));
+		console.info(`Opening ${url}`);
+		return;
+	}
+
+	let profile;
+	let access;
+	try {
+		[profile, access] = await Promise.all([
+			getProfile({ token, host }),
+			getRepositoryAccess({ repo, token, host }),
+		]);
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to fetch repository details: ${message}`);
+		}
+		throw error;
+	}
+
+	const repoData = profile.repositories.find((r) => r.domain === repo);
+	if (!repoData) {
+		throw new CommandError(`Repository not found: ${repo}`);
+	}
+
+	if (json) {
+		console.info(
+			stringify({
+				domain: repoData.domain,
+				name: repoData.name ?? null,
+				url,
+				apiAccess: access,
+			}),
+		);
+		return;
+	}
+
+	const name = repoData.name || "(no name)";
+	console.info(`Name: ${name}`);
+	console.info(`URL: ${url}`);
+	console.info(`Content API: ${access}`);
+});

--- a/src/commands/repo.ts
+++ b/src/commands/repo.ts
@@ -1,0 +1,33 @@
+import { createCommandRouter } from "../lib/command";
+import repoCreate from "./repo-create";
+import repoList from "./repo-list";
+import repoSetApiAccess from "./repo-set-api-access";
+import repoSetName from "./repo-set-name";
+import repoView from "./repo-view";
+
+export default createCommandRouter({
+	name: "prismic repo",
+	description: "Manage Prismic repositories.",
+	commands: {
+		create: {
+			handler: repoCreate,
+			description: "Create a new repository",
+		},
+		list: {
+			handler: repoList,
+			description: "List repositories",
+		},
+		view: {
+			handler: repoView,
+			description: "View repository details",
+		},
+		"set-name": {
+			handler: repoSetName,
+			description: "Set repository display name",
+		},
+		"set-api-access": {
+			handler: repoSetApiAccess,
+			description: "Set Content API access level",
+		},
+	},
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import locale from "./commands/locale";
 import login from "./commands/login";
 import logout from "./commands/logout";
 import preview from "./commands/preview";
+import repo from "./commands/repo";
 import sync from "./commands/sync";
 import token from "./commands/token";
 import webhook from "./commands/webhook";
@@ -57,6 +58,10 @@ const router = createCommandRouter({
 		locale: {
 			handler: locale,
 			description: "Manage locales",
+		},
+		repo: {
+			handler: repo,
+			description: "Manage repositories",
 		},
 		preview: {
 			handler: preview,

--- a/test/it.ts
+++ b/test/it.ts
@@ -20,6 +20,7 @@ export type Fixtures = {
 	login: () => Promise<{ token: string; email: string }>;
 	logout: () => Promise<void>;
 	token: string;
+	password: string;
 	repo: string;
 };
 
@@ -106,6 +107,10 @@ export const it = test.extend<Fixtures>({
 		for (const proc of procs) {
 			if (proc.exitCode === undefined) proc.kill();
 		}
+	},
+	// oxlint-disable-next-line no-empty-pattern
+	password: async ({}, use) => {
+		await use(process.env.E2E_PRISMIC_PASSWORD!);
 	},
 	// oxlint-disable-next-line no-empty-pattern
 	repo: async ({}, use) => {

--- a/test/preview-set-simulator.test.ts
+++ b/test/preview-set-simulator.test.ts
@@ -22,7 +22,7 @@ it.sequential("sets simulator URL", async ({ expect, prismic, repo, token, host 
 	expect(stdout).toContain(`Simulator URL set: ${simulatorUrl}`);
 
 	const repository = await getRepository({ repo, token, host });
-	expect(repository.simulator_url).toBe(simulatorUrl);
+	expect(repository.simulatorUrl).toBe(simulatorUrl);
 });
 
 // Must be sequential because the repo only has one simulator URL.

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -325,12 +325,27 @@ export async function deleteWriteToken(tokenValue: string, config: RepoConfig): 
 		throw new Error(`Failed to delete write token: ${res.status} ${await res.text()}`);
 }
 
-export async function getRepository(config: RepoConfig): Promise<{ simulator_url?: string }> {
+export async function getRepository(
+	config: RepoConfig,
+): Promise<{ name: string; framework: string; simulatorUrl?: string }> {
 	const host = config.host ?? DEFAULT_HOST;
-	const url = new URL("core/repository", `https://${config.repo}.${host}/`);
+	const url = new URL("repository/", `https://api.internal.${host}/`);
+	url.searchParams.set("repository", config.repo);
 	const res = await fetch(url, {
-		headers: { Cookie: `prismic-auth=${config.token}` },
+		headers: { Authorization: `Bearer ${config.token}` },
 	});
 	if (!res.ok) throw new Error(`Failed to get repository: ${res.status} ${await res.text()}`);
 	return await res.json();
+}
+
+export async function getRepositoryAccess(config: RepoConfig): Promise<string> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("syncState", `https://${config.repo}.${host}/`);
+	const res = await fetch(url, {
+		headers: { Cookie: `prismic-auth=${config.token}` },
+	});
+	if (!res.ok)
+		throw new Error(`Failed to get repository access: ${res.status} ${await res.text()}`);
+	const data = await res.json();
+	return data.repository.api_access;
 }

--- a/test/repo-create.test.ts
+++ b/test/repo-create.test.ts
@@ -1,0 +1,39 @@
+import { onTestFinished } from "vitest";
+
+import { it } from "./it";
+import { deleteRepository, getRepository } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["create", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo create [options]");
+});
+
+it("creates a repository", async ({ expect, prismic, token, host, password }) => {
+	const { stdout, exitCode } = await prismic("repo", ["create"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Repository created:");
+
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	onTestFinished(() => deleteRepository(domain!, { token, password, host }));
+
+	const repository = await getRepository({ repo: domain!, token, host });
+	expect(repository).toBeDefined();
+});
+
+it("creates a repository with a name", async ({ expect, prismic, token, host, password }) => {
+	const name = `Test ${crypto.randomUUID().slice(0, 8)}`;
+	const { stdout, exitCode } = await prismic("repo", ["create", "--name", name]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Repository created:");
+
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	onTestFinished(() => deleteRepository(domain!, { token, password, host }));
+
+	const repository = await getRepository({ repo: domain!, token, host });
+	expect(repository.name).toBe(name);
+});

--- a/test/repo-list.test.ts
+++ b/test/repo-list.test.ts
@@ -1,0 +1,22 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["list", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo list [options]");
+});
+
+it("lists repositories", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("repo", ["list"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+});
+
+it("lists repositories as JSON", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("repo", ["list", "--json"]);
+	expect(exitCode).toBe(0);
+	const parsed = JSON.parse(stdout);
+	expect(parsed).toEqual(
+		expect.arrayContaining([expect.objectContaining({ domain: repo })]),
+	);
+});

--- a/test/repo-set-api-access.test.ts
+++ b/test/repo-set-api-access.test.ts
@@ -1,0 +1,16 @@
+import { it } from "./it";
+import { getRepositoryAccess } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["set-api-access", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo set-api-access <level> [options]");
+});
+
+it("sets the repository API access level", async ({ expect, prismic, repo, token, host }) => {
+	const { exitCode } = await prismic("repo", ["set-api-access", "open"]);
+	expect(exitCode).toBe(0);
+
+	const access = await getRepositoryAccess({ repo, token, host });
+	expect(access).toBe("open");
+});

--- a/test/repo-set-name.test.ts
+++ b/test/repo-set-name.test.ts
@@ -1,0 +1,18 @@
+import { it } from "./it";
+import { getRepository } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["set-name", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo set-name <name> [options]");
+});
+
+it("sets the repository display name", async ({ expect, prismic, repo, token, host }) => {
+	const name = `Test ${crypto.randomUUID().slice(0, 8)}`;
+	const { stdout, exitCode } = await prismic("repo", ["set-name", name]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Repository name set to:");
+
+	const repository = await getRepository({ repo, token, host });
+	expect(repository.name).toBe(name);
+});

--- a/test/repo-view.test.ts
+++ b/test/repo-view.test.ts
@@ -1,0 +1,26 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["view", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo view [options]");
+});
+
+it("views repository details", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("repo", ["view"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+});
+
+it("views repository details as JSON", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("repo", ["view", "--json"]);
+	expect(exitCode).toBe(0);
+	const parsed = JSON.parse(stdout);
+	expect(parsed).toEqual(
+		expect.objectContaining({
+			domain: repo,
+			url: expect.stringContaining(repo),
+			apiAccess: expect.any(String),
+		}),
+	);
+});

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo <command> [options]");
+});
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("repo", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic repo <command> [options]");
+});


### PR DESCRIPTION
Resolves: #16

### Description

Re-enable repository management commands (`repo create`, `repo list`, `repo view`, `repo set-name`, `repo set-api-access`) so the CLI can manage Prismic repositories against the live APIs.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI flows that create repositories and mutate repository settings via live APIs, so failures or incorrect parameters could impact real user projects despite relatively small code changes.
> 
> **Overview**
> Adds a new `prismic repo` command group to the CLI with subcommands to **create**, **list**, and **view** repositories, plus update operations to set a repository’s display name and Content API access level.
> 
> Extends API clients to support repository creation/domain-availability checks and reading/updating repository metadata (API access + name), and updates profile parsing to include repository `role`. E2E tests are expanded to cover the new commands, and test helpers are updated (including repository fetch and simulator URL field naming) to align with current live endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c72552a2b602d5754b789d2cb41c59f9f659c19d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->