### PR TITLE
fix: poll CT API for consistency in sync tests

### DIFF
--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -47,6 +47,32 @@ export async function deleteRepository(
 	}
 }
 
+export async function getCustomTypes(config: RepoConfig): Promise<{ id: string }[]> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("customtypes", `https://customtypes.${host}/`);
+	const res = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${config.token}`,
+			repository: config.repo,
+		},
+	});
+	if (!res.ok) throw new Error(`Failed to get custom types: ${res.status} ${await res.text()}`);
+	return await res.json();
+}
+
+export async function getSlices(config: RepoConfig): Promise<{ id: string }[]> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("slices", `https://customtypes.${host}/`);
+	const res = await fetch(url, {
+		headers: {
+			Authorization: `Bearer ${config.token}`,
+			repository: config.repo,
+		},
+	});
+	if (!res.ok) throw new Error(`Failed to get slices: ${res.status} ${await res.text()}`);
+	return await res.json();
+}
+
 export async function insertCustomType(customType: object, config: RepoConfig): Promise<void> {
 	const host = config.host ?? DEFAULT_HOST;
 	const url = new URL("customtypes/insert", `https://customtypes.${host}/`);

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,5 +1,6 @@
 import { writeFile, mkdir } from "node:fs/promises";
 
+import { getCustomTypes, getSlices } from "../src/clients/custom-types";
 import { buildCustomType, buildSlice, captureOutput, it } from "./it";
 import { deleteCustomType, deleteSlice, insertCustomType, insertSlice } from "./prismic";
 
@@ -82,6 +83,10 @@ it("adds new slice to existing library on re-sync", async ({
 	// Insert a second slice remotely
 	const sliceB = buildSlice();
 	await insertSlice(sliceB, { repo, token, host });
+	await expect.poll(
+		async () => (await getSlices({ repo, token, host })).map((s) => s.id),
+		{ timeout: 5_000 },
+	).toContain(sliceB.id);
 
 	// Second sync — should add slice B without breaking slice A
 	const second = await prismic("sync", ["--repo", repo]);
@@ -114,6 +119,10 @@ it("removes deleted slice and updates index on re-sync", async ({
 
 	// Delete slice B from remote
 	await deleteSlice(sliceB.id, { repo, token, host });
+	await expect.poll(
+		async () => (await getSlices({ repo, token, host })).map((s) => s.id),
+		{ timeout: 5_000 },
+	).not.toContain(sliceB.id);
 
 	// Second sync — should remove slice B and update the index
 	const second = await prismic("sync", ["--repo", repo]);
@@ -199,6 +208,10 @@ it("removes route when page type is deleted", async ({
 	await expect(project).toHaveRoute({ type: customType.id });
 
 	await deleteCustomType(customType.id, { repo, token, host });
+	await expect.poll(
+		async () => (await getCustomTypes({ repo, token, host })).map((ct) => ct.id),
+		{ timeout: 5_000 },
+	).not.toContain(customType.id);
 
 	// Second sync — removes the route
 	const second = await prismic("sync", ["--repo", repo]);

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -1,8 +1,14 @@
 import { writeFile, mkdir } from "node:fs/promises";
 
-import { getCustomTypes, getSlices } from "../src/clients/custom-types";
 import { buildCustomType, buildSlice, captureOutput, it } from "./it";
-import { deleteCustomType, deleteSlice, insertCustomType, insertSlice } from "./prismic";
+import {
+	deleteCustomType,
+	deleteSlice,
+	getCustomTypes,
+	getSlices,
+	insertCustomType,
+	insertSlice,
+} from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("sync", ["--help"]);


### PR DESCRIPTION
Resolves: #119

### Description

After mutating the Custom Types API (insert/delete), sync tests now poll the GET endpoint using Vitest's `expect.poll()` until the mutation is reflected before running `prismic sync`. This prevents flaky failures caused by API eventual consistency.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

CI sync tests should pass more reliably.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to test utilities and sync E2E tests, adding polling to reduce flakiness from eventual consistency in Prismic’s Custom Types API.
> 
> **Overview**
> Improves `sync` integration test stability by waiting for Prismic Custom Types API mutations to become visible before running subsequent `prismic sync` assertions.
> 
> Adds `getCustomTypes()` and `getSlices()` helpers in `test/prismic.ts`, and updates relevant `test/sync.test.ts` cases to use `expect.poll()` (with a short timeout) after slice/custom type insertions or deletions so tests don’t race API propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62580d57710c56afbf299d80c59fcacbe804af71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->