### PR TITLE
refactor: inline adapter helpers, improve command types, and extract test builders

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -105,14 +105,18 @@ export abstract class Adapter {
 
 	async createSlice(model: SharedSlice, library?: URL): Promise<void> {
 		library ??= await this.getDefaultSliceLibrary();
-		await upsertSliceModel(model, library);
+		const sliceDirectoryName = pascalCase(model.name);
+		const sliceDirectory = new URL(sliceDirectoryName, appendTrailingSlash(library));
+		const modelPath = new URL("model.json", appendTrailingSlash(sliceDirectory));
+		await writeFileRecursive(modelPath, stringify(model));
 		await this.createSliceIndexFile(library);
 		await this.onSliceCreated(model, library);
 	}
 
 	async updateSlice(model: SharedSlice): Promise<void> {
 		const slice = await this.getSlice(model.id);
-		await upsertSliceModel(model, slice.library);
+		const modelPath = new URL("model.json", appendTrailingSlash(slice.directory));
+		await writeFileRecursive(modelPath, stringify(model));
 		await this.onSliceUpdated(model);
 	}
 
@@ -153,13 +157,18 @@ export abstract class Adapter {
 	}
 
 	async createCustomType(model: CustomType): Promise<void> {
-		await upsertCustomTypeModel(model);
+		const projectRoot = await findProjectRoot();
+		const customTypesDirectory = new URL("customtypes/", projectRoot);
+		const modelPath = new URL(`${model.id}/index.json`, customTypesDirectory);
+		await writeFileRecursive(modelPath, stringify(model));
 		if (model.format === "page") await addRoute(model);
 		await this.onCustomTypeCreated(model);
 	}
 
 	async updateCustomType(model: CustomType): Promise<void> {
-		await upsertCustomTypeModel(model);
+		const customType = await this.getCustomType(model.id);
+		const modelPath = new URL("index.json", appendTrailingSlash(customType.directory));
+		await writeFileRecursive(modelPath, stringify(model));
 		await updateRoute(model);
 		await this.onCustomTypeUpdated(model);
 	}
@@ -189,18 +198,4 @@ export abstract class Adapter {
 		await writeFileRecursive(output, types);
 		return output;
 	}
-}
-
-async function upsertSliceModel(model: SharedSlice, library: URL): Promise<void> {
-	const sliceDirectoryName = pascalCase(model.name);
-	const sliceDirectory = new URL(sliceDirectoryName, appendTrailingSlash(library));
-	const modelPath = new URL("model.json", appendTrailingSlash(sliceDirectory));
-	await writeFileRecursive(modelPath, stringify(model));
-}
-
-async function upsertCustomTypeModel(model: CustomType): Promise<void> {
-	const projectRoot = await findProjectRoot();
-	const customTypesDirectory = new URL("customtypes/", projectRoot);
-	const modelPath = new URL(`${model.id}/index.json`, customTypesDirectory);
-	await writeFileRecursive(modelPath, stringify(model));
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -12,9 +12,21 @@ export type CommandConfig = {
 	options?: Record<string, ParseArgsOptionDescriptor & { description: string; required?: boolean }>;
 };
 
-type CommandHandlerArgs<T extends CommandConfig> = ReturnType<
+type CommandHandlerArgs<T extends CommandConfig> = ParseArgsReturnType<T> & {
+	values: ParseArgsRequiredValues<T>;
+};
+
+type ParseArgsReturnType<T extends CommandConfig> = ReturnType<
 	typeof parseArgs<T & { allowPositionals: T["positionals"] extends undefined ? false : true }>
 >;
+
+type ParseArgsRequiredValues<T extends CommandConfig> = {
+	[P in keyof T["options"] as NonNullable<NonNullable<T["options"]>[P]>["required"] extends true
+		? P
+		: never]: P extends keyof ParseArgsReturnType<T>["values"]
+		? NonNullable<ParseArgsReturnType<T>["values"][P]>
+		: never;
+};
 
 export function createCommand<T extends CommandConfig>(
 	config: T,

--- a/test/gen-types.test.ts
+++ b/test/gen-types.test.ts
@@ -1,8 +1,6 @@
-import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-
 import { mkdir, writeFile } from "node:fs/promises";
 
-import { it } from "./it";
+import { buildCustomType, buildSlice, it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("gen", ["types", "--help"]);
@@ -37,33 +35,3 @@ it("generates types with no models", async ({ expect, project, prismic }) => {
 
 	await expect(project).toHaveFile("prismicio-types.d.ts");
 });
-
-function buildCustomType(): CustomType {
-	const id = crypto.randomUUID().split("-")[0];
-	return {
-		id: `type-T${id}`,
-		label: `TypeT${id}`,
-		repeatable: true,
-		status: true,
-		json: {},
-	};
-}
-
-function buildSlice(): SharedSlice {
-	const id = crypto.randomUUID().split("-")[0];
-	return {
-		id: `slice-S${id}`,
-		type: "SharedSlice",
-		name: `SliceS${id}`,
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-			},
-		],
-	};
-}

--- a/test/it.ts
+++ b/test/it.ts
@@ -1,3 +1,4 @@
+import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import type { Result } from "tinyexec";
 
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
@@ -123,4 +124,36 @@ export function captureOutput(proc: Result): () => string {
 	proc.process?.stdout?.on("data", (c: Buffer) => (output += c.toString()));
 	proc.process?.stderr?.on("data", (c: Buffer) => (output += c.toString()));
 	return () => output;
+}
+
+export function buildCustomType(overrides?: Partial<CustomType>): CustomType {
+	const id = crypto.randomUUID().split("-")[0];
+	return {
+		id: `type-T${id}`,
+		label: `TypeT${id}`,
+		repeatable: true,
+		status: true,
+		json: { Main: {} },
+		...overrides,
+	};
+}
+
+export function buildSlice(overrides?: Partial<SharedSlice>): SharedSlice {
+	const id = crypto.randomUUID().split("-")[0];
+	return {
+		id: `slice-S${id}`,
+		type: "SharedSlice",
+		name: `SliceS${id}`,
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+			},
+		],
+		...overrides,
+	};
 }

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,8 +1,6 @@
-import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-
 import { writeFile, mkdir } from "node:fs/promises";
 
