### PR TITLE
fix: only send unknown or intentionally tracked errors to Segment

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -199,6 +199,9 @@ async function main(): Promise<void> {
 		process.exitCode = 1;
 
 		if (error instanceof CommandError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
 			console.error(error.message);
 			return;
 		}
@@ -212,11 +215,17 @@ async function main(): Promise<void> {
 		}
 
 		if (error instanceof UnauthorizedRequestError || error instanceof ForbiddenRequestError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command, { error });
+			}
 			console.error("Not logged in. Run `prismic login` first.");
 			return;
 		}
 
 		if (error instanceof NotFoundRequestError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
 			console.error(
 				error.message || "Not found. Verify the repository and any specified identifiers exist.",
 			);
@@ -224,16 +233,25 @@ async function main(): Promise<void> {
 		}
 
 		if (error instanceof InvalidPrismicConfigError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
 			console.error(`${error.message} Run \`prismic init\` to re-create a config.`);
 			return;
 		}
 
 		if (error instanceof MissingPrismicConfigError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
 			console.error(`${error.message} Run \`prismic init\` to create a config.`);
 			return;
 		}
 
 		if (error instanceof TypeBuilderRequiredError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
 			console.error(dedent`
 				This command requires the Type Builder in your repository.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,11 +198,15 @@ async function main(): Promise<void> {
 	} catch (error) {
 		process.exitCode = 1;
 
-		if (!UNTRACKED_COMMANDS.includes(command)) {
-			segmentTrackEnd(command, { error });
+		if (error instanceof CommandError) {
+			console.error(error.message);
+			return;
 		}
 
-		if (error instanceof CommandError || error instanceof NoSupportedFrameworkError) {
+		if (error instanceof NoSupportedFrameworkError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command, { error });
+			}
 			console.error(error.message);
 			return;
 		}
@@ -242,6 +246,9 @@ async function main(): Promise<void> {
 			return;
 		}
 
+		if (!UNTRACKED_COMMANDS.includes(command)) {
+			segmentTrackEnd(command, { error });
+		}
 		await sentryCaptureError(error);
 		throw error;
 	}


### PR DESCRIPTION
Resolves: #131

### Description

Previously, all errors were sent to Segment before being classified. Known/expected errors (user input mistakes, auth failures, missing config) added noise to analytics. Now only unknown errors and `NoSupportedFrameworkError` are tracked.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to telemetry/error-reporting behavior in the CLI; main risk is reduced visibility or altered analytics for some known error cases.
> 
> **Overview**
> Adjusts CLI error handling in `src/index.ts` so Segment telemetry only includes `error` details for *unexpected* failures (and `NoSupportedFrameworkError`), while other known/expected errors end the event without an error payload.
> 
> This reorders the `catch` branches to classify `CommandError` earlier and avoids attaching error metadata for common user-facing failures (e.g., missing/invalid config, not-found), while still reporting unknown errors to both Segment and Sentry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b214b317adb3a86d04e9c00acdc910f40b15f64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->