### PR TITLE
feat: support document API endpoint for non-default hosts

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url";
 import * as z from "zod/mini";
 
 import { refreshToken as baseRefreshToken } from "./clients/auth";
-import { env } from "./env";
+import { DEFAULT_PRISMIC_HOST, env } from "./env";
 import { exists } from "./lib/file";
 import { stringify } from "./lib/json";
 import { appendTrailingSlash } from "./lib/url";
@@ -14,7 +14,6 @@ const AUTH_FILE_PATH = new URL(".prismic", appendTrailingSlash(pathToFileURL(hom
 const LOGIN_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
 const PREFERRED_PORT = 5555;
 const LOGIN_SOURCE = "prismic-cli";
-const DEFAULT_PRISMIC_HOST = "prismic.io";
 
 const AuthFileSchema = z.object({
 	token: z.optional(z.string().check(z.minLength(1))),

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ import {
 	readLegacySliceMachineConfig,
 	UnknownProjectRoot,
 } from "../config";
+import { DEFAULT_PRISMIC_HOST } from "../env";
 import { openBrowser } from "../lib/browser";
 import { generateAndWriteTypes } from "../lib/codegen";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
@@ -108,8 +109,11 @@ export default createCommand(config, async ({ values }) => {
 
 	// Create prismic.config.json
 	try {
+		const documentAPIEndpoint =
+			host !== DEFAULT_PRISMIC_HOST ? `https://${repo}.cdn.${host}/api/v2/` : undefined;
 		await createConfig({
 			repositoryName: repo,
+			documentAPIEndpoint,
 			libraries: legacySliceMachineConfig?.libraries,
 			routes: [],
 		});

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ export type Route = z.infer<typeof RouteSchema>;
 
 const ConfigSchema = z.object({
 	repositoryName: z.string(),
+	documentAPIEndpoint: z.optional(z.url()),
 	libraries: z.optional(z.array(z.string())),
 	routes: z.optional(z.array(RouteSchema)),
 });

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,6 +3,8 @@ import * as z from "zod/mini";
 const DEFAULT_PRISMIC_SENTRY_DSN =
 	"https://e1886b1775bd397cd1afc60bfd2ebfc8@o146123.ingest.us.sentry.io/4510445143588864";
 
+export const DEFAULT_PRISMIC_HOST = "prismic.io";
+
 const Env = z.object({
 	MODE: z.string(),
 	DEV: z.stringbool(),


### PR DESCRIPTION
Resolves: #70

### Description

When using a non-default Prismic host (e.g. not `prismic.io`), the CLI now writes a `documentAPIEndpoint` URL to `prismic.config.json` during `init`. This lets downstream tools know where to fetch content from when the repository isn't on the default host.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the generated `prismic.config.json` schema/output and could affect downstream consumers expecting the previous shape, but the behavior is gated to non-default hosts and is additive.
> 
> **Overview**
> `prismic init` now writes a `documentAPIEndpoint` to `prismic.config.json` when the CLI is configured to use a non-default host, pointing at `https://{repo}.cdn.{host}/api/v2/`.
> 
> The config schema is updated to accept this new optional `documentAPIEndpoint` field, and `DEFAULT_PRISMIC_HOST` is centralized in `env.ts` for reuse (including `auth.ts`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 430169d18207aeb95c600efc4e6d5958ccda50b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->