### PR TITLE
feat: add a consistent table formatter for tabular output

### DIFF
--- a/src/commands/docs-list.ts
+++ b/src/commands/docs-list.ts
@@ -2,6 +2,7 @@ import { getDocsIndex, getDocsPageIndex } from "../clients/docs";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { NotFoundRequestError, UnknownRequestError } from "../lib/request";
+import { formatTable } from "../lib/string";
 
 const config = {
 	name: "prismic docs list",
@@ -52,9 +53,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 			return;
 		}
 
-		for (const anchor of entry.anchors) {
-			console.info(`${path}#${anchor.slug}: ${anchor.excerpt}`);
-		}
+		const rows = entry.anchors.map((anchor) => [`${path}#${anchor.slug}`, anchor.excerpt]);
+		console.info(formatTable(rows));
 	} else {
 		let pages;
 		try {
@@ -79,9 +79,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 			return;
 		}
 
-		for (const page of pages) {
-			const description = page.description ? ` — ${page.description}` : "";
-			console.info(`${page.path}: ${page.title}${description}`);
-		}
+		const rows = pages.map((page) => [page.path, page.title, page.description ?? ""]);
+		console.info(formatTable(rows));
 	}
 });

--- a/src/commands/docs-list.ts
+++ b/src/commands/docs-list.ts
@@ -54,7 +54,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		}
 
 		const rows = entry.anchors.map((anchor) => [`${path}#${anchor.slug}`, anchor.excerpt]);
-		console.info(formatTable(rows));
+		console.info(formatTable(rows, { headers: ["PATH", "EXCERPT"] }));
 	} else {
 		let pages;
 		try {
@@ -80,6 +80,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 		}
 
 		const rows = pages.map((page) => [page.path, page.title, page.description ?? ""]);
-		console.info(formatTable(rows));
+		console.info(formatTable(rows, { headers: ["PATH", "TITLE", "DESCRIPTION"] }));
 	}
 });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getLocales } from "../clients/locale";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -36,8 +37,9 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const locale of locales) {
+	const rows = locales.map((locale) => {
 		const masterLabel = locale.isMaster ? " (master)" : "";
-		console.info(`${locale.id}  ${locale.label}${masterLabel}`);
-	}
+		return [locale.id, `${locale.label}${masterLabel}`];
+	});
+	console.info(formatTable(rows));
 });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -41,5 +41,5 @@ export default createCommand(config, async ({ values }) => {
 		const masterLabel = locale.isMaster ? " (master)" : "";
 		return [locale.id, `${locale.label}${masterLabel}`];
 	});
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["ID", "LABEL"] }));
 });

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getPreviews, getSimulatorUrl } from "../clients/core";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -44,9 +45,8 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const preview of previews) {
-		console.info(`${preview.url}  ${preview.label}`);
-	}
+	const rows = previews.map((preview) => [preview.url, preview.label]);
+	console.info(formatTable(rows));
 
 	if (simulatorUrl) {
 		console.info(`\nSimulator: ${simulatorUrl}`);

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -46,7 +46,7 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	const rows = previews.map((preview) => [preview.url, preview.label]);
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["URL", "LABEL"] }));
 
 	if (simulatorUrl) {
 		console.info(`\nSimulator: ${simulatorUrl}`);

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -47,7 +47,7 @@ export default createCommand(config, async ({ values }) => {
 
 	if (previews.length > 0) {
 		const rows = previews.map((preview) => [preview.url, preview.label]);
-		console.info(formatTable(rows, { headers: ["URL", "LABEL"] }));
+		console.info(formatTable(rows, { headers: ["URL", "NAME"] }));
 	}
 
 	if (simulatorUrl) {

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -45,10 +45,15 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	const rows = previews.map((preview) => [preview.url, preview.label]);
-	console.info(formatTable(rows, { headers: ["URL", "LABEL"] }));
+	if (previews.length > 0) {
+		const rows = previews.map((preview) => [preview.url, preview.label]);
+		console.info(formatTable(rows, { headers: ["URL", "LABEL"] }));
+	}
 
 	if (simulatorUrl) {
-		console.info(`\nSimulator: ${simulatorUrl}`);
+		if (previews.length > 0) {
+			console.info("");
+		}
+		console.info(`Simulator: ${simulatorUrl}`);
 	}
 });

--- a/src/commands/repo-list.ts
+++ b/src/commands/repo-list.ts
@@ -3,6 +3,7 @@ import { getProfile } from "../clients/user";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
+import { formatTable } from "../lib/string";
 
 const config = {
 	name: "prismic repo list",
@@ -50,9 +51,9 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const repo of repos) {
+	const rows = repos.map((repo) => {
 		const name = repo.name || "(no name)";
-		const role = repo.role ? `  ${repo.role}` : "";
-		console.info(`${repo.domain}  ${name}${role}`);
-	}
+		return [repo.domain, name, repo.role ?? ""];
+	});
+	console.info(formatTable(rows));
 });

