### PR TITLE
feat: create a new repository during init when --repo is not provided

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -39,6 +39,7 @@ export async function getAdapter(): Promise<Adapter> {
 
 export class NoSupportedFrameworkError extends Error {
 	name = "NoSupportedFrameworkError";
+	message = "No supported framework found. Run this command in a Next.js, Nuxt, or SvelteKit project.";
 }
 
 export abstract class Adapter {

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -38,7 +38,7 @@ export async function getAdapter(): Promise<Adapter> {
 }
 
 export class NoSupportedFrameworkError extends Error {
-	message = "No supported framework found (Next.js, Nuxt, or SvelteKit required)";
+	name = "NoSupportedFrameworkError";
 }
 
 export abstract class Adapter {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,14 +18,18 @@ import {
 	UnknownProjectRootError,
 } from "../project";
 import { checkIsTypeBuilderEnabled, TypeBuilderRequiredError } from "../project";
+import { createRepo } from "./repo-create";
 
 const config = {
 	name: "prismic init",
 	description: `
-		Initialize a Prismic project by creating a prismic.config.json file.
+		Initialize a new Prismic project by creating a repository and
+		prismic.config.json file. Detects the project framework, installs
+		dependencies, and syncs models from Prismic.
 
-		Detects the project framework, installs dependencies, and syncs models
-		from Prismic. If a slicemachine.config.json exists, it will be migrated.
+		Use --repo to connect to an existing repository instead. If a
+		slicemachine.config.json exists, its repository and settings will be
+		migrated.
 	`,
 	options: {
 		repo: { type: "string", short: "r", description: "Repository name" },
@@ -63,12 +67,6 @@ export default createCommand(config, async ({ values }) => {
 		}
 	}
 
-	const repo = explicitRepo ?? legacySliceMachineConfig?.repositoryName;
-	if (!repo) {
-		throw new CommandError("Missing required flag: --repo");
-	}
-
-	// Validate repo membership
 	let token = await getToken();
 	const host = await getHost();
 	let profile: Profile;
@@ -96,19 +94,27 @@ export default createCommand(config, async ({ values }) => {
 		}
 	}
 
-	const repoMeta = profile.repositories.find((repository) => repository.domain === repo);
-	if (!repoMeta) {
-		throw new CommandError(
-			`Repository "${repo}" not found in your account. Check the name or request access to the repository.`,
-		);
-	}
+	let repo = explicitRepo ?? legacySliceMachineConfig?.repositoryName;
+	if (repo) {
+		const hasRepoAccess = profile.repositories.some((repository) => repository.domain === repo);
+		if (!hasRepoAccess) {
+			throw new CommandError(
+				`Repository "${repo}" not found in your account. Check the name or request access to the repository.`,
+			);
+		}
 
-	const isTypeBuilderEnabled = await checkIsTypeBuilderEnabled(repo, { token, host });
-	if (!isTypeBuilderEnabled) {
-		throw new TypeBuilderRequiredError();
+		const isTypeBuilderEnabled = await checkIsTypeBuilderEnabled(repo, { token, host });
+		if (!isTypeBuilderEnabled) {
+			throw new TypeBuilderRequiredError();
+		}
 	}
 
 	const adapter = await getAdapter();
+
+	if (!repo) {
+		repo = await createRepo({ token, host });
+		console.info(`Created repository: ${repo}`);
+	}
 
 	// Create prismic.config.json
 	try {

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -19,6 +19,18 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const domain = await createRepo({ name, token, host });
+
+	console.info(`Repository created: ${domain}`);
+	console.info(`URL: https://${domain}.${host}/`);
+});
+
+export async function createRepo(config: {
+	name?: string;
+	token: string | undefined;
+	host: string;
+}): Promise<string> {
+	const { name, token, host } = config;
 
 	const domain = await findAvailableDomain({ token, host });
 	if (!domain) {
@@ -38,9 +50,8 @@ export default createCommand(config, async ({ values }) => {
 		throw error;
 	}
 
-	console.info(`Repository created: ${domain}`);
-	console.info(`URL: https://${domain}.${host}/`);
-});
+	return domain;
+}
 
 async function findAvailableDomain(config: {
 	token: string | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import webhook from "./commands/webhook";
 import whoami from "./commands/whoami";
 import { UPDATE_NOTIFIER_STATE_PATH } from "./config";
 import { CommandError, createCommandRouter } from "./lib/command";
+import { decodePayload } from "./lib/jwt";
 import {
 	ForbiddenRequestError,
 	NotFoundRequestError,
@@ -42,7 +43,6 @@ import {
 	sentrySetUser,
 	setupSentry,
 } from "./lib/sentry";
-import { decodePayload } from "./lib/jwt";
 import { dedent } from "./lib/string";
 import { initUpdateNotifier } from "./lib/update-notifier";
 import { InvalidPrismicConfigError, MissingPrismicConfigError } from "./project";
@@ -210,7 +210,9 @@ async function main(): Promise<void> {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
 				segmentTrackEnd(command, { error });
 			}
-			console.error(error.message);
+			console.error(
+				"No supported framework found. Run this command in a Next.js, Nuxt, or SvelteKit project.",
+			);
 			return;
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -216,9 +216,7 @@ async function main(): Promise<void> {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
 				segmentTrackEnd(command, { error });
 			}
-			console.error(
-				"No supported framework found. Run this command in a Next.js, Nuxt, or SvelteKit project.",
-			);
+			console.error(error.message);
 			return;
 		}
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -14,16 +14,21 @@ it("fails if prismic.config.json already exists", async ({ expect, prismic }) =>
 	expect(stderr).toContain("already initialized");
 });
 
-it("fails if --repo is not provided and no legacy config exists", async ({
+it("creates a repo if --repo is not provided and no legacy config exists", async ({
 	expect,
 	project,
 	prismic,
 }) => {
 	await rm(new URL("prismic.config.json", project));
-	const { exitCode, stderr } = await prismic("init");
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain("Missing required flag");
-});
+	const { exitCode, stdout } = await prismic("init");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Created repository:");
+	expect(stdout).toContain("Initialized Prismic for repository");
+
+	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
+	const config = JSON.parse(configRaw);
+	expect(config.repositoryName).toMatch(/^[a-f0-9]{8}$/);
+}, 60_000);
 
 it("initializes a project with --repo when logged in", async ({
 	expect,


### PR DESCRIPTION
Resolves: #138

### Description

The `init` command now creates a new repository when `--repo` is not provided, instead of failing with a missing flag error. Use `--repo` to connect to an existing repository.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `prismic init` to provision a new Prismic repository via API calls when no `--repo`/legacy repo is provided, which affects onboarding flow and could fail due to network/auth conditions. Risk is moderated by retaining existing `--repo` validation and adding test coverage for the new path.
> 
> **Overview**
> `prismic init` no longer requires `--repo`; when no repo is provided (and none is found in legacy `slicemachine.config.json`), it now **creates a new Prismic repository** and then writes `prismic.config.json` using the generated domain.
> 
> Repository creation logic is refactored into a reusable `createRepo()` helper (used by both `prismic init` and `prismic repo create`), and init only performs repo access/Type Builder checks when connecting to an *existing* repo. Error messaging for unsupported frameworks is also updated, and tests now assert the auto-create init flow (including an 8-char generated repo name).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b04d05f60346b8a93566de6328bced5ed5813985. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->