### PR TITLE
feat: add tab management commands

### DIFF
--- a/src/commands/type-add-tab.ts
+++ b/src/commands/type-add-tab.ts
@@ -1,0 +1,67 @@
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic type add-tab",
+	description: "Add a tab to a content type.",
+	positionals: {
+		name: { description: "Name of the tab", required: true },
+	},
+	options: {
+		to: { type: "string", required: true, description: "Name of the content type" },
+		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [name] = positionals;
+	const { to, "with-slice-zone": withSliceZone, repo = await getRepositoryName() } = values;
+
+	const adapter = await getAdapter();
+	const token = await getToken();
+	const host = await getHost();
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const type = customTypes.find((ct) => ct.label === to);
+
+	if (!type) {
+		throw new CommandError(`Type not found: ${to}`);
+	}
+
+	if (name in type.json) {
+		throw new CommandError(`Tab "${name}" already exists in "${to}".`);
+	}
+
+	type.json[name] = withSliceZone
+		? {
+				slices: {
+					type: "Slices",
+					fieldset: "Slice Zone",
+					config: { choices: {} },
+				},
+			}
+		: {};
+
+	try {
+		await updateCustomType(type, { repo, host, token });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to add tab: ${message}`);
+		}
+		throw error;
+	}
+
+	try {
+		await adapter.updateCustomType(type);
+	} catch {
+		await adapter.createCustomType(type);
+	}
+	await adapter.generateTypes();
+
+	console.info(`Added tab "${name}" to "${to}"`);
+});

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -40,6 +40,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 		throw new CommandError(`Tab "${currentName}" not found in "${typeName}".`);
 	}
 
+	if ("with-slice-zone" in values && "without-slice-zone" in values) {
+		throw new CommandError("Cannot use --with-slice-zone and --without-slice-zone together.");
+	}
+
 	if ("with-slice-zone" in values) {
 		const tab = type.json[currentName];
 		const hasSliceZone = Object.values(tab).some((field) => field.type === "Slices");

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -1,0 +1,109 @@
+import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
+
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic type edit-tab",
+	description: "Edit a tab of a content type.",
+	positionals: {
+		name: { description: "Current name of the tab", required: true },
+	},
+	options: {
+		in: { type: "string", required: true, description: "Name of the content type" },
+		name: { type: "string", short: "n", description: "New name for the tab" },
+		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
+		"without-slice-zone": { type: "boolean", description: "Remove the slice zone from the tab" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [currentName] = positionals;
+	const { in: typeName, repo = await getRepositoryName() } = values;
+
+	const adapter = await getAdapter();
+	const token = await getToken();
+	const host = await getHost();
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const type = customTypes.find((ct) => ct.label === typeName);
+
+	if (!type) {
+		throw new CommandError(`Type not found: ${typeName}`);
+	}
+
+	if (!(currentName in type.json)) {
+		throw new CommandError(`Tab "${currentName}" not found in "${typeName}".`);
+	}
+
+	if ("with-slice-zone" in values) {
+		const tab = type.json[currentName];
+		const hasSliceZone = Object.values(tab).some((field) => field.type === "Slices");
+
+		if (hasSliceZone) {
+			throw new CommandError(`Tab "${currentName}" already has a slice zone.`);
+		}
+
+		tab.slices = {
+			type: "Slices",
+			fieldset: "Slice Zone",
+			config: { choices: {} },
+		};
+	}
+
+	if ("without-slice-zone" in values) {
+		const tab = type.json[currentName];
+		const sliceZoneEntry = Object.entries(tab).find(([, field]) => field.type === "Slices");
+
+		if (!sliceZoneEntry) {
+			throw new CommandError(`Tab "${currentName}" does not have a slice zone.`);
+		}
+
+		const [sliceZoneId, sliceZoneField] = sliceZoneEntry;
+		const choices =
+			sliceZoneField.type === "Slices" ? (sliceZoneField.config?.choices ?? {}) : {};
+
+		if (Object.keys(choices).length > 0) {
+			throw new CommandError(
+				`Cannot remove slice zone from "${currentName}": disconnect all slices first.`,
+			);
+		}
+
+		delete tab[sliceZoneId];
+	}
+
+	if ("name" in values) {
+		if (values.name! in type.json) {
+			throw new CommandError(`Tab "${values.name}" already exists in "${typeName}".`);
+		}
+
+		const newJson: CustomType["json"] = {};
+		for (const [key, value] of Object.entries(type.json)) {
+			newJson[key === currentName ? values.name! : key] = value;
+		}
+		type.json = newJson;
+	}
+
+	try {
+		await updateCustomType(type, { repo, host, token });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to update tab: ${message}`);
+		}
+		throw error;
+	}
+
+	try {
+		await adapter.updateCustomType(type);
+	} catch {
+		await adapter.createCustomType(type);
+	}
+	await adapter.generateTypes();
+
+	console.info(`Tab updated: "${currentName}" in "${typeName}"`);
+});