--- a/src/commands/repo-list.ts
+++ b/src/commands/repo-list.ts
@@ -55,5 +55,5 @@ export default createCommand(config, async ({ values }) => {
 		const name = repo.name || "(no name)";
 		return [repo.domain, name, repo.role ?? ""];
 	});
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["DOMAIN", "NAME", "ROLE"] }));
 });

--- a/src/commands/slice-list.ts
+++ b/src/commands/slice-list.ts
@@ -32,5 +32,5 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	const rows = slices.map((slice) => [slice.name, slice.id]);
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["NAME", "ID"] }));
 });

--- a/src/commands/slice-list.ts
+++ b/src/commands/slice-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getSlices } from "../clients/custom-types";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -30,7 +31,6 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const slice of slices) {
-		console.info(`${slice.name} (id: ${slice.id})`);
-	}
+	const rows = slices.map((slice) => [slice.name, slice.id]);
+	console.info(formatTable(rows));
 });

--- a/src/commands/slice-view.ts
+++ b/src/commands/slice-view.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getSlices } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -44,12 +45,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 		if (entries.length === 0) {
 			console.info("  (no fields)");
 		} else {
-			for (const [id, field] of entries) {
+			const rows = entries.map(([id, field]) => {
 				const config = field.config as Record<string, unknown> | undefined;
 				const label = (config?.label as string) || "";
 				const placeholder = config?.placeholder ? `"${config.placeholder}"` : "";
-				console.info(`  ${[id, field.type, label, placeholder].filter(Boolean).join("  ")}`);
-			}
+				return [`  ${id}`, field.type, label, placeholder];
+			});
+			console.info(formatTable(rows));
 		}
 	}
 });

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getOAuthApps, getWriteTokens } from "../clients/wroom";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -46,9 +47,8 @@ export default createCommand(config, async ({ values }) => {
 
 	if (accessTokens.length > 0) {
 		console.info("ACCESS TOKENS");
-		for (const accessToken of accessTokens) {
-			console.info(`  ${accessToken.name}  ${accessToken.scope}  ${accessToken.token}  ${accessToken.createdAt}`);
-		}
+		const rows = accessTokens.map((t) => [`  ${t.name}`, t.scope, t.token, t.createdAt]);
+		console.info(formatTable(rows));
 	} else {
 		console.info("ACCESS TOKENS  (none)");
 	}
@@ -57,10 +57,11 @@ export default createCommand(config, async ({ values }) => {
 
 	if (writeTokens.length > 0) {
 		console.info("WRITE TOKENS");
-		for (const writeToken of writeTokens) {
-			const date = new Date(writeToken.timestamp * 1000).toISOString().split("T")[0];
-			console.info(`  ${writeToken.app_name}  ${writeToken.token}  ${date}`);
-		}
+		const rows = writeTokens.map((t) => {
+			const date = new Date(t.timestamp * 1000).toISOString().split("T")[0];
+			return [`  ${t.app_name}`, t.token, date];
+		});
+		console.info(formatTable(rows));
 	} else {
 		console.info("WRITE TOKENS  (none)");
 	}

--- a/src/commands/type-list.ts
+++ b/src/commands/type-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes } from "../clients/custom-types";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -31,8 +32,9 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const type of types) {
+	const rows = types.map((type) => {
 		const label = type.label || "(no name)";
-		console.info(`${label} (id: ${type.id}, format: ${type.format})`);
-	}
+		return [label, type.id, type.format ?? ""];
+	});
+	console.info(formatTable(rows));
 });

