### PR TITLE
feat: replace name-based model specifiers with IDs

### DIFF
--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -16,7 +16,7 @@ const config = {
 		name: { description: "Name of the variation", required: true },
 	},
 	options: {
-		to: { type: "string", required: true, description: "Name of the slice" },
+		to: { type: "string", required: true, description: "ID of the slice" },
 		id: { type: "string", description: "Custom ID for the variation" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
@@ -30,7 +30,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.name === to);
+	const slice = slices.find((s) => s.id === to);
 
 	if (!slice) {
 		throw new CommandError(`Slice not found: ${to}`);

--- a/src/commands/slice-connect.ts
+++ b/src/commands/slice-connect.ts
@@ -11,13 +11,13 @@ const config = {
 	name: "prismic slice connect",
 	description: "Connect a slice to a type's slice zone.",
 	positionals: {
-		name: { description: "Name of the slice", required: true },
+		id: { description: "ID of the slice", required: true },
 	},
 	options: {
 		to: {
 			type: "string",
 			required: true,
-			description: "Name of the content type",
+			description: "ID of the content type",
 		},
 		"slice-zone": {
 			type: "string",
@@ -28,7 +28,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { to, "slice-zone": sliceZone = "slices", repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
@@ -37,13 +37,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const apiConfig = { repo, token, host };
 
 	const slices = await getSlices(apiConfig);
-	const slice = slices.find((s) => s.name === name);
+	const slice = slices.find((s) => s.id === id);
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${name}`);
+		throw new CommandError(`Slice not found: ${id}`);
 	}
 
 	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.label === to);
+	const customType = customTypes.find((ct) => ct.id === to);
 	if (!customType) {
 		throw new CommandError(`Type not found: ${to}`);
 	}
@@ -86,5 +86,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Connected slice "${name}" to "${to}"`);
+	console.info(`Connected slice "${id}" to "${to}"`);
 });

--- a/src/commands/slice-disconnect.ts
+++ b/src/commands/slice-disconnect.ts
@@ -11,13 +11,13 @@ const config = {
 	name: "prismic slice disconnect",
 	description: "Disconnect a slice from a type's slice zone.",
 	positionals: {
-		name: { description: "Name of the slice", required: true },
+		id: { description: "ID of the slice", required: true },
 	},
 	options: {
 		from: {
 			type: "string",
 			required: true,
-			description: "Name of the content type",
+			description: "ID of the content type",
 		},
 		"slice-zone": {
 			type: "string",
@@ -28,7 +28,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { from, "slice-zone": sliceZone = "slices", repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
@@ -37,13 +37,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const apiConfig = { repo, token, host };
 
 	const slices = await getSlices(apiConfig);
-	const slice = slices.find((s) => s.name === name);
+	const slice = slices.find((s) => s.id === id);
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${name}`);
+		throw new CommandError(`Slice not found: ${id}`);
 	}
 
 	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.label === from);
+	const customType = customTypes.find((ct) => ct.id === from);
 	if (!customType) {
 		throw new CommandError(`Type not found: ${from}`);
 	}
@@ -83,5 +83,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Disconnected slice "${name}" from "${from}"`);
+	console.info(`Disconnected slice "${id}" from "${from}"`);
 });

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -11,33 +11,33 @@ const config = {
 	name: "prismic slice edit-variation",
 	description: "Edit a variation of a slice.",
 	positionals: {
-		name: { description: "Name of the variation", required: true },
+		id: { description: "ID of the variation", required: true },
 	},
 	options: {
-		"from-slice": { type: "string", required: true, description: "Name of the slice" },
+		"from-slice": { type: "string", required: true, description: "ID of the slice" },
 		name: { type: "string", short: "n", description: "New name for the variation" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [currentName] = positionals;
-	const { "from-slice": sliceName, repo = await getRepositoryName() } = values;
+	const [currentId] = positionals;
+	const { "from-slice": sliceId, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.name === sliceName);
+	const slice = slices.find((s) => s.id === sliceId);
 
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${sliceName}`);
+		throw new CommandError(`Slice not found: ${sliceId}`);
 	}
 
-	const variation = slice.variations.find((v) => v.name === currentName);
+	const variation = slice.variations.find((v) => v.id === currentId);
 
 	if (!variation) {
-		throw new CommandError(`Variation "${currentName}" not found in slice "${sliceName}".`);
+		throw new CommandError(`Variation "${currentId}" not found in slice "${sliceId}".`);
 	}
 
 	if ("name" in values) variation.name = values.name!;
@@ -61,5 +61,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Variation updated: "${variation.name}" in slice "${sliceName}"`);
+	console.info(`Variation updated: "${currentId}" in slice "${sliceId}"`);
 });

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -21,7 +21,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [currentId] = positionals;
+	const [id] = positionals;
 	const { "from-slice": sliceId, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
@@ -34,10 +34,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 		throw new CommandError(`Slice not found: ${sliceId}`);
 	}
 
-	const variation = slice.variations.find((v) => v.id === currentId);
+	const variation = slice.variations.find((v) => v.id === id);
 
 	if (!variation) {
-		throw new CommandError(`Variation "${currentId}" not found in slice "${sliceId}".`);
+		throw new CommandError(`Variation "${id}" not found in slice "${sliceId}".`);
 	}
 
 	if ("name" in values) variation.name = values.name!;
@@ -61,5 +61,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Variation updated: "${currentId}" in slice "${sliceId}"`);
+	console.info(`Variation updated: "${id}" in slice "${sliceId}"`);
 });

--- a/src/commands/slice-edit.ts
+++ b/src/commands/slice-edit.ts
@@ -11,7 +11,7 @@ const config = {
 	name: "prismic slice edit",
 	description: "Edit a slice.",
 	positionals: {
-		name: { description: "Name of the slice", required: true },
+		id: { description: "ID of the slice", required: true },
 	},
 	options: {
 		name: { type: "string", short: "n", description: "New name for the slice" },
@@ -20,17 +20,17 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [currentName] = positionals;
+	const [id] = positionals;
 	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.name === currentName);
+	const slice = slices.find((s) => s.id === id);
 
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${currentName}`);
+		throw new CommandError(`Slice not found: ${id}`);
 	}
 
 	const updatedSlice: SharedSlice = { ...slice };

--- a/src/commands/slice-remove-variation.ts
+++ b/src/commands/slice-remove-variation.ts
@@ -11,32 +11,32 @@ const config = {
 	name: "prismic slice remove-variation",
 	description: "Remove a variation from a slice.",
 	positionals: {
-		name: { description: "Name of the variation", required: true },
+		id: { description: "ID of the variation", required: true },
 	},
 	options: {
-		from: { type: "string", required: true, description: "Name of the slice" },
+		from: { type: "string", required: true, description: "ID of the slice" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { from, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.name === from);
+	const slice = slices.find((s) => s.id === from);
 
 	if (!slice) {
 		throw new CommandError(`Slice not found: ${from}`);
 	}
 
-	const variation = slice.variations.find((v) => v.name === name);
+	const variation = slice.variations.find((v) => v.id === id);
 
 	if (!variation) {
-		throw new CommandError(`Variation "${name}" not found in slice "${from}".`);
+		throw new CommandError(`Variation "${id}" not found in slice "${from}".`);
 	}
 
 	const updatedSlice: SharedSlice = {
@@ -61,5 +61,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Removed variation "${name}" from slice "${from}"`);
+	console.info(`Removed variation "${id}" from slice "${from}"`);
 });

--- a/src/commands/slice-remove.ts
+++ b/src/commands/slice-remove.ts
@@ -9,7 +9,7 @@ const config = {
 	name: "prismic slice remove",
 	description: "Remove a slice.",
 	positionals: {
-		name: { description: "Name of the slice", required: true },
+		id: { description: "ID of the slice", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -17,17 +17,17 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.name === name);
+	const slice = slices.find((s) => s.id === id);
 
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${name}`);
+		throw new CommandError(`Slice not found: ${id}`);
 	}
 
 	try {
@@ -45,5 +45,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	} catch {}
 	await adapter.generateTypes();
 
-	console.info(`Slice removed: "${name}" (id: ${slice.id})`);
+	console.info(`Slice removed: ${id}`);
 });

--- a/src/commands/slice-view.ts
+++ b/src/commands/slice-view.ts
@@ -8,7 +8,7 @@ const config = {
 	name: "prismic slice view",
 	description: "View details of a slice.",
 	positionals: {
-		name: { description: "Name of the slice", required: true },
+		id: { description: "ID of the slice", required: true },
 	},
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
@@ -17,16 +17,16 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { json, repo = await getRepositoryName() } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((slice) => slice.name === name);
+	const slice = slices.find((slice) => slice.id === id);
 
 	if (!slice) {
-		throw new CommandError(`Slice not found: ${name}`);
+		throw new CommandError(`Slice not found: ${id}`);
 	}
 
 	if (json) {

--- a/src/commands/type-add-tab.ts
+++ b/src/commands/type-add-tab.ts
@@ -12,7 +12,7 @@ const config = {
 		name: { description: "Name of the tab", required: true },
 	},
 	options: {
-		to: { type: "string", required: true, description: "Name of the content type" },
+		to: { type: "string", required: true, description: "ID of the content type" },
 		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
@@ -26,7 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === to);
+	const type = customTypes.find((ct) => ct.id === to);
 
 	if (!type) {
 		throw new CommandError(`Type not found: ${to}`);

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -14,7 +14,7 @@ const config = {
 		name: { description: "Current name of the tab", required: true },
 	},
 	options: {
-		"from-type": { type: "string", required: true, description: "Name of the content type" },
+		"from-type": { type: "string", required: true, description: "ID of the content type" },
 		name: { type: "string", short: "n", description: "New name for the tab" },
 		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
 		"without-slice-zone": { type: "boolean", description: "Remove the slice zone from the tab" },
@@ -24,20 +24,20 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [currentName] = positionals;
-	const { "from-type": typeName, repo = await getRepositoryName() } = values;
+	const { "from-type": typeId, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === typeName);
+	const type = customTypes.find((ct) => ct.id === typeId);
 
 	if (!type) {
-		throw new CommandError(`Type not found: ${typeName}`);
+		throw new CommandError(`Type not found: ${typeId}`);
 	}
 
 	if (!(currentName in type.json)) {
-		throw new CommandError(`Tab "${currentName}" not found in "${typeName}".`);
+		throw new CommandError(`Tab "${currentName}" not found in "${typeId}".`);
 	}
 
 	if ("with-slice-zone" in values && "without-slice-zone" in values) {
@@ -82,7 +82,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	if ("name" in values) {
 		if (values.name! in type.json) {
-			throw new CommandError(`Tab "${values.name}" already exists in "${typeName}".`);
+			throw new CommandError(`Tab "${values.name}" already exists in "${typeId}".`);
 		}
 
 		const newJson: CustomType["json"] = {};
@@ -109,5 +109,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	await adapter.generateTypes();
 
-	console.info(`Tab updated: "${currentName}" in "${typeName}"`);
+	console.info(`Tab updated: "${currentName}" in "${typeId}"`);
 });

--- a/src/commands/type-edit.ts
+++ b/src/commands/type-edit.ts
@@ -9,7 +9,7 @@ const config = {
 	name: "prismic type edit",
 	description: "Edit a content type.",
 	positionals: {
-		name: { description: "Name of the content type", required: true },
+		id: { description: "ID of the content type", required: true },
 	},
 	options: {
 		name: { type: "string", short: "n", description: "New name for the type" },
@@ -19,7 +19,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [currentName] = positionals;
+	const [id] = positionals;
 	const { repo = await getRepositoryName() } = values;
 
 	if ("format" in values && values.format !== "custom" && values.format !== "page") {
@@ -30,10 +30,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === currentName);
+	const type = customTypes.find((ct) => ct.id === id);
 
 	if (!type) {
-		throw new CommandError(`Type not found: ${currentName}`);
+		throw new CommandError(`Type not found: ${id}`);
 	}
 
 	if ("name" in values) type.label = values.name;

--- a/src/commands/type-remove-tab.ts
+++ b/src/commands/type-remove-tab.ts
@@ -12,7 +12,7 @@ const config = {
 		name: { description: "Name of the tab", required: true },
 	},
 	options: {
-		from: { type: "string", required: true, description: "Name of the content type" },
+		from: { type: "string", required: true, description: "ID of the content type" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
@@ -25,7 +25,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === from);
+	const type = customTypes.find((ct) => ct.id === from);
 
 	if (!type) {
 		throw new CommandError(`Type not found: ${from}`);

--- a/src/commands/type-remove.ts
+++ b/src/commands/type-remove.ts
@@ -9,7 +9,7 @@ const config = {
 	name: "prismic type remove",
 	description: "Remove a content type.",
 	positionals: {
-		name: { description: "Name of the content type", required: true },
+		id: { description: "ID of the content type", required: true },
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
@@ -17,17 +17,17 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === name);
+	const type = customTypes.find((ct) => ct.id === id);
 
 	if (!type) {
-		throw new CommandError(`Type not found: ${name}`);
+		throw new CommandError(`Type not found: ${id}`);
 	}
 
 	try {
@@ -45,5 +45,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	} catch {}
 	await adapter.generateTypes();
 
-	console.info(`Type removed: "${name}" (id: ${type.id})`);
+	console.info(`Type removed: ${id}`);
 });

--- a/src/commands/type-view.ts
+++ b/src/commands/type-view.ts
@@ -8,7 +8,7 @@ const config = {
 	name: "prismic type view",
 	description: "View details of a content type.",
 	positionals: {
-		name: { description: "Name of the content type", required: true },
+		id: { description: "ID of the content type", required: true },
 	},
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
@@ -17,16 +17,16 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
-	const [name] = positionals;
+	const [id] = positionals;
 	const { json, repo = await getRepositoryName() } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.label === name);
+	const type = customTypes.find((ct) => ct.id === id);
 
 	if (!type) {
-		throw new CommandError(`Type not found: ${name}`);
+		throw new CommandError(`Type not found: ${id}`);
 	}
 
 	if (json) {

--- a/src/models.ts
+++ b/src/models.ts
@@ -14,16 +14,16 @@ type ApiConfig = { repo: string; token: string | undefined; host: string };
 type Target = [fields: Fields, save: () => Promise<void>, modelKind: ModelKind];
 
 export const TARGET_OPTIONS = {
-	"to-slice": { type: "string", description: "Name of the target slice" },
-	"to-type": { type: "string", description: "Name of the target content type" },
+	"to-slice": { type: "string", description: "ID of the target slice" },
+	"to-type": { type: "string", description: "ID of the target content type" },
 	variation: { type: "string", description: 'Slice variation ID (default: "default")' },
 	tab: { type: "string", description: 'Content type tab name (default: "Main")' },
 	repo: { type: "string", short: "r", description: "Repository domain" },
 } satisfies CommandConfig["options"];
 
 export const SOURCE_OPTIONS = {
-	"from-slice": { type: "string", description: "Name of the source slice" },
-	"from-type": { type: "string", description: "Name of the source content type" },
+	"from-slice": { type: "string", description: "ID of the source slice" },
+	"from-type": { type: "string", description: "ID of the source content type" },
 	variation: TARGET_OPTIONS.variation,
 	tab: TARGET_OPTIONS.tab,
 	repo: TARGET_OPTIONS.repo,
@@ -55,7 +55,7 @@ export async function resolveFieldContainer(
 
 	if (fromSlice) {
 		const slices = await getSlices(apiConfig);
-		const slice = slices.find((s) => s.name === fromSlice);
+		const slice = slices.find((s) => s.id === fromSlice);
 		if (!slice) {
 			throw new CommandError(`Slice not found: ${fromSlice}`);
 		}
@@ -82,7 +82,7 @@ export async function resolveFieldContainer(
 	}
 
 	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.label === fromType);
+	const customType = customTypes.find((ct) => ct.id === fromType);
 	if (!customType) {
 		throw new CommandError(`Type not found: ${fromType}`);
 	}
@@ -122,10 +122,10 @@ export async function resolveModel(
 	apiConfig: ApiConfig,
 ): Promise<Target> {
 	const adapter = await getAdapter();
-	const sliceName = values["to-slice"] ?? values["from-slice"];
-	const typeName = values["to-type"] ?? values["from-type"];
+	const sliceId = values["to-slice"] ?? values["from-slice"];
+	const typeId = values["to-type"] ?? values["from-type"];
 
-	const providedCount = [sliceName, typeName].filter(Boolean).length;
+	const providedCount = [sliceId, typeId].filter(Boolean).length;
 	if (providedCount === 0) {
 		throw new CommandError("Specify a target with --to-slice or --to-type.");
 	}
@@ -133,16 +133,16 @@ export async function resolveModel(
 		throw new CommandError("Only one of --to-slice or --to-type can be specified.");
 	}
 
-	if (sliceName) {
+	if (sliceId) {
 		if ("tab" in values) {
 			throw new CommandError("--tab is only valid for content types.");
 		}
 
 		const variation = values.variation ?? "default";
 		const slices = await getSlices(apiConfig);
-		const slice = slices.find((s) => s.name === sliceName);
+		const slice = slices.find((s) => s.id === sliceId);
 		if (!slice) {
-			throw new CommandError(`Slice not found: ${sliceName}`);
+			throw new CommandError(`Slice not found: ${sliceId}`);
 		}
 
 		const newModel = structuredClone(slice);
@@ -182,9 +182,9 @@ export async function resolveModel(
 
 	const tab = values.tab ?? "Main";
 	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.label === typeName);
+	const customType = customTypes.find((ct) => ct.id === typeId);
 	if (!customType) {
-		throw new CommandError(`Type not found: ${typeName}`);
+		throw new CommandError(`Type not found: ${typeId}`);
 	}
 
 	const newModel = structuredClone(customType);

--- a/test/field-add-boolean.test.ts
+++ b/test/field-add-boolean.test.ts
@@ -16,7 +16,7 @@ it("adds a boolean field to a slice", async ({ expect, prismic, repo, token, hos
 		"boolean",
 		"my_field",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_field");
@@ -36,7 +36,7 @@ it("adds a boolean field to a custom type", async ({ expect, prismic, repo, toke
 		"boolean",
 		"is_active",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: is_active");

--- a/test/field-add-color.test.ts
+++ b/test/field-add-color.test.ts
@@ -16,7 +16,7 @@ it("adds a color field to a slice", async ({ expect, prismic, repo, token, host 
 		"color",
 		"my_color",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_color");
@@ -36,7 +36,7 @@ it("adds a color field to a custom type", async ({ expect, prismic, repo, token,
 		"color",
 		"my_color",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_color");

--- a/test/field-add-content-relationship.test.ts
+++ b/test/field-add-content-relationship.test.ts
@@ -22,7 +22,7 @@ it("adds a content relationship field to a slice", async ({
 		"content-relationship",
 		"my_link",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
@@ -48,7 +48,7 @@ it("adds a content relationship field to a custom type", async ({
 		"content-relationship",
 		"my_link",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");

--- a/test/field-add-date.test.ts
+++ b/test/field-add-date.test.ts
@@ -16,7 +16,7 @@ it("adds a date field to a slice", async ({ expect, prismic, repo, token, host }
 		"date",
 		"my_date",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_date");
@@ -36,7 +36,7 @@ it("adds a date field to a custom type", async ({ expect, prismic, repo, token, 
 		"date",
 		"my_date",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_date");

--- a/test/field-add-embed.test.ts
+++ b/test/field-add-embed.test.ts
@@ -16,7 +16,7 @@ it("adds an embed field to a slice", async ({ expect, prismic, repo, token, host
 		"embed",
 		"my_embed",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");
@@ -36,7 +36,7 @@ it("adds an embed field to a custom type", async ({ expect, prismic, repo, token
 		"embed",
 		"my_embed",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");

--- a/test/field-add-geopoint.test.ts
+++ b/test/field-add-geopoint.test.ts
@@ -16,7 +16,7 @@ it("adds a geopoint field to a slice", async ({ expect, prismic, repo, token, ho
 		"geopoint",
 		"my_location",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_location");
@@ -36,7 +36,7 @@ it("adds a geopoint field to a custom type", async ({ expect, prismic, repo, tok
 		"geopoint",
 		"my_location",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_location");

--- a/test/field-add-group.test.ts
+++ b/test/field-add-group.test.ts
@@ -18,7 +18,7 @@ it("adds a group field to a slice", async ({ expect, prismic, repo, token, host 
 		"group",
 		"my_group",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
@@ -38,7 +38,7 @@ it("adds a group field to a custom type", async ({ expect, prismic, repo, token,
 		"group",
 		"my_group",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
@@ -65,7 +65,7 @@ it("adds a field inside a group using dot syntax", async ({
 		"text",
 		"my_group.subtitle",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group.subtitle");
@@ -93,7 +93,7 @@ it("errors when dot syntax targets a non-existent field", async ({
 		"text",
 		"nonexistent.subtitle",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(1);
 	expect(stderr).toContain('Field "nonexistent" does not exist.');
@@ -115,7 +115,7 @@ it("errors when dot syntax targets a non-group field", async ({
 		"text",
 		"my_text.subtitle",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(1);
 	expect(stderr).toContain('Field "my_text" is not a group field.');

--- a/test/field-add-image.test.ts
+++ b/test/field-add-image.test.ts
@@ -16,7 +16,7 @@ it("adds an image field to a slice", async ({ expect, prismic, repo, token, host
 		"image",
 		"my_image",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_image");
@@ -36,7 +36,7 @@ it("adds an image field to a custom type", async ({ expect, prismic, repo, token
 		"image",
 		"my_image",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_image");

--- a/test/field-add-integration.test.ts
+++ b/test/field-add-integration.test.ts
@@ -16,7 +16,7 @@ it("adds an integration field to a slice", async ({ expect, prismic, repo, token
 		"integration",
 		"my_integration",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");
@@ -36,7 +36,7 @@ it("adds an integration field to a custom type", async ({ expect, prismic, repo,
 		"integration",
 		"my_integration",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");

--- a/test/field-add-link.test.ts
+++ b/test/field-add-link.test.ts
@@ -21,7 +21,7 @@ it("adds a link field to a slice", async ({ expect, prismic, repo, token, host }
 		"link",
 		"my_link",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
@@ -41,7 +41,7 @@ it("adds a link field to a custom type", async ({ expect, prismic, repo, token, 
 		"link",
 		"my_link",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
@@ -61,7 +61,7 @@ it("adds a media link field with --allow media", async ({ expect, prismic, repo,
 		"link",
 		"my_media",
 		"--to-slice",
-		slice.name,
+		slice.id,
 		"--allow",
 		"media",
 	]);

--- a/test/field-add-number.test.ts
+++ b/test/field-add-number.test.ts
@@ -16,7 +16,7 @@ it("adds a number field to a slice", async ({ expect, prismic, repo, token, host
 		"number",
 		"my_number",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_number");
@@ -36,7 +36,7 @@ it("adds a number field to a custom type", async ({ expect, prismic, repo, token
 		"number",
 		"my_number",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_number");

--- a/test/field-add-rich-text.test.ts
+++ b/test/field-add-rich-text.test.ts
@@ -16,7 +16,7 @@ it("adds a rich text field to a slice", async ({ expect, prismic, repo, token, h
 		"rich-text",
 		"my_content",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_content");
@@ -36,7 +36,7 @@ it("adds a rich text field to a custom type", async ({ expect, prismic, repo, to
 		"rich-text",
 		"my_content",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_content");

--- a/test/field-add-select.test.ts
+++ b/test/field-add-select.test.ts
@@ -16,7 +16,7 @@ it("adds a select field to a slice", async ({ expect, prismic, repo, token, host
 		"select",
 		"my_select",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_select");
@@ -36,7 +36,7 @@ it("adds a select field to a custom type", async ({ expect, prismic, repo, token
 		"select",
 		"my_select",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_select");

--- a/test/field-add-table.test.ts
+++ b/test/field-add-table.test.ts
@@ -16,7 +16,7 @@ it("adds a table field to a slice", async ({ expect, prismic, repo, token, host 
 		"table",
 		"my_table",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_table");
@@ -36,7 +36,7 @@ it("adds a table field to a custom type", async ({ expect, prismic, repo, token,
 		"table",
 		"my_table",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_table");

--- a/test/field-add-text.test.ts
+++ b/test/field-add-text.test.ts
@@ -16,7 +16,7 @@ it("adds a text field to a slice", async ({ expect, prismic, repo, token, host }
 		"text",
 		"subtitle",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
@@ -36,7 +36,7 @@ it("adds a text field to a custom type", async ({ expect, prismic, repo, token, 
 		"text",
 		"subtitle",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
@@ -56,7 +56,7 @@ it("adds a text field to a page type", async ({ expect, prismic, repo, token, ho
 		"text",
 		"subtitle",
 		"--to-type",
-		pageType.label!,
+		pageType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");

--- a/test/field-add-timestamp.test.ts
+++ b/test/field-add-timestamp.test.ts
@@ -16,7 +16,7 @@ it("adds a timestamp field to a slice", async ({ expect, prismic, repo, token, h
 		"timestamp",
 		"my_timestamp",
 		"--to-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");
@@ -36,7 +36,7 @@ it("adds a timestamp field to a custom type", async ({ expect, prismic, repo, to
 		"timestamp",
 		"my_timestamp",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");

--- a/test/field-add-uid.test.ts
+++ b/test/field-add-uid.test.ts
@@ -15,7 +15,7 @@ it("adds a uid field to a custom type", async ({ expect, prismic, repo, token, h
 		"add",
 		"uid",
 		"--to-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: uid");
@@ -34,7 +34,7 @@ it("adds a uid field to a page type", async ({ expect, prismic, repo, token, hos
 		"add",
 		"uid",
 		"--to-type",
-		pageType.label!,
+		pageType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: uid");

--- a/test/field-edit.test.ts
+++ b/test/field-edit.test.ts
@@ -16,7 +16,7 @@ it("edits a field label on a slice", async ({ expect, prismic, repo, token, host
 		"edit",
 		"my_field",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--label",
 		"New Label",
 	]);
@@ -46,7 +46,7 @@ it("edits a field label on a custom type", async ({ expect, prismic, repo, token
 		"edit",
 		"title",
 		"--from-type",
-		customType.label!,
+		customType.id,
 		"--label",
 		"Page Title",
 	]);
@@ -70,7 +70,7 @@ it("edits boolean field options", async ({ expect, prismic, repo, token, host })
 		"edit",
 		"is_active",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--default-value",
 		"true",
 		"--true-label",
@@ -103,7 +103,7 @@ it("edits number field options", async ({ expect, prismic, repo, token, host }) 
 		"edit",
 		"quantity",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--min",
 		"0",
 		"--max",
@@ -133,7 +133,7 @@ it("edits select field options", async ({ expect, prismic, repo, token, host }) 
 		"edit",
 		"color",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--default-value",
 		"green",
 		"--option",
@@ -170,7 +170,7 @@ it("edits link field options", async ({ expect, prismic, repo, token, host }) =>
 		"edit",
 		"cta_link",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--allow-target-blank",
 	]);
 	expect(exitCode).toBe(0);

--- a/test/field-remove.test.ts
+++ b/test/field-remove.test.ts
@@ -31,7 +31,7 @@ it("removes a field from a slice", async ({ expect, prismic, repo, token, host }
 		"remove",
 		"my_field",
 		"--from-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: my_field");
@@ -55,7 +55,7 @@ it("removes a field from a custom type", async ({ expect, prismic, repo, token, 
 		"remove",
 		"title",
 		"--from-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: title");
@@ -95,7 +95,7 @@ it("removes a nested field using dot notation", async ({ expect, prismic, repo, 
 		"remove",
 		"my_group.subtitle",
 		"--from-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: my_group.subtitle");

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -19,7 +19,7 @@ it("views a field in a slice", async ({ expect, prismic, repo, token, host }) =>
 		"view",
 		"title",
 		"--from-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Type: StructuredText");
@@ -39,7 +39,7 @@ it("views a field in a custom type", async ({ expect, prismic, repo, token, host
 		"view",
 		"count",
 		"--from-type",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Type: Number");
@@ -60,7 +60,7 @@ it("outputs JSON with --json", async ({ expect, prismic, repo, token, host }) =>
 		"view",
 		"is_active",
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--json",
 	]);
 	expect(exitCode).toBe(0);
@@ -79,7 +79,7 @@ it("errors for non-existent field", async ({ expect, prismic, repo, token, host 
 		"view",
 		"nonexistent",
 		"--from-slice",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).not.toBe(0);
 	expect(stderr).toContain("nonexistent");

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -17,11 +17,11 @@ it("adds a variation to a slice", async ({ expect, prismic, repo, token, host })
 		"add-variation",
 		variationName,
 		"--to",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
-	expect(stdout).toContain(`to slice "${slice.name}"`);
+	expect(stdout).toContain(`to slice "${slice.id}"`);
 
 	const slices = await getSlices({ repo, token, host });
 	const updated = slices.find((s) => s.id === slice.id);

--- a/test/slice-connect.test.ts
+++ b/test/slice-connect.test.ts
@@ -6,7 +6,7 @@ import { getCustomTypes, insertCustomType, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["connect", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice connect <name> [options]");
+	expect(stdout).toContain("prismic slice connect <id> [options]");
 });
 
 it("connects a slice to a type", async ({ expect, prismic, repo, token, host }) => {
@@ -29,12 +29,12 @@ it("connects a slice to a type", async ({ expect, prismic, repo, token, host }) 
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"connect",
-		slice.name,
+		slice.id,
 		"--to",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Connected slice "${slice.name}" to "${customType.label}"`);
+	expect(stdout).toContain(`Connected slice "${slice.id}" to "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);

--- a/test/slice-disconnect.test.ts
+++ b/test/slice-disconnect.test.ts
@@ -6,7 +6,7 @@ import { getCustomTypes, insertCustomType, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["disconnect", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice disconnect <name> [options]");
+	expect(stdout).toContain("prismic slice disconnect <id> [options]");
 });
 
 it("disconnects a slice from a type", async ({ expect, prismic, repo, token, host }) => {
@@ -29,12 +29,12 @@ it("disconnects a slice from a type", async ({ expect, prismic, repo, token, hos
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"disconnect",
-		slice.name,
+		slice.id,
 		"--from",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Disconnected slice "${slice.name}" from "${customType.label}"`);
+	expect(stdout).toContain(`Disconnected slice "${slice.id}" from "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -4,7 +4,7 @@ import { getSlices, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["edit-variation", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice edit-variation <name> [options]");
+	expect(stdout).toContain("prismic slice edit-variation <id> [options]");
 });
 
 it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
@@ -32,14 +32,14 @@ it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"edit-variation",
-		variationName,
+		variationId,
 		"--from-slice",
-		slice.name,
+		slice.id,
 		"--name",
 		newName,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Variation updated: "${newName}" in slice "${slice.name}"`);
+	expect(stdout).toContain(`Variation updated: "${variationId}" in slice "${slice.id}"`);
 
 	const slices = await getSlices({ repo, token, host });
 	const updated = slices.find((s) => s.id === slice.id);

--- a/test/slice-edit.test.ts
+++ b/test/slice-edit.test.ts
@@ -4,7 +4,7 @@ import { getSlices, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["edit", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice edit <name> [options]");
+	expect(stdout).toContain("prismic slice edit <id> [options]");
 });
 
 it("edits a slice name", async ({ expect, prismic, repo, token, host }) => {
@@ -13,7 +13,7 @@ it("edits a slice name", async ({ expect, prismic, repo, token, host }) => {
 
 	const newName = `SliceS${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", ["edit", slice.name, "--name", newName]);
+	const { stdout, exitCode } = await prismic("slice", ["edit", slice.id, "--name", newName]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Slice updated: "${newName}"`);
 

--- a/test/slice-remove-variation.test.ts
+++ b/test/slice-remove-variation.test.ts
@@ -4,7 +4,7 @@ import { getSlices, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["remove-variation", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice remove-variation <name> [options]");
+	expect(stdout).toContain("prismic slice remove-variation <id> [options]");
 });
 
 it("removes a variation from a slice", async ({ expect, prismic, repo, token, host }) => {
@@ -30,12 +30,12 @@ it("removes a variation from a slice", async ({ expect, prismic, repo, token, ho
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"remove-variation",
-		variationName,
+		variationId,
 		"--from",
-		slice.name,
+		slice.id,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Removed variation "${variationName}" from slice "${slice.name}"`);
+	expect(stdout).toContain(`Removed variation "${variationId}" from slice "${slice.id}"`);
 
 	const slices = await getSlices({ repo, token, host });
 	const updated = slices.find((s) => s.id === slice.id);

--- a/test/slice-remove.test.ts
+++ b/test/slice-remove.test.ts
@@ -4,16 +4,16 @@ import { getSlices, insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["remove", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice remove <name> [options]");
+	expect(stdout).toContain("prismic slice remove <id> [options]");
 });
 
 it("removes a slice", async ({ expect, prismic, repo, token, host }) => {
 	const slice = buildSlice();
 	await insertSlice(slice, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("slice", ["remove", slice.name]);
+	const { stdout, exitCode } = await prismic("slice", ["remove", slice.id]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Slice removed: "${slice.name}" (id: ${slice.id})`);
+	expect(stdout).toContain(`Slice removed: ${slice.id}`);
 
 	const slices = await getSlices({ repo, token, host });
 	const removed = slices.find((s) => s.id === slice.id);

--- a/test/slice-view.test.ts
+++ b/test/slice-view.test.ts
@@ -4,14 +4,14 @@ import { insertSlice } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["view", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic slice view <name> [options]");
+	expect(stdout).toContain("prismic slice view <id> [options]");
 });
 
 it("views a slice", async ({ expect, prismic, repo, token, host }) => {
 	const slice = buildSlice();
 	await insertSlice(slice, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.name]);
+	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`ID: ${slice.id}`);
 	expect(stdout).toContain(`Name: ${slice.name}`);
@@ -48,7 +48,7 @@ it("shows fields per variation", async ({ expect, prismic, repo, token, host }) 
 	});
 	await insertSlice(slice, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.name]);
+	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("default:");
 	expect(stdout).toContain("title  StructuredText  Title");
@@ -62,7 +62,7 @@ it("views a slice as JSON", async ({ expect, prismic, repo, token, host }) => {
 	const slice = buildSlice();
 	await insertSlice(slice, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.name, "--json"]);
+	const { stdout, exitCode } = await prismic("slice", ["view", slice.id, "--json"]);
 	expect(exitCode).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toMatchObject({ id: slice.id, name: slice.name });

--- a/test/type-add-tab.test.ts
+++ b/test/type-add-tab.test.ts
@@ -17,10 +17,10 @@ it("adds a tab to a type", async ({ expect, prismic, repo, token, host }) => {
 		"add-tab",
 		tabName,
 		"--to",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.label}"`);
+	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);
@@ -38,11 +38,11 @@ it("adds a tab with a slice zone", async ({ expect, prismic, repo, token, host }
 		"add-tab",
 		tabName,
 		"--to",
-		customType.label!,
+		customType.id,
 		"--with-slice-zone",
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.label}"`);
+	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);

--- a/test/type-edit-tab.test.ts
+++ b/test/type-edit-tab.test.ts
@@ -17,12 +17,12 @@ it("edits a tab name", async ({ expect, prismic, repo, token, host }) => {
 		"edit-tab",
 		"OldName",
 		"--from-type",
-		customType.label!,
+		customType.id,
 		"--name",
 		newName,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Tab updated: "OldName" in "${customType.label}"`);
+	expect(stdout).toContain(`Tab updated: "OldName" in "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);
@@ -38,11 +38,11 @@ it("adds a slice zone to a tab", async ({ expect, prismic, repo, token, host }) 
 		"edit-tab",
 		"Main",
 		"--from-type",
-		customType.label!,
+		customType.id,
 		"--with-slice-zone",
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Tab updated: "Main" in "${customType.label}"`);
+	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);
@@ -68,11 +68,11 @@ it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, hos
 		"edit-tab",
 		"Main",
 		"--from-type",
-		customType.label!,
+		customType.id,
 		"--without-slice-zone",
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Tab updated: "Main" in "${customType.label}"`);
+	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);

--- a/test/type-edit.test.ts
+++ b/test/type-edit.test.ts
@@ -4,7 +4,7 @@ import { getCustomTypes, insertCustomType } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["edit", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic type edit <name> [options]");
+	expect(stdout).toContain("prismic type edit <id> [options]");
 });
 
 it("edits a type name", async ({ expect, prismic, repo, token, host }) => {
@@ -13,10 +13,10 @@ it("edits a type name", async ({ expect, prismic, repo, token, host }) => {
 
 	const newName = `TypeT${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, stderr, exitCode } = await prismic("type", ["edit", customType.label!, "--name", newName]);
+	const { stdout, stderr, exitCode } = await prismic("type", ["edit", customType.id, "--name", newName]);
 	expect(stderr).toBe("");
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Type updated: "${newName}"`);
+	expect(stdout).toContain(`Type updated: "${newName}" (id: ${customType.id})`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);
@@ -27,7 +27,7 @@ it("edits a type format", async ({ expect, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { stderr, exitCode } = await prismic("type", ["edit", customType.label!, "--format", "page"]);
+	const { stderr, exitCode } = await prismic("type", ["edit", customType.id, "--format", "page"]);
 	expect(stderr).toBe("");
 	expect(exitCode).toBe(0);
 

--- a/test/type-remove-tab.test.ts
+++ b/test/type-remove-tab.test.ts
@@ -15,10 +15,10 @@ it("removes a tab from a type", async ({ expect, prismic, repo, token, host }) =
 		"remove-tab",
 		"Extra",
 		"--from",
-		customType.label!,
+		customType.id,
 	]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Removed tab "Extra" from "${customType.label}"`);
+	expect(stdout).toContain(`Removed tab "Extra" from "${customType.id}"`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const updated = customTypes.find((ct) => ct.id === customType.id);

--- a/test/type-remove.test.ts
+++ b/test/type-remove.test.ts
@@ -4,16 +4,16 @@ import { getCustomTypes, insertCustomType } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["remove", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic type remove <name> [options]");
+	expect(stdout).toContain("prismic type remove <id> [options]");
 });
 
 it("removes a type", async ({ expect, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("type", ["remove", customType.label!]);
+	const { stdout, exitCode } = await prismic("type", ["remove", customType.id]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Type removed: "${customType.label}" (id: ${customType.id})`);
+	expect(stdout).toContain(`Type removed: ${customType.id}`);
 
 	const customTypes = await getCustomTypes({ repo, token, host });
 	const removed = customTypes.find((ct) => ct.id === customType.id);

--- a/test/type-view.test.ts
+++ b/test/type-view.test.ts
@@ -4,14 +4,14 @@ import { insertCustomType } from "./prismic";
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["view", "--help"]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain("prismic type view <name> [options]");
+	expect(stdout).toContain("prismic type view <id> [options]");
 });
 
 it("views a type", async ({ expect, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.label!]);
+	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`ID: ${customType.id}`);
 	expect(stdout).toContain(`Name: ${customType.label}`);
@@ -34,7 +34,7 @@ it("shows fields per tab", async ({ expect, prismic, repo, token, host }) => {
 	});
 	await insertCustomType(customType, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.label!]);
+	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Main:");
 	expect(stdout).toContain("title  StructuredText  Title");
@@ -48,7 +48,7 @@ it("views a type as JSON", async ({ expect, prismic, repo, token, host }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.label!, "--json"]);
+	const { stdout, exitCode } = await prismic("type", ["view", customType.id, "--json"]);
 	expect(exitCode).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toMatchObject({ id: customType.id, label: customType.label, format: "custom" });


### PR DESCRIPTION
Resolves: #105

### Description

Replace name-based model specifiers with IDs in all modeling commands. Slice commands now resolve by `id` instead of `name`, content type commands resolve by `id` instead of `label`, and variation commands resolve by `id` instead of `name`.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This changes CLI arguments for many modeling commands from name/label-based lookups to ID-based lookups, which is a backward-incompatible behavior change and may break existing scripts. Logic changes are straightforward but touch multiple commands and shared model resolution paths.
> 
> **Overview**
> **Model targeting is now ID-based across the CLI.** Slice commands (`add-variation`, `connect`/`disconnect`, `edit`, `remove`, `view`, and variation edit/remove) now resolve the target slice/variation via `id` rather than `name`.
> 
> **Content type commands follow the same shift.** Type commands (`edit`, `remove`, `view`, tab add/edit/remove) now resolve content types via `id` rather than `label`, and shared field-model resolution in `src/models.ts` updates `--to-*`/`--from-*` options and lookups accordingly.
> 
> Tests and `--help` expectations are updated throughout to pass IDs and assert the new output/messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc4c3ff01d048547231bca3a802ccd42ceec5b80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->