### PR TITLE
feat: add `--screenshot` option to `slice add-variation` and `slice edit-variation`

### DIFF
--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -176,7 +176,7 @@ const AclCreateResponseSchema = z.object({
 	imgixEndpoint: z.string(),
 });
 
-const MIME_TYPE_EXTENSIONS: Record<string, string> = {
+const SUPPORTED_IMAGE_MIME_TYPES: Record<string, string> = {
 	"image/png": ".png",
 	"image/jpeg": ".jpg",
 	"image/gif": ".gif",
@@ -196,7 +196,7 @@ export async function uploadScreenshot(
 	const { sliceId, variationId, repo, token, host } = config;
 
 	const type = blob.type;
-	if (!(type in MIME_TYPE_EXTENSIONS)) {
+	if (!(type in SUPPORTED_IMAGE_MIME_TYPES)) {
 		throw new UnsupportedFileTypeError(type);
 	}
 
@@ -206,7 +206,7 @@ export async function uploadScreenshot(
 		schema: AclCreateResponseSchema,
 	});
 
-	const extension = MIME_TYPE_EXTENSIONS[type];
+	const extension = SUPPORTED_IMAGE_MIME_TYPES[type];
 	const digest = createHash("md5")
 		.update(new Uint8Array(await blob.arrayBuffer()))
 		.digest("hex");
@@ -232,7 +232,7 @@ export class UnsupportedFileTypeError extends Error {
 	name = "UnsupportedFileTypeError";
 
 	constructor(mimeType: string) {
-		const supportedTypes = Object.keys(MIME_TYPE_EXTENSIONS);
+		const supportedTypes = Object.keys(SUPPORTED_IMAGE_MIME_TYPES);
 		super(
 			`Unsupported file type: ${mimeType || "unknown"}. Supported: ${supportedTypes.join(", ")}`,
 		);

--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -2,7 +2,6 @@ import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/cust
 
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { extname } from "node:path";
 
 import * as z from "zod/mini";
 
@@ -193,7 +192,7 @@ export async function uploadScreenshot(
 ): Promise<string> {
 	const { repo, sliceId, variationId, token, host } = config;
 
-	const { data, ext } = await resolveScreenshotSource(source);
+	const { blob, ext } = await resolveScreenshotSource(source);
 
 	const mimeType = MIME_TYPES[ext];
 	if (!mimeType) {
@@ -203,7 +202,9 @@ export async function uploadScreenshot(
 		);
 	}
 
-	const digest = createHash("md5").update(data).digest("hex");
+	const digest = createHash("md5")
+		.update(new Uint8Array(await blob.arrayBuffer()))
+		.digest("hex");
 	const key = `${repo}/shared-slices/${sliceId}/${variationId}/${digest}${ext}`;
 
 	const aclUrl = new URL("create", getAclProviderUrl(host));
@@ -218,8 +219,7 @@ export async function uploadScreenshot(
 	}
 	formData.append("key", key);
 	formData.append("Content-Type", mimeType);
-	const fileBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
-	formData.append("file", new Blob([fileBuffer], { type: mimeType }));
+	formData.append("file", new Blob([blob], { type: mimeType }));
 
 	await request(acl.values.url, { method: "POST", body: formData });
 
@@ -230,7 +230,7 @@ export async function uploadScreenshot(
 
 async function resolveScreenshotSource(
 	source: string,
-): Promise<{ data: Uint8Array; ext: string }> {
+): Promise<{ blob: Blob; ext: string }> {
 	if (URL.canParse(source)) {
 		const url = new URL(source);
 		if (url.protocol === "http:" || url.protocol === "https:") {
@@ -241,15 +241,14 @@ async function resolveScreenshotSource(
 				);
 			}
 
-			let ext = extname(url.pathname).toLowerCase();
+			let ext = extname(url.pathname);
 			if (!MIME_TYPES[ext]) {
 				const contentType = response.headers.get("content-type")?.split(";")[0].trim();
 				const match = Object.entries(MIME_TYPES).find(([, mime]) => mime === contentType);
 				ext = match?.[0] ?? ext;
 			}
 
-			const data = new Uint8Array(await response.arrayBuffer());
-			return { data, ext };
+			return { blob: await response.blob(), ext };
 		}
 	}
 
@@ -263,8 +262,13 @@ async function resolveScreenshotSource(
 		throw error;
 	}
 
-	const ext = extname(source).toLowerCase();
-	return { data, ext };
+	const ext = extname(source);
+	return { blob: new Blob([data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer]), ext };
+}
+
+function extname(path: string): string {
+	const match = path.match(/\.\w+$/);
+	return match ? match[0].toLowerCase() : "";
 }
 
 function getCustomTypesServiceUrl(host: string): URL {

--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -1,12 +1,10 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { createHash } from "node:crypto";
-import { readFile } from "node:fs/promises";
-
 import * as z from "zod/mini";
 
-import { CommandError } from "../lib/command";
 import { NotFoundRequestError, request } from "../lib/request";
+import { appendTrailingSlash } from "../lib/url";
 
 export async function getCustomTypes(config: {
 	repo: string;
@@ -178,34 +176,29 @@ const AclCreateResponseSchema = z.object({
 	imgixEndpoint: z.string(),
 });
 
-const MIME_TYPES: Record<string, string> = {
-	".png": "image/png",
-	".jpg": "image/jpeg",
-	".jpeg": "image/jpeg",
-	".gif": "image/gif",
-	".webp": "image/webp",
+const MIME_TYPE_EXTENSIONS: Record<string, string> = {
+	"image/png": ".png",
+	"image/jpeg": ".jpg",
+	"image/gif": ".gif",
+	"image/webp": ".webp",
 };
 
 export async function uploadScreenshot(
-	source: string,
-	config: { repo: string; sliceId: string; variationId: string; token: string | undefined; host: string },
-): Promise<string> {
-	const { repo, sliceId, variationId, token, host } = config;
+	blob: Blob,
+	config: {
+		sliceId: string;
+		variationId: string;
+		repo: string;
+		token: string | undefined;
+		host: string;
+	},
+): Promise<URL> {
+	const { sliceId, variationId, repo, token, host } = config;
 
-	const { blob, ext } = await resolveScreenshotSource(source);
-
-	const mimeType = MIME_TYPES[ext];
-	if (!mimeType) {
-		const supported = Object.keys(MIME_TYPES).join(", ");
-		throw new CommandError(
-			`Unsupported screenshot format "${ext}". Supported: ${supported}`,
-		);
+	const type = blob.type;
+	if (!(type in MIME_TYPE_EXTENSIONS)) {
+		throw new UnsupportedFileTypeError(type);
 	}
-
-	const digest = createHash("md5")
-		.update(new Uint8Array(await blob.arrayBuffer()))
-		.digest("hex");
-	const key = `${repo}/shared-slices/${sliceId}/${variationId}/${digest}${ext}`;
 
 	const aclUrl = new URL("create", getAclProviderUrl(host));
 	const acl = await request(aclUrl, {
@@ -213,62 +206,37 @@ export async function uploadScreenshot(
 		schema: AclCreateResponseSchema,
 	});
 
+	const extension = MIME_TYPE_EXTENSIONS[type];
+	const digest = createHash("md5")
+		.update(new Uint8Array(await blob.arrayBuffer()))
+		.digest("hex");
+	const key = `${repo}/shared-slices/${sliceId}/${variationId}/${digest}${extension}`;
+
 	const formData = new FormData();
 	for (const [field, value] of Object.entries(acl.values.fields)) {
 		formData.append(field, value);
 	}
 	formData.append("key", key);
-	formData.append("Content-Type", mimeType);
-	formData.append("file", new Blob([blob], { type: mimeType }));
+	formData.append("Content-Type", type);
+	formData.append("file", blob);
 
 	await request(acl.values.url, { method: "POST", body: formData });
 
-	const url = new URL(key, acl.imgixEndpoint);
+	const url = new URL(key, appendTrailingSlash(acl.imgixEndpoint));
 	url.searchParams.set("auto", "compress,format");
-	return url.toString();
+
+	return url;
 }
 
-async function resolveScreenshotSource(
-	source: string,
-): Promise<{ blob: Blob; ext: string }> {
-	if (URL.canParse(source)) {
-		const url = new URL(source);
-		if (url.protocol === "http:" || url.protocol === "https:") {
-			const response = await fetch(source);
-			if (!response.ok) {
-				throw new CommandError(
-					`Failed to download screenshot from "${source}" (HTTP ${response.status}).`,
-				);
-			}
+export class UnsupportedFileTypeError extends Error {
+	name = "UnsupportedFileTypeError";
 
-			let ext = extname(url.pathname);
-			if (!MIME_TYPES[ext]) {
-				const contentType = response.headers.get("content-type")?.split(";")[0].trim();
-				const match = Object.entries(MIME_TYPES).find(([, mime]) => mime === contentType);
-				ext = match?.[0] ?? ext;
-			}
-
-			return { blob: await response.blob(), ext };
-		}
+	constructor(mimeType: string) {
+		const supportedTypes = Object.keys(MIME_TYPE_EXTENSIONS);
+		super(
+			`Unsupported file type: ${mimeType || "unknown"}. Supported: ${supportedTypes.join(", ")}`,
+		);
 	}
-
-	let data: Uint8Array;
-	try {
-		data = await readFile(source);
-	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-			throw new CommandError(`Screenshot file not found: ${source}`);
-		}
-		throw error;
-	}
-
-	const ext = extname(source);
-	return { blob: new Blob([data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer]), ext };
-}
-
-function extname(path: string): string {
-	const match = path.match(/\.\w+$/);
-	return match ? match[0].toLowerCase() : "";
 }
 
 function getCustomTypesServiceUrl(host: string): URL {

--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -171,11 +171,11 @@ export async function removeSlice(
 	});
 }
 
-const ACL_PROVIDER_URL = "https://acl-provider.prismic.io/create";
-
 const AclCreateResponseSchema = z.object({
-	uploadEndpoint: z.string(),
-	requiredFormDataFields: z.record(z.string(), z.string()),
+	values: z.object({
+		url: z.string(),
+		fields: z.record(z.string(), z.string()),
+	}),
 	imgixEndpoint: z.string(),
 });
 
@@ -189,47 +189,43 @@ const MIME_TYPES: Record<string, string> = {
 
 export async function uploadScreenshot(
 	source: string,
-	config: { repo: string; sliceId: string; variationId: string },
+	config: { repo: string; sliceId: string; variationId: string; token: string | undefined; host: string },
 ): Promise<string> {
-	const { repo, sliceId, variationId } = config;
+	const { repo, sliceId, variationId, token, host } = config;
 
 	const { data, ext } = await resolveScreenshotSource(source);
 
 	const mimeType = MIME_TYPES[ext];
 	if (!mimeType) {
+		const supported = Object.keys(MIME_TYPES).join(", ");
 		throw new CommandError(
-			`Unsupported screenshot format "${ext}". Supported: png, jpg, jpeg, gif, webp`,
+			`Unsupported screenshot format "${ext}". Supported: ${supported}`,
 		);
 	}
 
 	const digest = createHash("md5").update(data).digest("hex");
 	const key = `${repo}/shared-slices/${sliceId}/${variationId}/${digest}${ext}`;
 
-	const acl = await request(ACL_PROVIDER_URL, {
-		method: "POST",
-		body: {},
+	const aclUrl = new URL("create", getAclProviderUrl(host));
+	const acl = await request(aclUrl, {
+		headers: { Repository: repo, Authorization: `Bearer ${token}` },
 		schema: AclCreateResponseSchema,
 	});
 
 	const formData = new FormData();
-	for (const [field, value] of Object.entries(acl.requiredFormDataFields)) {
+	for (const [field, value] of Object.entries(acl.values.fields)) {
 		formData.append(field, value);
 	}
 	formData.append("key", key);
 	formData.append("Content-Type", mimeType);
-	formData.append("file", new Blob([data.buffer as ArrayBuffer], { type: mimeType }));
+	const fileBuffer = data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength) as ArrayBuffer;
+	formData.append("file", new Blob([fileBuffer], { type: mimeType }));
 
-	const uploadResponse = await fetch(acl.uploadEndpoint, {
-		method: "POST",
-		body: formData,
-	});
-	if (!uploadResponse.ok) {
-		throw new CommandError(
-			`Failed to upload screenshot (HTTP ${uploadResponse.status}).`,
-		);
-	}
+	await request(acl.values.url, { method: "POST", body: formData });
 
-	return `${acl.imgixEndpoint}/${key}?auto=compress,format`;
+	const url = new URL(key, acl.imgixEndpoint);
+	url.searchParams.set("auto", "compress,format");
+	return url.toString();
 }
 
 async function resolveScreenshotSource(
@@ -273,4 +269,8 @@ async function resolveScreenshotSource(
 
 function getCustomTypesServiceUrl(host: string): URL {
 	return new URL(`https://customtypes.${host}/`);
+}
+
+function getAclProviderUrl(host: string): URL {
+	return new URL(`https://acl-provider.${host}/`);
 }

--- a/src/clients/custom-types.ts
+++ b/src/clients/custom-types.ts
@@ -1,5 +1,12 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { extname } from "node:path";
+
+import * as z from "zod/mini";
+
+import { CommandError } from "../lib/command";
 import { NotFoundRequestError, request } from "../lib/request";
 
 export async function getCustomTypes(config: {
@@ -162,6 +169,106 @@ export async function removeSlice(
 		method: "DELETE",
 		headers: { repository: repo, Authorization: `Bearer ${token}` },
 	});
+}
+
+const ACL_PROVIDER_URL = "https://acl-provider.prismic.io/create";
+
+const AclCreateResponseSchema = z.object({
+	uploadEndpoint: z.string(),
+	requiredFormDataFields: z.record(z.string(), z.string()),
+	imgixEndpoint: z.string(),
+});
+
+const MIME_TYPES: Record<string, string> = {
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".webp": "image/webp",
+};
+
+export async function uploadScreenshot(
+	source: string,
+	config: { repo: string; sliceId: string; variationId: string },
+): Promise<string> {
+	const { repo, sliceId, variationId } = config;
+
+	const { data, ext } = await resolveScreenshotSource(source);
+
+	const mimeType = MIME_TYPES[ext];
+	if (!mimeType) {
+		throw new CommandError(
+			`Unsupported screenshot format "${ext}". Supported: png, jpg, jpeg, gif, webp`,
+		);
+	}
+
+	const digest = createHash("md5").update(data).digest("hex");
+	const key = `${repo}/shared-slices/${sliceId}/${variationId}/${digest}${ext}`;
+
+	const acl = await request(ACL_PROVIDER_URL, {
+		method: "POST",
+		body: {},
+		schema: AclCreateResponseSchema,
+	});
+
+	const formData = new FormData();
+	for (const [field, value] of Object.entries(acl.requiredFormDataFields)) {
+		formData.append(field, value);
+	}
+	formData.append("key", key);
+	formData.append("Content-Type", mimeType);
+	formData.append("file", new Blob([data.buffer as ArrayBuffer], { type: mimeType }));
+
+	const uploadResponse = await fetch(acl.uploadEndpoint, {
+		method: "POST",
+		body: formData,
+	});
+	if (!uploadResponse.ok) {
+		throw new CommandError(
+			`Failed to upload screenshot (HTTP ${uploadResponse.status}).`,
+		);
+	}
+
+	return `${acl.imgixEndpoint}/${key}?auto=compress,format`;
+}
+
+async function resolveScreenshotSource(
+	source: string,
+): Promise<{ data: Uint8Array; ext: string }> {
+	if (URL.canParse(source)) {
+		const url = new URL(source);
+		if (url.protocol === "http:" || url.protocol === "https:") {
+			const response = await fetch(source);
+			if (!response.ok) {
+				throw new CommandError(
+					`Failed to download screenshot from "${source}" (HTTP ${response.status}).`,
+				);
+			}
+
+			let ext = extname(url.pathname).toLowerCase();
+			if (!MIME_TYPES[ext]) {
+				const contentType = response.headers.get("content-type")?.split(";")[0].trim();
+				const match = Object.entries(MIME_TYPES).find(([, mime]) => mime === contentType);
+				ext = match?.[0] ?? ext;
+			}
+
+			const data = new Uint8Array(await response.arrayBuffer());
+			return { data, ext };
+		}
+	}
+
+	let data: Uint8Array;
+	try {
+		data = await readFile(source);
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+			throw new CommandError(`Screenshot file not found: ${source}`);
+		}
+		throw error;
+	}
+
+	const ext = extname(source).toLowerCase();
+	return { data, ext };
 }
 
 function getCustomTypesServiceUrl(host: string): URL {

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -42,6 +42,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 			repo,
 			sliceId: to,
 			variationId: id,
+			token,
+			host,
 		});
 	}
 

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -45,7 +45,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	let imageUrl = "";
 	if (screenshot) {
-		const url = URL.canParse(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
+		const url = /^https?:\/\//i.test(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
 		const blob = await readURLFile(url);
 		let screenshotUrl;
 		try {

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -1,11 +1,18 @@
 import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { camelCase } from "change-case";
+import { pathToFileURL } from "node:url";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice, uploadScreenshot } from "../clients/custom-types";
+import {
+	getSlice,
+	UnsupportedFileTypeError,
+	updateSlice,
+	uploadScreenshot,
+} from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { readURLFile } from "../lib/file";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
 
@@ -25,7 +32,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const { to, id = camelCase(name), repo = await getRepositoryName() } = values;
+	const { to, id = camelCase(name), screenshot, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
@@ -37,14 +44,25 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	let imageUrl = "";
-	if (values.screenshot) {
-		imageUrl = await uploadScreenshot(values.screenshot, {
-			repo,
-			sliceId: to,
-			variationId: id,
-			token,
-			host,
-		});
+	if (screenshot) {
+		const url = URL.canParse(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
+		const blob = await readURLFile(url);
+		let screenshotUrl;
+		try {
+			screenshotUrl = await uploadScreenshot(blob, {
+				sliceId: slice.id,
+				variationId: id,
+				repo,
+				token,
+				host,
+			});
+		} catch (error) {
+			if (error instanceof UnsupportedFileTypeError) {
+				throw new CommandError(error.message);
+			}
+			throw error;
+		}
+		imageUrl = screenshotUrl.toString();
 	}
 
 	const updatedSlice: SharedSlice = {

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -4,7 +4,7 @@ import { camelCase } from "change-case";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice, uploadScreenshot } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,6 +18,7 @@ const config = {
 	options: {
 		to: { type: "string", required: true, description: "ID of the slice" },
 		id: { type: "string", description: "Custom ID for the variation" },
+		screenshot: { type: "string", short: "s", description: "Screenshot image file path or URL" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
@@ -35,6 +36,15 @@ export default createCommand(config, async ({ positionals, values }) => {
 		throw new CommandError(`Variation "${id}" already exists in slice "${to}".`);
 	}
 
+	let imageUrl = "";
+	if (values.screenshot) {
+		imageUrl = await uploadScreenshot(values.screenshot, {
+			repo,
+			sliceId: to,
+			variationId: id,
+		});
+	}
+
 	const updatedSlice: SharedSlice = {
 		...slice,
 		variations: [
@@ -44,7 +54,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 				name,
 				description: name,
 				docURL: "",
-				imageUrl: "",
+				imageUrl,
 				version: "",
 				primary: {},
 			},

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -1,9 +1,15 @@
-import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
+import { pathToFileURL } from "node:url";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice, uploadScreenshot } from "../clients/custom-types";
+import {
+	getSlice,
+	UnsupportedFileTypeError,
+	updateSlice,
+	uploadScreenshot,
+} from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { readURLFile } from "../lib/file";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
 
@@ -23,7 +29,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { "from-slice": sliceId, repo = await getRepositoryName() } = values;
+	const { "from-slice": sliceId, screenshot, repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
 	const token = await getToken();
@@ -31,27 +37,35 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const slice = await getSlice(sliceId, { repo, token, host });
 
 	const variation = slice.variations.find((v) => v.id === id);
-
 	if (!variation) {
 		throw new CommandError(`Variation "${id}" not found in slice "${sliceId}".`);
 	}
 
 	if ("name" in values) variation.name = values.name!;
 
-	if (values.screenshot) {
-		variation.imageUrl = await uploadScreenshot(values.screenshot, {
-			repo,
-			sliceId: sliceId,
-			variationId: id,
-			token,
-			host,
-		});
+	if (screenshot) {
+		const url = URL.canParse(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
+		const blob = await readURLFile(url);
+		let screenshotUrl;
+		try {
+			screenshotUrl = await uploadScreenshot(blob, {
+				sliceId: slice.id,
+				variationId: variation.id,
+				repo,
+				token,
+				host,
+			});
+		} catch (error) {
+			if (error instanceof UnsupportedFileTypeError) {
+				throw new CommandError(error.message);
+			}
+			throw error;
+		}
+		variation.imageUrl = screenshotUrl.toString();
 	}
 
-	const updatedSlice: SharedSlice = { ...slice };
-
 	try {
-		await updateSlice(updatedSlice, { repo, host, token });
+		await updateSlice(slice, { repo, host, token });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -61,9 +75,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	try {
-		await adapter.updateSlice(updatedSlice);
+		await adapter.updateSlice(slice);
 	} catch {
-		await adapter.createSlice(updatedSlice);
+		await adapter.createSlice(slice);
 	}
 	await adapter.generateTypes();
 

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -2,7 +2,7 @@ import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice } from "../clients/custom-types";
+import { getSlice, updateSlice, uploadScreenshot } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -16,6 +16,7 @@ const config = {
 	options: {
 		"from-slice": { type: "string", required: true, description: "ID of the slice" },
 		name: { type: "string", short: "n", description: "New name for the variation" },
+		screenshot: { type: "string", short: "s", description: "Screenshot image file path or URL" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
@@ -36,6 +37,14 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	if ("name" in values) variation.name = values.name!;
+
+	if (values.screenshot) {
+		variation.imageUrl = await uploadScreenshot(values.screenshot, {
+			repo,
+			sliceId: sliceId,
+			variationId: id,
+		});
+	}
 
 	const updatedSlice: SharedSlice = { ...slice };
 

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -44,7 +44,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	if ("name" in values) variation.name = values.name!;
 
 	if (screenshot) {
-		const url = URL.canParse(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
+		const url = /^https?:\/\//i.test(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
 		const blob = await readURLFile(url);
 		let screenshotUrl;
 		try {

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -43,6 +43,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 			repo,
 			sliceId: sliceId,
 			variationId: id,
+			token,
+			host,
 		});
 	}
 

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -2,7 +2,7 @@ import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import * as z from "zod/mini";
 
-import { appendTrailingSlash } from "./url";
+import { appendTrailingSlash, getExtension } from "./url";
 
 export async function findUpward(
 	name: string,
@@ -67,4 +67,35 @@ export async function readJsonFile<T = unknown>(
 	const json = JSON.parse(file);
 	if (schema) return z.parse(schema, json);
 	return json;
+}
+
+const MIME_TYPES: Record<string, string> = {
+	png: "image/png",
+	jpg: "image/jpeg",
+	jpeg: "image/jpeg",
+	gif: "image/gif",
+	webp: "image/webp",
+};
+
+export async function readURLFile(url: URL): Promise<Blob> {
+	if (url.protocol === "http:" || url.protocol === "https:") {
+		const response = await fetch(url);
+		if (!response.ok) {
+			throw new Error(
+				`Failed to download file from "${url.toString()}" (HTTP ${response.status}).`,
+			);
+		}
+		return await response.blob();
+	}
+
+	if (url.protocol === "file:") {
+		const buffer = await readFile(url);
+		const extension = getExtension(url);
+		const type = extension
+			? MIME_TYPES[extension] || "application/octet-stream"
+			: "application/octet-stream";
+		return new Blob([buffer], { type });
+	}
+
+	throw new Error(`Unsupported file protocol: ${url.protocol}`);
 }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -10,3 +10,9 @@ export function appendTrailingSlash(url: string | URL): URL {
 export function relativePathname(a: URL, b: URL): string {
 	return relative(fileURLToPath(a), fileURLToPath(b));
 }
+
+export function getExtension(url: URL): string | undefined {
+	const dotIndex = url.pathname.lastIndexOf(".");
+	if (dotIndex === -1) return undefined;
+	return url.pathname.slice(dotIndex + 1).toLowerCase() || undefined;
+}

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -1,3 +1,7 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { buildSlice, it } from "./it";
 import { getSlices, insertSlice } from "./prismic";
 
@@ -42,6 +46,37 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, tok
 		slice.id,
 		"--screenshot",
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Added variation "${variationName}"`);
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	const variation = updated?.variations.find((v) => v.name === variationName);
+	expect(variation).toBeDefined();
+	expect(variation?.imageUrl).toContain("https://");
+	expect(variation?.imageUrl).toContain(".png");
+});
+
+it("adds a variation with a local screenshot file", async ({ expect, prismic, project, repo, token, host }) => {
+	const slice = buildSlice();
+	await insertSlice(slice, { repo, token, host });
+
+	const screenshotUrl = "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format";
+	const response = await fetch(screenshotUrl);
+	const data = new Uint8Array(await response.arrayBuffer());
+	const screenshotPath = join(fileURLToPath(project), "screenshot.png");
+	await writeFile(screenshotPath, data);
+
+	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
+
+	const { stdout, exitCode } = await prismic("slice", [
+		"add-variation",
+		variationName,
+		"--to",
+		slice.id,
+		"--screenshot",
+		screenshotPath,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -44,7 +44,7 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, tok
 		"--to",
 		slice.id,
 		"--screenshot",
-		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png",
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
@@ -57,16 +57,24 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, tok
 	expect(variation?.imageUrl).toContain(".png");
 });
 
-it("adds a variation with a local screenshot file", async ({ expect, prismic, project, repo, token, host }) => {
+it("adds a variation with a local screenshot file", async ({
+	expect,
+	prismic,
+	project,
+	repo,
+	token,
+	host,
+}) => {
 	const slice = buildSlice();
 	await insertSlice(slice, { repo, token, host });
 
-	const screenshotUrl = "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format";
+	const screenshotUrl =
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png";
 	const response = await fetch(screenshotUrl);
 	const data = new Uint8Array(await response.arrayBuffer());
-	const screenshotUrl2 = new URL("screenshot.png", project);
-	await writeFile(screenshotUrl2, data);
-	const screenshotPath = fileURLToPath(screenshotUrl2);
+	const screenshotFileUrl = new URL("screenshot.png", project);
+	await writeFile(screenshotFileUrl, data);
+	const screenshotPath = fileURLToPath(screenshotFileUrl);
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -1,5 +1,4 @@
 import { writeFile } from "node:fs/promises";
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { buildSlice, it } from "./it";
@@ -65,8 +64,9 @@ it("adds a variation with a local screenshot file", async ({ expect, prismic, pr
 	const screenshotUrl = "https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format";
 	const response = await fetch(screenshotUrl);
 	const data = new Uint8Array(await response.arrayBuffer());
-	const screenshotPath = join(fileURLToPath(project), "screenshot.png");
-	await writeFile(screenshotPath, data);
+	const screenshotUrl2 = new URL("screenshot.png", project);
+	await writeFile(screenshotUrl2, data);
+	const screenshotPath = fileURLToPath(screenshotUrl2);
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -28,3 +28,28 @@ it("adds a variation to a slice", async ({ expect, prismic, repo, token, host })
 	const variation = updated?.variations.find((v) => v.name === variationName);
 	expect(variation).toBeDefined();
 });
+
+it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice();
+	await insertSlice(slice, { repo, token, host });
+
+	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
+
+	const { stdout, exitCode } = await prismic("slice", [
+		"add-variation",
+		variationName,
+		"--to",
+		slice.id,
+		"--screenshot",
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Added variation "${variationName}"`);
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	const variation = updated?.variations.find((v) => v.name === variationName);
+	expect(variation).toBeDefined();
+	expect(variation?.imageUrl).toContain("https://");
+	expect(variation?.imageUrl).toContain(".png");
+});

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -1,3 +1,6 @@
+import { writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
 import { buildSlice, it } from "./it";
 import { getSlices, insertSlice } from "./prismic";
 
@@ -58,6 +61,43 @@ it("sets a screenshot on a variation", async ({ expect, prismic, repo, token, ho
 		slice.id,
 		"--screenshot",
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	const variation = updated?.variations.find((v) => v.id === "default");
+	expect(variation?.imageUrl).toContain("https://");
+	expect(variation?.imageUrl).toContain(".png");
+});
+
+it("sets a local screenshot file on a variation", async ({
+	expect,
+	prismic,
+	project,
+	repo,
+	token,
+	host,
+}) => {
+	const slice = buildSlice();
+	await insertSlice(slice, { repo, token, host });
+
+	const screenshotUrl =
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png";
+	const response = await fetch(screenshotUrl);
+	const data = new Uint8Array(await response.arrayBuffer());
+	const screenshotFileUrl = new URL("screenshot.png", project);
+	await writeFile(screenshotFileUrl, data);
+	const screenshotPath = fileURLToPath(screenshotFileUrl);
+
+	const { stdout, exitCode } = await prismic("slice", [
+		"edit-variation",
+		"default",
+		"--from-slice",
+		slice.id,
+		"--screenshot",
+		screenshotPath,
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -57,7 +57,7 @@ it("sets a screenshot on a variation", async ({ expect, prismic, repo, token, ho
 		"--from-slice",
 		slice.id,
 		"--screenshot",
-		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png",
 	]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -46,3 +46,25 @@ it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
 	const variation = updated?.variations.find((v) => v.id === variationId);
 	expect(variation?.name).toBe(newName);
 });
+
+it("sets a screenshot on a variation", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice();
+	await insertSlice(slice, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("slice", [
+		"edit-variation",
+		"default",
+		"--from-slice",
+		slice.id,
+		"--screenshot",
+		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png?auto=compress,format",
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	const variation = updated?.variations.find((v) => v.id === "default");
+	expect(variation?.imageUrl).toContain("https://");
+	expect(variation?.imageUrl).toContain(".png");
+});


### PR DESCRIPTION
Resolves: #95

### Description

Add a `--screenshot` option to `slice add-variation` and `slice edit-variation` that accepts either a local file path or a URL. The image is uploaded to S3 via the ACL provider, and the resulting imgix URL is stored in the variation's `imageUrl` field.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```bash
# With a URL
prismic slice edit-variation default --from-slice my_slice --screenshot https://example.com/image.png

# With a local file
prismic slice add-variation "With Image" --to my_slice --screenshot ./screenshot.png
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new networked file-download + S3 upload flow (via ACL provider) to CLI commands, which can fail due to file type/protocol handling and external service interactions. Core slice update paths are unchanged but now conditionally include `imageUrl` updates.
> 
> **Overview**
> Adds a new `--screenshot/-s` option to `slice add-variation` and `slice edit-variation` to set a variation’s `imageUrl` by uploading an image from a local path or HTTP(S) URL.
> 
> Introduces screenshot upload support in the custom-types client via the ACL provider (typed response validation, MIME-type allowlist, deterministic keying via MD5, and imgix URL generation) plus a new `readURLFile()` helper to load files from `file:`/`http(s):` URLs. Tests are extended to cover both URL-based and local-file screenshots for both commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be58488603f3bb87979579cb63d126366a91d844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->