--- a/src/commands/type-list.ts
+++ b/src/commands/type-list.ts
@@ -36,5 +36,5 @@ export default createCommand(config, async ({ values }) => {
 		const label = type.label || "(no name)";
 		return [label, type.id, type.format ?? ""];
 	});
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["NAME", "ID", "FORMAT"] }));
 });

--- a/src/commands/type-view.ts
+++ b/src/commands/type-view.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -46,12 +47,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 		if (entries.length === 0) {
 			console.info("  (no fields)");
 		} else {
-			for (const [id, field] of entries) {
+			const rows = entries.map(([id, field]) => {
 				const config = field.config as Record<string, unknown> | undefined;
 				const label = (config?.label as string) || "";
 				const placeholder = config?.placeholder ? `"${config.placeholder}"` : "";
-				console.info(`  ${[id, field.type, label, placeholder].filter(Boolean).join("  ")}`);
-			}
+				return [`  ${id}`, field.type, label, placeholder];
+			});
+			console.info(formatTable(rows));
 		}
 	}
 });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -2,6 +2,7 @@ import { getHost, getToken } from "../auth";
 import { getWebhooks } from "../clients/wroom";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -35,9 +36,10 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	for (const webhook of webhooks) {
+	const rows = webhooks.map((webhook) => {
 		const status = webhook.config.active ? "enabled" : "disabled";
 		const name = webhook.config.name ? ` (${webhook.config.name})` : "";
-		console.info(`${webhook.config.url}${name}  [${status}]`);
-	}
+		return [`${webhook.config.url}${name}`, `[${status}]`];
+	});
+	console.info(formatTable(rows));
 });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -41,5 +41,5 @@ export default createCommand(config, async ({ values }) => {
 		const name = webhook.config.name ? ` (${webhook.config.name})` : "";
 		return [`${webhook.config.url}${name}`, `[${status}]`];
 	});
-	console.info(formatTable(rows));
+	console.info(formatTable(rows, { headers: ["URL", "STATUS"] }));
 });

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -2,7 +2,7 @@ import type { ParseArgsOptionDescriptor } from "node:util";
 
 import { parseArgs } from "node:util";
 
