### PR TITLE
refactor: add `getCustomType` and `getSlice` client functions

### DIFF
--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -1,6 +1,6 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { request } from "../lib/request";
+import { NotFoundRequestError, request } from "../lib/request";
 
 export async function getCustomTypes(config: {
 	repo: string;
@@ -14,6 +14,25 @@ export async function getCustomTypes(config: {
 		headers: { repository: repo, Authorization: `Bearer ${token}` },
 	});
 	return response;
+}
+
+export async function getCustomType(
+	id: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<CustomType> {
+	const { repo, token, host } = config;
+	const customTypesServiceUrl = getCustomTypesServiceUrl(host);
+	const url = new URL(`customtypes/${encodeURIComponent(id)}`, customTypesServiceUrl);
+	try {
+		return await request<CustomType>(url, {
+			headers: { repository: repo, Authorization: `Bearer ${token}` },
+		});
+	} catch (error) {
+		if (error instanceof NotFoundRequestError) {
+			error.message = `Type not found: ${id}`;
+		}
+		throw error;
+	}
 }
 
 export async function insertCustomType(
@@ -69,6 +88,25 @@ export async function getSlices(config: {
 		headers: { repository: repo, Authorization: `Bearer ${token}` },
 	});
 	return response;
+}
+
+export async function getSlice(
+	id: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<SharedSlice> {
+	const { repo, token, host } = config;
+	const customTypesServiceUrl = getCustomTypesServiceUrl(host);
+	const url = new URL(`slices/${encodeURIComponent(id)}`, customTypesServiceUrl);
+	try {
+		return await request<SharedSlice>(url, {
+			headers: { repository: repo, Authorization: `Bearer ${token}` },
+		});
+	} catch (error) {
+		if (error instanceof NotFoundRequestError) {
+			error.message = `Slice not found: ${id}`;
+		}
+		throw error;
+	}
 }
 
 export async function insertSlice(

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -4,7 +4,7 @@ import { camelCase } from "change-case";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlices, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -29,12 +29,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.id === to);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${to}`);
-	}
+	const slice = await getSlice(to, { repo, token, host });
 
 	if (slice.variations.some((v) => v.id === id)) {
 		throw new CommandError(`Variation "${id}" already exists in slice "${to}".`);

--- a/src/commands/slice-connect.ts
+++ b/src/commands/slice-connect.ts
@@ -2,7 +2,7 @@ import type { DynamicWidget } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, getSlices, updateCustomType } from "../clients/custom-types";
+import { getCustomType, getSlice, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -36,17 +36,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const host = await getHost();
 	const apiConfig = { repo, token, host };
 
-	const slices = await getSlices(apiConfig);
-	const slice = slices.find((s) => s.id === id);
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${id}`);
-	}
-
-	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.id === to);
-	if (!customType) {
-		throw new CommandError(`Type not found: ${to}`);
-	}
+	const slice = await getSlice(id, apiConfig);
+	const customType = await getCustomType(to, apiConfig);
 
 	const allFields: Record<string, DynamicWidget> = Object.assign(
 		{},

--- a/src/commands/slice-disconnect.ts
+++ b/src/commands/slice-disconnect.ts
@@ -2,7 +2,7 @@ import type { DynamicWidget } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, getSlices, updateCustomType } from "../clients/custom-types";
+import { getCustomType, getSlice, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -36,17 +36,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const host = await getHost();
 	const apiConfig = { repo, token, host };
 
-	const slices = await getSlices(apiConfig);
-	const slice = slices.find((s) => s.id === id);
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${id}`);
-	}
-
-	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.id === from);
-	if (!customType) {
-		throw new CommandError(`Type not found: ${from}`);
-	}
+	const slice = await getSlice(id, apiConfig);
+	const customType = await getCustomType(from, apiConfig);
 
 	const allFields: Record<string, DynamicWidget> = Object.assign(
 		{},

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -2,7 +2,7 @@ import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlices, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -27,12 +27,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.id === sliceId);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${sliceId}`);
-	}
+	const slice = await getSlice(sliceId, { repo, token, host });
 
 	const variation = slice.variations.find((v) => v.id === id);
 

