### PR TITLE
feat: add `field view` command

### DIFF
--- a/src/commands/field-view.ts
+++ b/src/commands/field-view.ts
@@ -1,0 +1,56 @@
+import { capitalCase } from "change-case";
+
+import { getHost, getToken } from "../auth";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { resolveFieldContainer, resolveFieldTarget, SOURCE_OPTIONS } from "../models";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic field view",
+	description: "View details of a field in a slice or custom type.",
+	positionals: {
+		id: { description: "Field ID", required: true },
+	},
+	options: {
+		...SOURCE_OPTIONS,
+		json: { type: "boolean", description: "Output as JSON" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [id] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+	const [fields] = await resolveFieldContainer(id, values, { repo, token, host });
+	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
+
+	const field = targetFields[fieldId];
+	if (!field) {
+		throw new CommandError(`Field "${id}" does not exist.`);
+	}
+
+	if (values.json) {
+		console.info(stringify({ id: fieldId, ...field }));
+		return;
+	}
+
+	console.info(`Type: ${field.type}`);
+
+	if (field.config) {
+		for (const [key, value] of Object.entries(field.config)) {
+			if (value === undefined) continue;
+
+			if (key === "fields" && typeof value === "object" && value !== null) {
+				const ids = Object.keys(value).join(", ") || "(none)";
+				console.info(`Fields: ${ids}`);
+			} else if (Array.isArray(value)) {
+				console.info(`${capitalCase(key)}: ${value.join(", ")}`);
+			} else {
+				console.info(`${capitalCase(key)}: ${value}`);
+			}
+		}
+	}
+});

--- a/src/commands/field.ts
+++ b/src/commands/field.ts
@@ -3,6 +3,7 @@ import fieldAdd from "./field-add";
 import fieldEdit from "./field-edit";
 import fieldList from "./field-list";
 import fieldRemove from "./field-remove";
+import fieldView from "./field-view";
 
 export default createCommandRouter({
 	name: "prismic field",
@@ -23,6 +24,10 @@ export default createCommandRouter({
 		remove: {
 			handler: fieldRemove,
 			description: "Remove a field",
+		},
+		view: {
+			handler: fieldView,
+			description: "View details of a field",
 		},
 	},
 });

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -8,24 +8,11 @@ it("supports --help", async ({ expect, prismic }) => {
 });
 
 it("views a field in a slice", async ({ expect, prismic, repo, token, host }) => {
-	const slice = buildSlice({
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-				primary: {
-					title: {
-						type: "StructuredText",
-						config: { label: "Title", placeholder: "Enter title" },
-					},
-				},
-			},
-		],
-	});
+	const slice = buildSlice();
+	slice.variations[0].primary!.title = {
+		type: "StructuredText",
+		config: { label: "Title", placeholder: "Enter title" },
+	};
 	await insertSlice(slice, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -41,16 +28,11 @@ it("views a field in a slice", async ({ expect, prismic, repo, token, host }) =>
 });
 
 it("views a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
-	const customType = buildCustomType({
-		json: {
-			Main: {
-				count: {
-					type: "Number",
-					config: { label: "Count", placeholder: "Enter number", min: 0, max: 100 },
-				},
-			},
-		},
-	});
+	const customType = buildCustomType();
+	customType.json.Main.count = {
+		type: "Number",
+		config: { label: "Count", placeholder: "Enter number", min: 0, max: 100 },
+	};
 	await insertCustomType(customType, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -67,24 +49,11 @@ it("views a field in a custom type", async ({ expect, prismic, repo, token, host
 });
 
 it("outputs JSON with --json", async ({ expect, prismic, repo, token, host }) => {
-	const slice = buildSlice({
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-				primary: {
-					is_active: {
-						type: "Boolean",
-						config: { label: "Is Active", default_value: true },
-					},
-				},
-			},
-		],
-	});
+	const slice = buildSlice();
+	slice.variations[0].primary!.is_active = {
+		type: "Boolean",
+		config: { label: "Is Active", default_value: true },
+	};
 	await insertSlice(slice, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -1,0 +1,117 @@
+import { buildCustomType, buildSlice, it } from "./it";
+import { insertCustomType, insertSlice } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("field", ["view", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic field view <id> [options]");
+});
+
+it("views a field in a slice", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice({
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+				primary: {
+					title: {
+						type: "StructuredText",
+						config: { label: "Title", placeholder: "Enter title" },
+					},
+				},
+			},
+		],
+	});
+	await insertSlice(slice, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"view",
+		"title",
+		"--from-slice",
+		slice.name,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Type: StructuredText");
+	expect(stdout).toContain("Label: Title");
+	expect(stdout).toContain("Placeholder: Enter title");
+});
+
+it("views a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({
+		json: {
+			Main: {
+				count: {
+					type: "Number",
+					config: { label: "Count", placeholder: "Enter number", min: 0, max: 100 },
+				},
+			},
+		},
+	});
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"view",
+		"count",
+		"--from-type",
+		customType.label!,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Type: Number");
+	expect(stdout).toContain("Label: Count");
+	expect(stdout).toContain("Min: 0");
+	expect(stdout).toContain("Max: 100");
+});
+
+it("outputs JSON with --json", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice({
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+				primary: {
+					is_active: {
+						type: "Boolean",
+						config: { label: "Is Active", default_value: true },
+					},
+				},
+			},
+		],
+	});
+	await insertSlice(slice, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"view",
+		"is_active",
+		"--from-slice",
+		slice.name,
+		"--json",
+	]);
+	expect(exitCode).toBe(0);
+
+	const field = JSON.parse(stdout);
+	expect(field.id).toBe("is_active");
+	expect(field.type).toBe("Boolean");
+	expect(field.config.label).toBe("Is Active");
+});
+
+it("errors for non-existent field", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice();
+	await insertSlice(slice, { repo, token, host });
+
+	const { stderr, exitCode } = await prismic("field", [
+		"view",
+		"nonexistent",
+		"--from-slice",
+		slice.name,
+	]);
+	expect(exitCode).not.toBe(0);
+	expect(stderr).toContain("nonexistent");
+});


### PR DESCRIPTION
Resolves: #93

### Description

Add a `field view` command to inspect a single field's full configuration: type, label, placeholder, constraints, allowed types/options, and any other field-type-specific settings.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```sh
# View a field in a slice
npx prismic field view title --from-slice MySlice

# View a field in a custom type
npx prismic field view title --from-type "My Page"

# View with JSON output
npx prismic field view title --from-type "My Page" --json
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new read-only CLI subcommand and tests without modifying existing model update logic or API behavior.
> 
> **Overview**
> Adds a new `prismic field view` subcommand that fetches the target slice/custom type via existing `--from-slice`/`--from-type` resolution and prints the selected field’s type plus config values (or full JSON with `--json`), erroring when the field is missing.
> 
> Registers the command under `prismic field` and introduces coverage for help output, slice/type field viewing, JSON output, and missing-field errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20876afe9535d814be8f6f379bec5d7a7aa5c669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->