### PR TITLE
feat: rename `--in` flag to `--from-slice`/`--from-type`

### DIFF
--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -14,7 +14,7 @@ const config = {
 		name: { description: "Name of the variation", required: true },
 	},
 	options: {
-		in: { type: "string", required: true, description: "Name of the slice" },
+		"from-slice": { type: "string", required: true, description: "Name of the slice" },
 		name: { type: "string", short: "n", description: "New name for the variation" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
@@ -22,7 +22,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [currentName] = positionals;
-	const { in: sliceName, repo = await getRepositoryName() } = values;
+	const { "from-slice": sliceName, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -14,7 +14,7 @@ const config = {
 		name: { description: "Current name of the tab", required: true },
 	},
 	options: {
-		in: { type: "string", required: true, description: "Name of the content type" },
+		"from-type": { type: "string", required: true, description: "Name of the content type" },
 		name: { type: "string", short: "n", description: "New name for the tab" },
 		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
 		"without-slice-zone": { type: "boolean", description: "Remove the slice zone from the tab" },
@@ -24,7 +24,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [currentName] = positionals;
-	const { in: typeName, repo = await getRepositoryName() } = values;
+	const { "from-type": typeName, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -33,7 +33,7 @@ it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
 	const { stdout, exitCode } = await prismic("slice", [
 		"edit-variation",
 		variationName,
-		"--in",
+		"--from-slice",
 		slice.name,
 		"--name",
 		newName,

--- a/test/type-edit-tab.test.ts
+++ b/test/type-edit-tab.test.ts
@@ -16,7 +16,7 @@ it("edits a tab name", async ({ expect, prismic, repo, token, host }) => {
 	const { stdout, exitCode } = await prismic("type", [
 		"edit-tab",
 		"OldName",
-		"--in",
+		"--from-type",
 		customType.label!,
 		"--name",
 		newName,
@@ -37,7 +37,7 @@ it("adds a slice zone to a tab", async ({ expect, prismic, repo, token, host }) 
 	const { stdout, exitCode } = await prismic("type", [
 		"edit-tab",
 		"Main",
-		"--in",
+		"--from-type",
 		customType.label!,
 		"--with-slice-zone",
 	]);
@@ -67,7 +67,7 @@ it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, hos
 	const { stdout, exitCode } = await prismic("type", [
 		"edit-tab",
 		"Main",
-		"--in",
+		"--from-type",
 		customType.label!,
 		"--without-slice-zone",
 	]);


### PR DESCRIPTION
Resolves: #109

### Description

Renames the `--in` flag to `--from-slice` on `slice edit-variation` and `--from-type` on `type edit-tab` for consistency with other modeling commands.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```sh
npx prismic slice edit-variation --help   # should show --from-slice
npx prismic type edit-tab --help          # should show --from-type
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a user-facing CLI breaking change: scripts using `--in` will fail unless updated. The underlying slice/type update logic is unchanged, so functional risk is otherwise low.
> 
> **Overview**
> Renames the CLI option used to specify the parent model when editing: `slice edit-variation` now requires `--from-slice` and `type edit-tab` now requires `--from-type` instead of `--in`.
> 
> Updates command argument parsing to read the new option keys and adjusts the associated integration tests to invoke the commands with the renamed flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328ac8a9f6622481e732a8a3c57859e73f42bf23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->