--- a/src/commands/slice-edit.ts
+++ b/src/commands/slice-edit.ts
@@ -2,7 +2,7 @@ import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlices, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -26,12 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.id === id);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${id}`);
-	}
+	const slice = await getSlice(id, { repo, token, host });
 
 	const updatedSlice: SharedSlice = { ...slice };
 

--- a/src/commands/slice-remove-variation.ts
+++ b/src/commands/slice-remove-variation.ts
@@ -2,7 +2,7 @@ import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlices, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -26,12 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.id === from);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${from}`);
-	}
+	const slice = await getSlice(from, { repo, token, host });
 
 	const variation = slice.variations.find((v) => v.id === id);
 

--- a/src/commands/slice-remove.ts
+++ b/src/commands/slice-remove.ts
@@ -1,6 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlices, removeSlice } from "../clients/custom-types";
+import { getSlice, removeSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -23,12 +23,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((s) => s.id === id);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${id}`);
-	}
+	const slice = await getSlice(id, { repo, token, host });
 
 	try {
 		await removeSlice(slice.id, { repo, host, token });

--- a/src/commands/slice-view.ts
+++ b/src/commands/slice-view.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
-import { getSlices } from "../clients/custom-types";
-import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { getSlice } from "../clients/custom-types";
+import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
 import { getRepositoryName } from "../project";
@@ -23,12 +23,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
-	const slice = slices.find((slice) => slice.id === id);
-
-	if (!slice) {
-		throw new CommandError(`Slice not found: ${id}`);
-	}
+	const slice = await getSlice(id, { repo, token, host });
 
 	if (json) {
 		console.info(stringify(slice));

--- a/src/commands/type-add-tab.ts
+++ b/src/commands/type-add-tab.ts
@@ -1,6 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -25,18 +25,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.id === to);
+	const customType = await getCustomType(to, { repo, token, host });
 
-	if (!type) {
-		throw new CommandError(`Type not found: ${to}`);
-	}
-
-	if (name in type.json) {
+	if (name in customType.json) {
 		throw new CommandError(`Tab "${name}" already exists in "${to}".`);
 	}
 
-	type.json[name] = withSliceZone
+	customType.json[name] = withSliceZone
 		? {
 				slices: {
 					type: "Slices",
@@ -47,7 +42,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		: {};
 
 	try {
-		await updateCustomType(type, { repo, host, token });
+		await updateCustomType(customType, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -57,9 +52,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.updateCustomType(type);
+		await adapter.updateCustomType(customType);
 	} catch {
-		await adapter.createCustomType(type);
+		await adapter.createCustomType(customType);
 	}
 	await adapter.generateTypes();
 

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -2,7 +2,7 @@ import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -29,14 +29,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.id === typeId);
+	const customType = await getCustomType(typeId, { repo, token, host });
 
-	if (!type) {
-		throw new CommandError(`Type not found: ${typeId}`);
-	}
-
-	if (!(currentName in type.json)) {
+	if (!(currentName in customType.json)) {
 		throw new CommandError(`Tab "${currentName}" not found in "${typeId}".`);
 	}
 
@@ -45,7 +40,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	if ("with-slice-zone" in values) {
-		const tab = type.json[currentName];
+		const tab = customType.json[currentName];
 		const hasSliceZone = Object.values(tab).some((field) => field.type === "Slices");
 
 		if (hasSliceZone) {
@@ -60,7 +55,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	if ("without-slice-zone" in values) {
-		const tab = type.json[currentName];
+		const tab = customType.json[currentName];
 		const sliceZoneEntry = Object.entries(tab).find(([, field]) => field.type === "Slices");
 
 		if (!sliceZoneEntry) {
@@ -81,19 +76,19 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	if ("name" in values) {
-		if (values.name! in type.json) {
+		if (values.name! in customType.json) {
 			throw new CommandError(`Tab "${values.name}" already exists in "${typeId}".`);
 		}
 
 		const newJson: CustomType["json"] = {};
-		for (const [key, value] of Object.entries(type.json)) {
+		for (const [key, value] of Object.entries(customType.json)) {
 			newJson[key === currentName ? values.name! : key] = value;
 		}
-		type.json = newJson;
+		customType.json = newJson;
 	}
 
 	try {
-		await updateCustomType(type, { repo, host, token });
+		await updateCustomType(customType, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -103,9 +98,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.updateCustomType(type);
+		await adapter.updateCustomType(customType);
 	} catch {
-		await adapter.createCustomType(type);
+		await adapter.createCustomType(customType);
 	}
 	await adapter.generateTypes();
 

--- a/src/commands/type-edit.ts
+++ b/src/commands/type-edit.ts
@@ -1,6 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -29,18 +29,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.id === id);
+	const customType = await getCustomType(id, { repo, token, host });
 
-	if (!type) {
-		throw new CommandError(`Type not found: ${id}`);
-	}
-
-	if ("name" in values) type.label = values.name;
-	if ("format" in values) type.format = values.format as "custom" | "page";
+	if ("name" in values) customType.label = values.name;
+	if ("format" in values) customType.format = values.format as "custom" | "page";
 
 	try {
-		await updateCustomType(type, { repo, host, token });
+		await updateCustomType(customType, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -50,11 +45,11 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.updateCustomType(type);
+		await adapter.updateCustomType(customType);
 	} catch {
-		await adapter.createCustomType(type);
+		await adapter.createCustomType(customType);
 	}
 	await adapter.generateTypes();
 
-	console.info(`Type updated: "${type.label}" (id: ${type.id})`);
+	console.info(`Type updated: "${customType.label}" (id: ${customType.id})`);
 });

--- a/src/commands/type-remove-tab.ts
+++ b/src/commands/type-remove-tab.ts
@@ -1,6 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, updateCustomType } from "../clients/custom-types";
+import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -24,25 +24,20 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.id === from);
+	const customType = await getCustomType(from, { repo, token, host });
 
-	if (!type) {
-		throw new CommandError(`Type not found: ${from}`);
-	}
-
-	if (!(name in type.json)) {
+	if (!(name in customType.json)) {
 		throw new CommandError(`Tab "${name}" not found in "${from}".`);
 	}
 
-	if (Object.keys(type.json).length <= 1) {
+	if (Object.keys(customType.json).length <= 1) {
 		throw new CommandError(`Cannot remove the last tab from "${from}".`);
 	}
 
-	delete type.json[name];
+	delete customType.json[name];
 
 	try {
-		await updateCustomType(type, { repo, host, token });
+		await updateCustomType(customType, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -52,9 +47,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.updateCustomType(type);
+		await adapter.updateCustomType(customType);
 	} catch {
-		await adapter.createCustomType(type);
+		await adapter.createCustomType(customType);
 	}
 	await adapter.generateTypes();
 

--- a/src/commands/type-remove.ts
+++ b/src/commands/type-remove.ts
@@ -1,6 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getCustomTypes, removeCustomType } from "../clients/custom-types";
+import { getCustomType, removeCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -23,15 +23,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const adapter = await getAdapter();
 	const token = await getToken();
 	const host = await getHost();
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const type = customTypes.find((ct) => ct.id === id);
-
-	if (!type) {
-		throw new CommandError(`Type not found: ${id}`);
-	}
+	const customType = await getCustomType(id, { repo, token, host });
 
 	try {
-		await removeCustomType(type.id, { repo, host, token });
+		await removeCustomType(customType.id, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -41,7 +36,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.deleteCustomType(type.id);
+		await adapter.deleteCustomType(customType.id);
 	} catch {}
 	await adapter.generateTypes();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,11 @@ import webhook from "./commands/webhook";
 import whoami from "./commands/whoami";
 import { InvalidPrismicConfig, MissingPrismicConfig } from "./config";
 import { CommandError, createCommandRouter } from "./lib/command";
-import { ForbiddenRequestError, UnauthorizedRequestError } from "./lib/request";
+import {
+	ForbiddenRequestError,
+	NotFoundRequestError,
+	UnauthorizedRequestError,
+} from "./lib/request";
 import {
 	initSegment,
 	segmentIdentify,
@@ -195,6 +199,11 @@ async function main(): Promise<void> {
 
 		if (error instanceof UnauthorizedRequestError || error instanceof ForbiddenRequestError) {
 			console.error("Not logged in. Run `prismic login` first.");
+			return;
+		}
+
+		if (error instanceof NotFoundRequestError) {
+			console.error(error.message);
 			return;
 		}
 

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -94,7 +94,7 @@ export class NotFoundRequestError extends RequestError {
 
 	constructor(response: Response) {
 		super(response);
-		this.message = "Not found.";
+		this.message = `Not found: ${response.url}`;
 	}
 }
 export class ForbiddenRequestError extends RequestError {

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -91,6 +91,11 @@ export class UnknownRequestError extends RequestError {
 }
 export class NotFoundRequestError extends RequestError {
 	name = "NotFoundRequestError";
+
+	constructor(response: Response) {
+		super(response);
+		this.message = "Not found.";
+	}
 }
 export class ForbiddenRequestError extends RequestError {
 	name = "ForbiddenRequestError";

--- a/src/models.ts
+++ b/src/models.ts
@@ -3,7 +3,7 @@ import type { DynamicWidget } from "@prismicio/types-internal/lib/customtypes";
 import type { CommandConfig } from "./lib/command";
 
 import { getAdapter } from "./adapters";
-import { getCustomTypes, getSlices, updateCustomType, updateSlice } from "./clients/custom-types";
+import { getCustomType, getSlice, updateCustomType, updateSlice } from "./clients/custom-types";
 import { CommandError } from "./lib/command";
 import { UnknownRequestError } from "./lib/request";
 
@@ -54,11 +54,7 @@ export async function resolveFieldContainer(
 	}
 
 	if (fromSlice) {
-		const slices = await getSlices(apiConfig);
-		const slice = slices.find((s) => s.id === fromSlice);
-		if (!slice) {
-			throw new CommandError(`Slice not found: ${fromSlice}`);
-		}
+		const slice = await getSlice(fromSlice, apiConfig);
 		const variation = slice.variations.find((v) => v.id === variationId);
 		if (!variation) {
 			const variationIds = slice.variations?.map((v) => v.id).join(", ") || "(none)";
@@ -81,11 +77,7 @@ export async function resolveFieldContainer(
 		];
 	}
 
-	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.id === fromType);
-	if (!customType) {
-		throw new CommandError(`Type not found: ${fromType}`);
-	}
+	const customType = await getCustomType(fromType!, apiConfig);
 	let tab: Record<string, DynamicWidget> | undefined;
 	for (const tabName in customType.json) {
 		if (id in customType.json[tabName]) tab = customType.json[tabName];
@@ -139,11 +131,7 @@ export async function resolveModel(
 		}
 
 		const variation = values.variation ?? "default";
-		const slices = await getSlices(apiConfig);
-		const slice = slices.find((s) => s.id === sliceId);
-		if (!slice) {
-			throw new CommandError(`Slice not found: ${sliceId}`);
-		}
+		const slice = await getSlice(sliceId, apiConfig);
 
 		const newModel = structuredClone(slice);
 		const newVariation = newModel.variations?.find((v) => v.id === variation);
@@ -181,11 +169,7 @@ export async function resolveModel(
 	}
 
 	const tab = values.tab ?? "Main";
-	const customTypes = await getCustomTypes(apiConfig);
-	const customType = customTypes.find((ct) => ct.id === typeId);
-	if (!customType) {
-		throw new CommandError(`Type not found: ${typeId}`);
-	}
+	const customType = await getCustomType(typeId!, apiConfig);
 
 	const newModel = structuredClone(customType);
 	const newTab = newModel.json[tab];


### PR DESCRIPTION
Resolves:

### Description

Replace the `getCustomTypes().find()` and `getSlices().find()` patterns with dedicated single-resource fetch functions that set contextual error messages on `NotFoundRequestError`. Add a central handler in the root router to print those messages.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run any type or slice command with a nonexistent ID:
```
prismic type edit nonexistent-id -r your-repo
# → "Type not found: nonexistent-id"

prismic slice view nonexistent-id -r your-repo
# → "Slice not found: nonexistent-id"
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because multiple CLI commands now depend on new single-resource endpoints and centralized `404` handling, which could change behavior if the API routes or error mapping differ from the previous list-and-filter approach.
> 
> **Overview**
> **Refactors type/slice lookups to use dedicated single-resource API calls.** Adds `getCustomType(id)` and `getSlice(id)` client helpers that request `customtypes/{id}` and `slices/{id}`, and rewrite `404` errors to contextual messages (e.g. `Type not found: ...`).
> 
> Updates the various `slice-*`, `type-*`, and `models.ts` flows to call these helpers instead of `getCustomTypes()/getSlices()` + `.find()`, removing local “not found” checks in those commands.
> 
> **Improves CLI error output for missing resources.** `NotFoundRequestError` now defaults to a `Not found: <url>` message, and `src/index.ts` centrally catches `NotFoundRequestError` to print the (potentially contextual) message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6522d79987c29bb6190b9ef8876bfb5a3f50828. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->