### PR TITLE
fix: preserve API order for docs anchors instead of sorting alphabetically

### DIFF
--- a/src/commands/docs-list.ts
+++ b/src/commands/docs-list.ts
@@ -38,8 +38,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 			throw error;
 		}
 
-		entry.anchors.sort((a, b) => a.slug.localeCompare(b.slug));
-
 		if (json) {
 			console.info(stringify(entry));
 			return;


### PR DESCRIPTION
Resolves: #144

### Description

Removes the alphabetical sort on docs anchors so they appear in the order returned by the API, matching the structure of the underlying document.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic docs list fields/content-relationship` and verify anchors appear in document order rather than alphabetical order.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only removes a client-side sort so anchor output order matches the API response; no API calls, parsing, or error handling behavior changes.
> 
> **Overview**
> Updates `prismic docs list <path>` to **stop alphabetically sorting** `entry.anchors` by slug, so anchors are printed in the **same order returned by the docs API** (i.e., document order).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23cab8f960818cdaad971043ee214bc624fae517. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->