-import { captureOutput, it } from "./it";
+import { buildCustomType, buildSlice, captureOutput, it } from "./it";
 import { deleteCustomType, deleteSlice, insertCustomType, insertSlice } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
@@ -225,34 +223,3 @@ it("does not overwrite existing page file", async ({
 		contains: originalContent,
 	});
 });
-
-function buildCustomType(overrides?: Partial<CustomType>): CustomType {
-	const id = crypto.randomUUID().split("-")[0];
-	return {
-		id: `type-T${id}`,
-		label: `TypeT${id}`,
-		repeatable: true,
-		status: true,
-		json: {},
-		...overrides,
-	};
-}
-
-function buildSlice(): SharedSlice {
-	const id = crypto.randomUUID().split("-")[0];
-	return {
-		id: `slice-S${id}`,
-		type: "SharedSlice",
-		name: `SliceS${id}`,
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-			},
-		],
-	};
-}


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

- **Adapter**: Inline `upsertSliceModel` and `upsertCustomTypeModel` into their call sites, removing unnecessary indirection.
- **Command types**: Add `ParseArgsRequiredValues<T>` so command handlers get non-nullable types for options marked `required: true`.
- **Test builders**: Consolidate duplicate `buildCustomType()` and `buildSlice()` helpers into `test/it.ts` as shared utilities.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor with minor TypeScript type-level changes to CLI command handler args; runtime behavior is effectively unchanged aside from writing model JSON paths directly at call sites.
> 
> **Overview**
> Refactors adapter model persistence by inlining slice/custom type model writes into `create*`/`update*` methods and removing the `upsertSliceModel`/`upsertCustomTypeModel` helpers.
> 
> Improves CLI typing by extending command handler args so `values` includes non-nullable entries for options marked `required: true`.
> 
> Deduplicates test utilities by moving `buildCustomType`/`buildSlice` into shared `test/it.ts` and updating affected tests to import them.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffb760a8351f12385cf3a28d9eb31485b620f60c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->