--- a/src/commands/type-remove-tab.ts
+++ b/src/commands/type-remove-tab.ts
@@ -1,0 +1,62 @@
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { UnknownRequestError } from "../lib/request";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic type remove-tab",
+	description: "Remove a tab from a content type.",
+	positionals: {
+		name: { description: "Name of the tab", required: true },
+	},
+	options: {
+		from: { type: "string", required: true, description: "Name of the content type" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [name] = positionals;
+	const { from, repo = await getRepositoryName() } = values;
+
+	const adapter = await getAdapter();
+	const token = await getToken();
+	const host = await getHost();
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const type = customTypes.find((ct) => ct.label === from);
+
+	if (!type) {
+		throw new CommandError(`Type not found: ${from}`);
+	}
+
+	if (!(name in type.json)) {
+		throw new CommandError(`Tab "${name}" not found in "${from}".`);
+	}
+
+	if (Object.keys(type.json).length <= 1) {
+		throw new CommandError(`Cannot remove the last tab from "${from}".`);
+	}
+
+	delete type.json[name];
+
+	try {
+		await updateCustomType(type, { repo, host, token });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to remove tab: ${message}`);
+		}
+		throw error;
+	}
+
+	try {
+		await adapter.updateCustomType(type);
+	} catch {
+		await adapter.createCustomType(type);
+	}
+	await adapter.generateTypes();
+
+	console.info(`Removed tab "${name}" from "${from}"`);
+});

--- a/src/commands/type.ts
+++ b/src/commands/type.ts
@@ -1,8 +1,11 @@
 import { createCommandRouter } from "../lib/command";
+import typeAddTab from "./type-add-tab";
 import typeCreate from "./type-create";
 import typeEdit from "./type-edit";
+import typeEditTab from "./type-edit-tab";
 import typeList from "./type-list";
 import typeRemove from "./type-remove";
+import typeRemoveTab from "./type-remove-tab";
 import typeView from "./type-view";
 
 export default createCommandRouter({
@@ -28,6 +31,18 @@ export default createCommandRouter({
 		view: {
 			handler: typeView,
 			description: "View a content type",
+		},
+		"add-tab": {
+			handler: typeAddTab,
+			description: "Add a tab to a content type",
+		},
+		"edit-tab": {
+			handler: typeEditTab,
+			description: "Edit a tab of a content type",
+		},
+		"remove-tab": {
+			handler: typeRemoveTab,
+			description: "Remove a tab from a content type",
 		},
 	},
 });

--- a/test/type-add-tab.test.ts
+++ b/test/type-add-tab.test.ts
@@ -1,0 +1,52 @@
+import { buildCustomType, it } from "./it";
+import { getCustomTypes, insertCustomType } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("type", ["add-tab", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic type add-tab <name> [options]");
+});
+
+it("adds a tab to a type", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType();
+	await insertCustomType(customType, { repo, token, host });
+
+	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
+
+	const { stdout, exitCode } = await prismic("type", [
+		"add-tab",
+		tabName,
+		"--to",
+		customType.label!,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(updated?.json).toHaveProperty(tabName);
+	expect(updated?.json[tabName]).toEqual({});
+});
+
+it("adds a tab with a slice zone", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType();
+	await insertCustomType(customType, { repo, token, host });
+
+	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
+
+	const { stdout, exitCode } = await prismic("type", [
+		"add-tab",
+		tabName,
+		"--to",
+		customType.label!,
+		"--with-slice-zone",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	const tab = updated?.json[tabName];
+	expect(tab).toHaveProperty("slices");
+	expect(tab?.slices).toMatchObject({ type: "Slices" });
+});

--- a/test/type-edit-tab.test.ts
+++ b/test/type-edit-tab.test.ts
@@ -1,0 +1,80 @@
+import { buildCustomType, it } from "./it";
+import { getCustomTypes, insertCustomType } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("type", ["edit-tab", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic type edit-tab <name> [options]");
+});
+
+it("edits a tab name", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({ json: { Main: {}, OldName: {} } });
+	await insertCustomType(customType, { repo, token, host });
+
+	const newName = `Tab${crypto.randomUUID().split("-")[0]}`;
+
+	const { stdout, exitCode } = await prismic("type", [
+		"edit-tab",
+		"OldName",
+		"--in",
+		customType.label!,
+		"--name",
+		newName,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Tab updated: "OldName" in "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(updated?.json).not.toHaveProperty("OldName");
+	expect(updated?.json).toHaveProperty(newName);
+});
+
+it("adds a slice zone to a tab", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType();
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("type", [
+		"edit-tab",
+		"Main",
+		"--in",
+		customType.label!,
+		"--with-slice-zone",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Tab updated: "Main" in "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(updated?.json.Main).toHaveProperty("slices");
+	expect(updated?.json.Main.slices).toMatchObject({ type: "Slices" });
+});
+
+it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({
+		json: {
+			Main: {
+				slices: {
+					type: "Slices",
+					fieldset: "Slice Zone",
+					config: { choices: {} },
+				},
+			},
+		},
+	});
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("type", [
+		"edit-tab",
+		"Main",
+		"--in",
+		customType.label!,
+		"--without-slice-zone",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Tab updated: "Main" in "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(updated?.json.Main).not.toHaveProperty("slices");
+});

--- a/test/type-remove-tab.test.ts
+++ b/test/type-remove-tab.test.ts
@@ -1,0 +1,27 @@
+import { buildCustomType, it } from "./it";
+import { getCustomTypes, insertCustomType } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("type", ["remove-tab", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic type remove-tab <name> [options]");
+});
+
+it("removes a tab from a type", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({ json: { Main: {}, Extra: {} } });
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("type", [
+		"remove-tab",
+		"Extra",
+		"--from",
+		customType.label!,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Removed tab "Extra" from "${customType.label}"`);
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(updated?.json).not.toHaveProperty("Extra");
+	expect(updated?.json).toHaveProperty("Main");
+});


### PR DESCRIPTION
Resolves: #94

### Description

Add `type add-tab`, `type edit-tab`, and `type remove-tab` commands for managing tabs on content types.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```sh
prismic type add-tab "Content" --to "My Type" --with-slice-zone
prismic type edit-tab "Content" --in "My Type" --name "Body"
prismic type edit-tab "Body" --in "My Type" --without-slice-zone
prismic type remove-tab "Body" --from "My Type"
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI commands that mutate content type JSON (including slice zone fields) and push updates to Prismic plus local adapter generation, so mistakes could directly affect schemas in a repo. Scope is contained to new commands with coverage via integration tests.
> 
> **Overview**
> Adds three new `prismic type` subcommands: `add-tab`, `edit-tab`, and `remove-tab` to manage tabs within a content type’s `json`, including optional slice zone creation/removal and tab renaming.
> 
> Wires the new handlers into the `type` command router, ensures remote updates via `updateCustomType` with friendlier `UnknownRequestError` messaging, and updates local files/types via the adapter. Includes new tests covering `--help`, tab add/remove, renaming, and slice-zone toggling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9e01257a5154673266d7b3db28c9f905a85077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->