### PR TITLE
feat: add field reorder command

### DIFF
--- a/src/commands/field-reorder.ts
+++ b/src/commands/field-reorder.ts
@@ -1,0 +1,89 @@
+import { getHost, getToken } from "../auth";
+import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { resolveFieldPair, resolveFieldTarget } from "../models";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic field reorder",
+	description: "Reorder a field in a slice or custom type.",
+	positionals: {
+		id: { description: "Field ID to move", required: true },
+	},
+	options: {
+		before: { type: "string", description: "Place field before this field ID" },
+		after: { type: "string", description: "Place field after this field ID" },
+		"from-slice": { type: "string", description: "ID of the source slice" },
+		"from-type": { type: "string", description: "ID of the source content type" },
+		variation: { type: "string", description: 'Slice variation ID (default: "default")' },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [id] = positionals;
+	const { before, after, repo = await getRepositoryName() } = values;
+
+	if (!before && !after) {
+		throw new CommandError("Specify --before or --after.");
+	}
+	if (before && after) {
+		throw new CommandError("Only one of --before or --after can be specified.");
+	}
+
+	const anchor = (before ?? after)!;
+	const position = before ? "before" : "after";
+
+	if (id === anchor) {
+		throw new CommandError(`Cannot reorder "${id}" relative to itself.`);
+	}
+
+	const idParent = id.lastIndexOf(".");
+	const anchorParent = anchor.lastIndexOf(".");
+	if (
+		(idParent === -1 ? "" : id.slice(0, idParent)) !==
+		(anchorParent === -1 ? "" : anchor.slice(0, anchorParent))
+	) {
+		throw new CommandError(
+			`Cannot reorder "${id}" relative to "${anchor}": fields must be in the same container.`,
+		);
+	}
+
+	const token = await getToken();
+	const host = await getHost();
+	const [sourceFields, anchorFields, saveModel] = await resolveFieldPair(id, anchor, values, {
+		repo,
+		token,
+		host,
+	});
+
+	const [sourceLeaf, sourceFieldId] = resolveFieldTarget(sourceFields, id);
+	const [anchorLeaf, anchorFieldId] = resolveFieldTarget(anchorFields, anchor);
+
+	if (!(sourceFieldId in sourceLeaf)) {
+		throw new CommandError(`Field "${id}" does not exist.`);
+	}
+	if (!(anchorFieldId in anchorLeaf)) {
+		throw new CommandError(`Field "${anchor}" does not exist.`);
+	}
+
+	const fieldValue = sourceLeaf[sourceFieldId];
+	delete sourceLeaf[sourceFieldId];
+
+	const entries = Object.entries(anchorLeaf);
+	for (const key of Object.keys(anchorLeaf)) {
+		delete anchorLeaf[key];
+	}
+	for (const [key, value] of entries) {
+		if (position === "before" && key === anchorFieldId) {
+			anchorLeaf[sourceFieldId] = fieldValue;
+		}
+		anchorLeaf[key] = value;
+		if (position === "after" && key === anchorFieldId) {
+			anchorLeaf[sourceFieldId] = fieldValue;
+		}
+	}
+
+	await saveModel();
+
+	console.info(`Field reordered: ${id}`);
+});

--- a/src/commands/field.ts
+++ b/src/commands/field.ts
@@ -2,6 +2,7 @@ import { createCommandRouter } from "../lib/command";
 import fieldAdd from "./field-add";
 import fieldEdit from "./field-edit";
 import fieldRemove from "./field-remove";
