### PR TITLE
feat: handle type removal when documents exist

### DIFF
--- a/src/commands/type-remove.ts
+++ b/src/commands/type-remove.ts
@@ -30,6 +30,11 @@ export default createCommand(config, async ({ positionals, values }) => {
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
+			if (message.includes("associated documents")) {
+				throw new CommandError(
+					`Type "${id}" has documents. Delete its documents before removing the type.`,
+				);
+			}
 			throw new CommandError(`Failed to remove type: ${message}`);
 		}
 		throw error;


### PR DESCRIPTION
Resolves: #99

### Description

Show a clear error when removing a type that has documents, telling the user to delete its documents first.

### Checklist

- [x] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic type remove <id>` on a type that has documents. The error should read:

```
Type "<id>" has documents. Delete its documents before removing the type.
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts CLI error handling/messages for a specific backend failure case and does not change deletion behavior or data flow.
> 
> **Overview**
> Improves `prismic type remove` error handling by detecting the “associated documents” backend error and returning a clearer `CommandError` telling the user to delete documents before removing the type.
> 
> All other unknown request failures continue to surface as `Failed to remove type: ...`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa07e498f2ab2c0a4fbed5444c0197e5d8cf2188. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->