-import { dedent } from "./string";
+import { dedent, formatTable } from "./string";
 
 export type CommandConfig = {
 	name: string;
@@ -89,16 +89,13 @@ function buildCommandHelp(config: CommandConfig): string {
 	if (positionalNames.length > 0) {
 		lines.push("");
 		lines.push("ARGUMENTS");
-		const maxNameLength = Math.max(
-			...positionalNames.map((positionalName) => `<${positionalName}>`.length),
-		);
+		const rows: string[][] = [];
 		for (const positionalName in positionals) {
-			const formattedName = `<${positionalName}>`;
-			const paddedName = formattedName.padEnd(maxNameLength);
 			const positional = positionals[positionalName];
 			const description = positional.description + (positional.required ? " (required)" : "");
-			lines.push(`  ${paddedName}   ${description}`);
+			rows.push([`  <${positionalName}>`, description]);
 		}
+		lines.push(formatTable(rows));
 	}
 
 	lines.push("");
@@ -116,11 +113,8 @@ function buildCommandHelp(config: CommandConfig): string {
 		}
 	}
 	optionEntries.push({ left: "-h, --help", description: "Show help for command" });
-	const maxOptionLength = Math.max(...optionEntries.map((optionEntry) => optionEntry.left.length));
-	for (const optionEntry of optionEntries) {
-		const paddedLeft = optionEntry.left.padEnd(maxOptionLength);
-		lines.push(`  ${paddedLeft}   ${optionEntry.description}`);
-	}
+	const optionRows = optionEntries.map((entry) => [`  ${entry.left}`, entry.description]);
+	lines.push(formatTable(optionRows));
 
 	if (sections) {
 		for (const sectionName in sections) {
@@ -190,13 +184,8 @@ function buildRouterHelp(config: CreateCommandRouterConfig): string {
 
 	lines.push("");
 	lines.push("COMMANDS");
-	const commandNames = Object.keys(commands);
-	const maxNameLength = Math.max(...commandNames.map((commandName) => commandName.length));
-	for (const commandName of commandNames) {
-		const paddedName = commandName.padEnd(maxNameLength);
-		const description = commands[commandName].description;
-		lines.push(`  ${paddedName}   ${description}`);
-	}
+	const commandRows = Object.entries(commands).map(([name, cmd]) => [`  ${name}`, cmd.description]);
+	lines.push(formatTable(commandRows));
 
 	lines.push("");
 	lines.push("OPTIONS");

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,3 +1,20 @@
 import baseDedent from "dedent";
 
 export const dedent = baseDedent.withOptions({ alignValues: true });
+
+export function formatTable(rows: string[][], separator = "   "): string {
+	const columnWidths: number[] = [];
+	for (const row of rows) {
+		for (let i = 0; i < row.length; i++) {
+			columnWidths[i] = Math.max(columnWidths[i] ?? 0, row[i].length);
+		}
+	}
+	return rows
+		.map((row) =>
+			row
+				.map((cell, i) => (i < row.length - 1 ? cell.padEnd(columnWidths[i]) : cell))
+				.join(separator)
+				.trimEnd(),
+		)
+		.join("\n");
+}

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -2,19 +2,25 @@ import baseDedent from "dedent";
 
 export const dedent = baseDedent.withOptions({ alignValues: true });
 
-export function formatTable(rows: string[][], separator = "   "): string {
+export function formatTable(
+	rows: string[][],
+	config?: { headers?: string[]; separator?: string },
+): string {
+	const separator = config?.separator ?? "   ";
+	const allRows = config?.headers ? [config.headers, ...rows] : rows;
 	const columnWidths: number[] = [];
-	for (const row of rows) {
+	for (const row of allRows) {
 		for (let i = 0; i < row.length; i++) {
 			columnWidths[i] = Math.max(columnWidths[i] ?? 0, row[i].length);
 		}
 	}
-	return rows
-		.map((row) =>
-			row
+	return allRows
+		.map((row) => {
+			const line = row
 				.map((cell, i) => (i < row.length - 1 ? cell.padEnd(columnWidths[i]) : cell))
 				.join(separator)
-				.trimEnd(),
-		)
+				.trimEnd();
+			return line;
+		})
 		.join("\n");
 }

--- a/test/slice-list.test.ts
+++ b/test/slice-list.test.ts
@@ -13,7 +13,7 @@ it("lists slices", async ({ expect, prismic, repo, token, host }) => {
 
 	const { stdout, exitCode } = await prismic("slice", ["list"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`${slice.name} (id: ${slice.id})`);
+	expect(stdout).toMatch(new RegExp(`${slice.name}\\s+${slice.id}`));
 });
 
 it("lists slices as JSON", async ({ expect, prismic, repo, token, host }) => {

--- a/test/slice-view.test.ts
+++ b/test/slice-view.test.ts
@@ -51,11 +51,10 @@ it("shows fields per variation", async ({ expect, prismic, repo, token, host }) 
 	const { stdout, exitCode } = await prismic("slice", ["view", slice.name]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("default:");
-	expect(stdout).toContain("title  StructuredText  Title");
-	expect(stdout).toContain('"Enter title"');
-	expect(stdout).toContain("is_active  Boolean  Is Active");
+	expect(stdout).toMatch(/title\s+StructuredText\s+Title\s+"Enter title"/);
+	expect(stdout).toMatch(/is_active\s+Boolean\s+Is Active/);
 	expect(stdout).toContain("withImage:");
-	expect(stdout).toContain("image  Image  Image");
+	expect(stdout).toMatch(/image\s+Image\s+Image/);
 });
 
 it("views a slice as JSON", async ({ expect, prismic, repo, token, host }) => {

--- a/test/type-list.test.ts
+++ b/test/type-list.test.ts
@@ -15,8 +15,8 @@ it("lists all types", async ({ expect, prismic, repo, token, host }) => {
 
 	const { stdout, exitCode } = await prismic("type", ["list"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`${customType.label} (id: ${customType.id}, format: custom)`);
-	expect(stdout).toContain(`${pageType.label} (id: ${pageType.id}, format: page)`);
+	expect(stdout).toMatch(new RegExp(`${customType.label}\\s+${customType.id}\\s+custom`));
+	expect(stdout).toMatch(new RegExp(`${pageType.label}\\s+${pageType.id}\\s+page`));
 });
 
 it("lists types as JSON", async ({ expect, prismic, repo, token, host }) => {

--- a/test/type-view.test.ts
+++ b/test/type-view.test.ts
@@ -37,11 +37,10 @@ it("shows fields per tab", async ({ expect, prismic, repo, token, host }) => {
 	const { stdout, exitCode } = await prismic("type", ["view", customType.label!]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Main:");
-	expect(stdout).toContain("title  StructuredText  Title");
-	expect(stdout).toContain('"Enter title"');
-	expect(stdout).toContain("is_active  Boolean  Is Active");
+	expect(stdout).toMatch(/title\s+StructuredText\s+Title\s+"Enter title"/);
+	expect(stdout).toMatch(/is_active\s+Boolean\s+Is Active/);
 	expect(stdout).toContain("SEO:");
-	expect(stdout).toContain("meta_title  Text  Meta Title");
+	expect(stdout).toMatch(/meta_title\s+Text\s+Meta Title/);
 });
 
 it("views a type as JSON", async ({ expect, prismic, repo, token, host }) => {


### PR DESCRIPTION
Resolves: #113

### Description

Add a `formatTable` utility to `src/lib/string.ts` that computes column widths and pads cells with consistent spacing. Refactor all commands with tabular output to use it, replacing ad-hoc `padEnd()` logic and unaligned double-space concatenation.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

- Run `prismic --help` and `prismic <command> --help` to verify aligned columns in help text
- Run list commands (`locale list`, `repo list`, `token list`, `preview list`, `webhook list`, `type list`, `slice list`, `docs list`) to verify aligned columns
- Run view commands (`type view`, `slice view`) to verify aligned field tables

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatting-only change: replaces ad-hoc string concatenation/padding with a shared `formatTable` helper, which could slightly alter CLI text output and snapshot-like tests but not behavior or data handling.
> 
> **Overview**
> Adds a new `formatTable()` utility in `src/lib/string.ts` and switches CLI help + multiple list/view commands to use it for consistently aligned, columnar output (including optional headers).
> 
> Updates command help rendering in `src/lib/command.ts` and refactors tabular outputs in commands like `docs list`, `repo/locale/preview/token/webhook/type/slice list`, and `type/slice view`; associated tests were loosened to match whitespace-aligned table output rather than exact strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729b9ba963b44b1281b97669c84a745b63d7a4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->