+import fieldReorder from "./field-reorder";
 import fieldView from "./field-view";
 
 export default createCommandRouter({
@@ -19,6 +20,10 @@ export default createCommandRouter({
 		remove: {
 			handler: fieldRemove,
 			description: "Remove a field",
+		},
+		reorder: {
+			handler: fieldReorder,
+			description: "Reorder a field",
 		},
 		view: {
 			handler: fieldView,

--- a/src/models.ts
+++ b/src/models.ts
@@ -102,6 +102,93 @@ export async function resolveFieldContainer(
 	];
 }
 
+export async function resolveFieldPair(
+	sourceId: string,
+	anchorId: string,
+	values: {
+		"from-slice"?: string;
+		"from-type"?: string;
+		variation?: string;
+	},
+	apiConfig: ApiConfig,
+): Promise<[sourceFields: Fields, anchorFields: Fields, save: () => Promise<void>, modelKind: ModelKind]> {
+	const adapter = await getAdapter();
+	const {
+		"from-slice": fromSlice,
+		"from-type": fromType,
+		variation: variationId = "default",
+	} = values;
+
+	const providedCount = [fromSlice, fromType].filter(Boolean).length;
+	if (providedCount === 0) {
+		throw new CommandError("Specify a target with --from-slice or --from-type.");
+	}
+	if (providedCount > 1) {
+		throw new CommandError("Only one of --from-slice or --from-type can be specified.");
+	}
+
+	if (fromSlice) {
+		const slice = await getSlice(fromSlice, apiConfig);
+		const variation = slice.variations.find((v) => v.id === variationId);
+		if (!variation) {
+			const variationIds = slice.variations?.map((v) => v.id).join(", ") || "(none)";
+			throw new CommandError(`Variation "${variationId}" not found. Available: ${variationIds}`);
+		}
+		variation.primary ??= {};
+		return [
+			variation.primary,
+			variation.primary,
+			async () => {
+				await updateSlice(slice, apiConfig);
+				try {
+					await adapter.updateSlice(slice);
+				} catch {
+					await adapter.createSlice(slice);
+				}
+				await adapter.generateTypes();
+			},
+			"slice",
+		];
+	}
+
+	const customType = await getCustomType(fromType!, apiConfig);
+
+	const sourceRoot = sourceId.includes(".") ? sourceId.split(".")[0] : sourceId;
+	const anchorRoot = anchorId.includes(".") ? anchorId.split(".")[0] : anchorId;
+
+	let sourceTab: Record<string, DynamicWidget> | undefined;
+	let anchorTab: Record<string, DynamicWidget> | undefined;
+	for (const tabName in customType.json) {
+		const tab = customType.json[tabName];
+		if (sourceRoot in tab) sourceTab = tab;
+		if (anchorRoot in tab) anchorTab = tab;
+	}
+
+	const allFieldIds = Object.keys(Object.assign({}, ...Object.values(customType.json)));
+	const available = allFieldIds.join(", ") || "(none)";
+	if (!sourceTab) {
+		throw new CommandError(`Field "${sourceId}" not found. Available: ${available}`);
+	}
+	if (!anchorTab) {
+		throw new CommandError(`Field "${anchorId}" not found. Available: ${available}`);
+	}
+
+	return [
+		sourceTab,
+		anchorTab,
+		async () => {
+			await updateCustomType(customType, apiConfig);
+			try {
+				await adapter.updateCustomType(customType);
+			} catch {
+				await adapter.createCustomType(customType);
+			}
+			await adapter.generateTypes();
+		},
+		"customType",
+	];
+}
+
 export async function resolveModel(
 	values: {
 		"to-slice"?: string;

--- a/test/field-reorder.test.ts
+++ b/test/field-reorder.test.ts
@@ -10,23 +10,10 @@ it("supports --help", async ({ expect, prismic }) => {
 });
 
 it("reorders a field in a slice", async ({ expect, prismic, repo, token, host }) => {
-	const slice = buildSlice({
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-				primary: {
-					field_a: { type: "Boolean", config: { label: "A" } },
-					field_b: { type: "Boolean", config: { label: "B" } },
-					field_c: { type: "Boolean", config: { label: "C" } },
-				},
-			},
-		],
-	});
+	const slice = buildSlice();
+	slice.variations[0].primary!.field_a = { type: "Boolean", config: { label: "A" } };
+	slice.variations[0].primary!.field_b = { type: "Boolean", config: { label: "B" } };
+	slice.variations[0].primary!.field_c = { type: "Boolean", config: { label: "C" } };
 	await insertSlice(slice, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -46,15 +33,10 @@ it("reorders a field in a slice", async ({ expect, prismic, repo, token, host })
 });
 
 it("reorders a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
-	const customType = buildCustomType({
-		json: {
-			Main: {
-				title: { type: "StructuredText", config: { label: "Title" } },
-				body: { type: "StructuredText", config: { label: "Body" } },
-				image: { type: "Image", config: { label: "Image" } },
-			},
-		},
-	});
+	const customType = buildCustomType();
+	customType.json.Main.title = { type: "StructuredText", config: { label: "Title" } };
+	customType.json.Main.body = { type: "StructuredText", config: { label: "Body" } };
+	customType.json.Main.image = { type: "Image", config: { label: "Image" } };
 	await insertCustomType(customType, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -74,18 +56,13 @@ it("reorders a field in a custom type", async ({ expect, prismic, repo, token, h
 });
 
 it("moves a field across tabs in a custom type", async ({ expect, prismic, repo, token, host }) => {
-	const customType = buildCustomType({
-		json: {
-			Main: {
-				title: { type: "StructuredText", config: { label: "Title" } },
-				body: { type: "StructuredText", config: { label: "Body" } },
-			},
-			SEO: {
-				meta_title: { type: "Text", config: { label: "Meta Title" } },
-				meta_desc: { type: "Text", config: { label: "Meta Description" } },
-			},
-		},
-	});
+	const customType = buildCustomType();
+	customType.json.Main.title = { type: "StructuredText", config: { label: "Title" } };
+	customType.json.Main.body = { type: "StructuredText", config: { label: "Body" } };
+	customType.json.SEO = {
+		meta_title: { type: "Text", config: { label: "Meta Title" } },
+		meta_desc: { type: "Text", config: { label: "Meta Description" } },
+	};
 	await insertCustomType(customType, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -106,31 +83,18 @@ it("moves a field across tabs in a custom type", async ({ expect, prismic, repo,
 });
 
 it("reorders a nested field in a group", async ({ expect, prismic, repo, token, host }) => {
-	const slice = buildSlice({
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-				primary: {
-					my_group: {
-						type: "Group",
-						config: {
-							label: "My Group",
-							fields: {
-								sub_a: { type: "Boolean", config: { label: "A" } },
-								sub_b: { type: "Boolean", config: { label: "B" } },
-								sub_c: { type: "Boolean", config: { label: "C" } },
-							},
-						},
-					},
-				},
+	const slice = buildSlice();
+	slice.variations[0].primary!.my_group = {
+		type: "Group",
+		config: {
+			label: "My Group",
+			fields: {
+				sub_a: { type: "Boolean", config: { label: "A" } },
+				sub_b: { type: "Boolean", config: { label: "B" } },
+				sub_c: { type: "Boolean", config: { label: "C" } },
 			},
-		],
-	});
+		},
+	};
 	await insertSlice(slice, { repo, token, host });
 
 	const { stdout, exitCode } = await prismic("field", [
@@ -151,21 +115,8 @@ it("reorders a nested field in a group", async ({ expect, prismic, repo, token, 
 });
 
 it("errors when the field does not exist", async ({ expect, prismic, repo, token, host }) => {
-	const slice = buildSlice({
-		variations: [
-			{
-				id: "default",
-				name: "Default",
-				docURL: "",
-				version: "initial",
-				description: "Default",
-				imageUrl: "",
-				primary: {
-					field_a: { type: "Boolean", config: { label: "A" } },
-				},
-			},
-		],
-	});
+	const slice = buildSlice();
+	slice.variations[0].primary!.field_a = { type: "Boolean", config: { label: "A" } };
 	await insertSlice(slice, { repo, token, host });
 
 	const { stderr, exitCode } = await prismic("field", [

--- a/test/field-reorder.test.ts
+++ b/test/field-reorder.test.ts
@@ -1,0 +1,181 @@
+import type { Group } from "@prismicio/types-internal/lib/customtypes";
+
+import { buildCustomType, buildSlice, it } from "./it";
+import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("field", ["reorder", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic field reorder <id> [options]");
+});
+
+it("reorders a field in a slice", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice({
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+				primary: {
+					field_a: { type: "Boolean", config: { label: "A" } },
+					field_b: { type: "Boolean", config: { label: "B" } },
+					field_c: { type: "Boolean", config: { label: "C" } },
+				},
+			},
+		],
+	});
+	await insertSlice(slice, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"reorder",
+		"field_a",
+		"--after",
+		"field_c",
+		"--from-slice",
+		slice.id,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Field reordered: field_a");
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	expect(Object.keys(updated!.variations[0].primary!)).toEqual(["field_b", "field_c", "field_a"]);
+});
+
+it("reorders a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({
+		json: {
+			Main: {
+				title: { type: "StructuredText", config: { label: "Title" } },
+				body: { type: "StructuredText", config: { label: "Body" } },
+				image: { type: "Image", config: { label: "Image" } },
+			},
+		},
+	});
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"reorder",
+		"image",
+		"--before",
+		"body",
+		"--from-type",
+		customType.id,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Field reordered: image");
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(Object.keys(updated!.json.Main)).toEqual(["title", "image", "body"]);
+});
+
+it("moves a field across tabs in a custom type", async ({ expect, prismic, repo, token, host }) => {
+	const customType = buildCustomType({
+		json: {
+			Main: {
+				title: { type: "StructuredText", config: { label: "Title" } },
+				body: { type: "StructuredText", config: { label: "Body" } },
+			},
+			SEO: {
+				meta_title: { type: "Text", config: { label: "Meta Title" } },
+				meta_desc: { type: "Text", config: { label: "Meta Description" } },
+			},
+		},
+	});
+	await insertCustomType(customType, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"reorder",
+		"body",
+		"--after",
+		"meta_title",
+		"--from-type",
+		customType.id,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Field reordered: body");
+
+	const customTypes = await getCustomTypes({ repo, token, host });
+	const updated = customTypes.find((ct) => ct.id === customType.id);
+	expect(Object.keys(updated!.json.Main)).toEqual(["title"]);
+	expect(Object.keys(updated!.json.SEO)).toEqual(["meta_title", "body", "meta_desc"]);
+});
+
+it("reorders a nested field in a group", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice({
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+				primary: {
+					my_group: {
+						type: "Group",
+						config: {
+							label: "My Group",
+							fields: {
+								sub_a: { type: "Boolean", config: { label: "A" } },
+								sub_b: { type: "Boolean", config: { label: "B" } },
+								sub_c: { type: "Boolean", config: { label: "C" } },
+							},
+						},
+					},
+				},
+			},
+		],
+	});
+	await insertSlice(slice, { repo, token, host });
+
+	const { stdout, exitCode } = await prismic("field", [
+		"reorder",
+		"my_group.sub_c",
+		"--before",
+		"my_group.sub_a",
+		"--from-slice",
+		slice.id,
+	]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Field reordered: my_group.sub_c");
+
+	const slices = await getSlices({ repo, token, host });
+	const updated = slices.find((s) => s.id === slice.id);
+	const group = updated!.variations[0].primary!.my_group as Group;
+	expect(Object.keys(group.config!.fields!)).toEqual(["sub_c", "sub_a", "sub_b"]);
+});
+
+it("errors when the field does not exist", async ({ expect, prismic, repo, token, host }) => {
+	const slice = buildSlice({
+		variations: [
+			{
+				id: "default",
+				name: "Default",
+				docURL: "",
+				version: "initial",
+				description: "Default",
+				imageUrl: "",
+				primary: {
+					field_a: { type: "Boolean", config: { label: "A" } },
+				},
+			},
+		],
+	});
+	await insertSlice(slice, { repo, token, host });
+
+	const { stderr, exitCode } = await prismic("field", [
+		"reorder",
+		"missing",
+		"--after",
+		"field_a",
+		"--from-slice",
+		slice.id,
+	]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain('"missing"');
+});


### PR DESCRIPTION
Resolves: #100

### Description

Adds `prismic field reorder <id> (--before | --after) <anchor>` to reorder fields within a slice or custom type. The anchor field determines the destination — for custom types, this means fields can be moved across tabs by specifying an anchor in a different tab. Group fields use dot notation with the constraint that both fields must share the same parent container.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI behavior that mutates slice/custom type JSON by deleting and reinserting keys (including cross-tab moves), which could affect model persistence and generated types if edge cases are missed.
> 
> **Overview**
> Adds a new `prismic field reorder <id> (--before|--after) <anchor>` command to reposition fields in a slice variation or custom type, including support for nested group fields via dot notation and moving fields across custom type tabs by choosing an anchor in another tab.
> 
> Introduces `resolveFieldPair` in `models.ts` to locate both the source and anchor containers and provide a save callback, and wires the command into the `prismic field` router. Adds integration tests covering slice/custom type reorders, cross-tab moves, nested group fields, and missing-field errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 239ffb1a593e812ed3595ffe7bf002ea08f75f00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->