### PR TITLE
refactor: support `required` property for command positionals and options

### DIFF
--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		code: { description: "Locale code (e.g. fr-fr, es-es)" },
+		code: { description: "Locale code (e.g. fr-fr, es-es)", required: true },
 	},
 	options: {
 		master: { type: "boolean", description: "Set as the master locale" },
@@ -25,10 +25,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
 	const { repo = await getRepositoryName(), master = false, name } = values;
-
-	if (!code) {
-		throw new CommandError("Missing required argument: <code>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		code: { description: "Locale code (e.g. en-us, fr-fr)" },
+		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!code) {
-		throw new CommandError("Missing required argument: <code>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		code: { description: "Locale code (e.g. en-us, fr-fr)" },
+		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!code) {
-		throw new CommandError("Missing required argument: <code>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Preview URL (e.g. https://example.com/api/preview)" },
+		url: { description: "Preview URL (e.g. https://example.com/api/preview)", required: true },
 	},
 	options: {
 		name: { type: "string", short: "n", description: "Display name (defaults to hostname)" },
@@ -24,10 +24,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
 	const { repo = await getRepositoryName(), name } = values;
-
-	if (!previewUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	let parsed: URL;
 	try {

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Preview URL to remove" },
+		url: { description: "Preview URL to remove", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!previewUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -16,7 +16,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Simulator URL (e.g. https://example.com/slice-simulator)" },
+		url: { description: "Simulator URL (e.g. https://example.com/slice-simulator)", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -26,10 +26,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [urlArg] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!urlArg) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	let parsed: URL;
 	try {

--- a/src/commands/repo-set-api-access.ts
+++ b/src/commands/repo-set-api-access.ts
@@ -15,7 +15,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		level: { description: `Access level (${VALID_LEVELS.join(", ")})` },
+		level: { description: `Access level (${VALID_LEVELS.join(", ")})`, required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -25,10 +25,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [level] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!level) {
-		throw new CommandError("Missing required argument: <level>");
-	}
 
 	if (!VALID_LEVELS.includes(level as RepositoryAccessLevel)) {
 		throw new CommandError(

--- a/src/commands/repo-set-name.ts
+++ b/src/commands/repo-set-name.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		name: { description: "Display name for the repository" },
+		name: { description: "Display name for the repository", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [displayName] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!displayName) {
-		throw new CommandError("Missing required argument: <name>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -17,7 +17,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		token: { description: "Token value" },
+		token: { description: "Token value", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -27,10 +27,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [tokenValue] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!tokenValue) {
-		throw new CommandError("Missing required argument: <token>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL to receive events" },
+		url: { description: "Webhook URL to receive events", required: true },
 	},
 	options: {
 		name: { type: "string", short: "n", description: "Webhook name" },
@@ -43,10 +43,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName(), name, secret, trigger = [] } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	// Validate triggers
 	for (const t of trigger) {

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL" },
+		url: { description: "Webhook URL", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL" },
+		url: { description: "Webhook URL", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -13,7 +13,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL" },
+		url: { description: "Webhook URL", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -23,10 +23,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -13,14 +13,15 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL" },
+		url: { description: "Webhook URL", required: true },
 	},
 	options: {
 		trigger: {
 			type: "string",
 			multiple: true,
 			short: "t",
-			description: "Trigger events (can be repeated, at least one required)",
+			description: "Trigger events (can be repeated)",
+			required: true,
 		},
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
@@ -39,14 +40,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName(), trigger = [] } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
-
-	if (trigger.length === 0) {
-		throw new CommandError("Missing required option: --trigger");
-	}
 
 	// Validate triggers
 	for (const t of trigger) {

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -12,7 +12,7 @@ const config = {
 		project root.
 	`,
 	positionals: {
-		url: { description: "Webhook URL" },
+		url: { description: "Webhook URL", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -22,10 +22,6 @@ const config = {
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
 	const { repo = await getRepositoryName() } = values;
-
-	if (!webhookUrl) {
-		throw new CommandError("Missing required argument: <url>");
-	}
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -8,8 +8,8 @@ export type CommandConfig = {
 	name: string;
 	description: string;
 	sections?: Record<string, string>;
-	positionals?: Record<string, { description: string }>;
-	options?: Record<string, ParseArgsOptionDescriptor & { description: string }>;
+	positionals?: Record<string, { description: string; required?: boolean }>;
+	options?: Record<string, ParseArgsOptionDescriptor & { description: string; required?: boolean }>;
 };
 
 type CommandHandlerArgs<T extends CommandConfig> = ReturnType<
@@ -21,7 +21,7 @@ export function createCommand<T extends CommandConfig>(
 	handler: (args: CommandHandlerArgs<T>) => Promise<void>,
 ): () => Promise<void> {
 	return async function () {
-		const { positionals = {}, options } = config;
+		const { positionals = {}, options = {} } = config;
 
 		const depth = config.name.split(" ").length;
 		const args = process.argv.slice(1 + depth);
@@ -40,6 +40,18 @@ export function createCommand<T extends CommandConfig>(
 		if (result.values.help) {
 			console.info(buildCommandHelp(config));
 			return;
+		}
+
+		for (const [index, [name, config]] of Object.entries(positionals).entries()) {
+			if (config.required && !result.positionals[index]) {
+				throw new CommandError(`Missing required argument: <${name}>`);
+			}
+		}
+
+		for (const [name, config] of Object.entries(options)) {
+			if (config.required && !(name in result.values)) {
+				throw new CommandError(`Missing required option: --${name}`);
+			}
 		}
 
 		await handler(result as CommandHandlerArgs<T>);
@@ -71,7 +83,8 @@ function buildCommandHelp(config: CommandConfig): string {
 		for (const positionalName in positionals) {
 			const formattedName = `<${positionalName}>`;
 			const paddedName = formattedName.padEnd(maxNameLength);
-			const description = positionals[positionalName].description;
+			const positional = positionals[positionalName];
+			const description = positional.description + (positional.required ? " (required)" : "");
 			lines.push(`  ${paddedName}   ${description}`);
 		}
 	}
@@ -86,7 +99,8 @@ function buildCommandHelp(config: CommandConfig): string {
 			const shortPart = option.short ? `-${option.short}, ` : "    ";
 			const typeSuffix = option.type === "string" ? " string" : "";
 			const left = `${shortPart}--${optionName}${typeSuffix}`;
-			optionEntries.push({ left, description: option.description });
+			const description = option.description + (option.required ? " (required)" : "");
+			optionEntries.push({ left, description });
 		}
 	}
 	optionEntries.push({ left: "-h, --help", description: "Show help for command" });


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

Commands that require a positional argument or option currently validate this manually with repetitive `if (!x) throw CommandError(...)` blocks. This adds a `required` property to `createCommand`'s positional and option configs so the framework handles validation automatically, removing boilerplate from 15 command files.

Help output now shows `(required)` next to required arguments and options.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes required-argument/option validation in `createCommand`, which can change CLI behavior and error conditions across multiple commands if configs are mis-specified.
> 
> **Overview**
> Adds first-class `required` support to the command framework (`src/lib/command.ts`) for both positional arguments and options, enforcing missing-arg errors automatically and annotating help output with "(required)".
> 
> Updates a set of CLI commands (locales, previews, repo settings, tokens, webhooks) to mark their previously-manual required inputs as `required: true` and removes duplicated `if (!arg) throw` checks, including making `webhook set-triggers` require `--trigger` via config rather than bespoke validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 383cd3485701251ba9a35abcb44e14bc98938554. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->