### PR TITLE
feat: add `type edit` command

### DIFF
--- a/src/commands/type-edit.ts
+++ b/src/commands/type-edit.ts
@@ -1,0 +1,64 @@
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic type edit",
+	description: "Edit a content type.",
+	positionals: {
+		name: { description: "Name of the content type", required: true },
+	},
+	options: {
+		name: { type: "string", short: "n", description: "New name for the type" },
+		format: { type: "string", short: "f", description: 'Type format: "custom" or "page"' },
+		repeatable: { type: "boolean", description: "Allow multiple documents of this type" },
+		single: { type: "boolean", short: "s", description: "Restrict to a single document" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [currentName] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	if ("repeatable" in values && "single" in values) {
+		throw new CommandError("Cannot use both --repeatable and --single");
+	}
+
+	if ("format" in values && values.format !== "custom" && values.format !== "page") {
+		throw new CommandError(`Invalid format: "${values.format}". Use "custom" or "page".`);
+	}
+
+	const adapter = await getAdapter();
+	const token = await getToken();
+	const host = await getHost();
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const type = customTypes.find((ct) => ct.label === currentName);
+
+	if (!type) {
+		throw new CommandError(`Type not found: ${currentName}`);
+	}
+
+	if ("name" in values) type.label = values.name;
+	if ("format" in values) type.format = values.format as "custom" | "page";
+	if ("repeatable" in values) type.repeatable = true;
+	if ("single" in values) type.repeatable = false;
+
+	try {
+		await updateCustomType(type, { repo, host, token });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to update type: ${message}`);
+		}
+		throw error;
+	}
+
+	await adapter.updateCustomType(type);
+	await adapter.generateTypes();
+
+	console.info(`Type updated: "${type.label}" (id: ${type.id})`);
+});

--- a/src/commands/type.ts
+++ b/src/commands/type.ts
@@ -1,5 +1,6 @@
 import { createCommandRouter } from "../lib/command";
 import typeCreate from "./type-create";
+import typeEdit from "./type-edit";
 import typeList from "./type-list";
 import typeRemove from "./type-remove";
 import typeView from "./type-view";
@@ -11,6 +12,10 @@ export default createCommandRouter({
 		create: {
 			handler: typeCreate,
 			description: "Create a new content type",
+		},
+		edit: {
+			handler: typeEdit,
+			description: "Edit a content type",
 		},
 		remove: {
 			handler: typeRemove,


### PR DESCRIPTION
Resolves: #91

### Description

Add `type edit` subcommand to update content type metadata after creation.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

```
$ prismic type edit --help
Edit a content type.

USAGE
  prismic type edit <name> [options]

ARGUMENTS
  <name>   Name of the content type (required)

OPTIONS
  -n, --name string     New name for the type
  -f, --format string   Type format: "custom" or "page"
      --repeatable      Allow multiple documents of this type
  -s, --single          Restrict to a single document
  -r, --repo string     Repository domain
  -h, --help            Show help for command
```

### How to QA [^1]

```bash
node --run build
./dist/index.mjs type edit "MyType" --name "NewName"
./dist/index.mjs type edit "MyType" --single
./dist/index.mjs type edit "MyType" --repeatable
./dist/index.mjs type edit "MyType" --format page
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI flow that mutates remote content type metadata via the Custom Types API; mistakes or edge cases could rename/flip repeatability unexpectedly in user repositories.
> 
> **Overview**
> Adds a new `prismic type edit` subcommand to update an existing content type’s metadata (label, `format`, and repeatability) by fetching types from the repository, validating flags, and calling `updateCustomType`.
> 
> After a successful API update, it syncs the local adapter state (`adapter.updateCustomType`) and regenerates types, and it wires the new handler into the `prismic type` command router.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf3e8548e677f60a52b99d94a8e1439967dee26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->