### PR TITLE
feat: document group field dot notation in field add help

### DIFF
--- a/src/commands/field-add.ts
+++ b/src/commands/field-add.ts
@@ -20,6 +20,15 @@ import fieldAddUid from "./field-add-uid";
 export default createCommandRouter({
 	name: "prismic field add",
 	description: "Add a field to a slice or custom type.",
+	sections: {
+		"GROUP FIELDS": `
+			To add a field inside a group, use dot notation for the field ID:
+
+			  prismic field add text my_group.description --to-type blog_post
+
+			The group must already exist. Only one level of nesting is supported.
+		`,
+	},
 	commands: {
 		boolean: {
 			handler: fieldAddBoolean,

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -138,6 +138,7 @@ function buildCommandHelp(config: CommandConfig): string {
 type CreateCommandRouterConfig = {
 	name: string;
 	description: string;
+	sections?: Record<string, string>;
 	commands: Record<string, RouterCommand>;
 };
 type RouterCommand = { handler: () => Promise<void>; description: string };
@@ -174,7 +175,7 @@ export function createCommandRouter(config: CreateCommandRouterConfig): () => Pr
 }
 
 function buildRouterHelp(config: CreateCommandRouterConfig): string {
-	const { name, description, commands } = config;
+	const { name, description, sections, commands } = config;
 
 	const lines = [description];
 
@@ -190,6 +191,17 @@ function buildRouterHelp(config: CreateCommandRouterConfig): string {
 	lines.push("");
 	lines.push("OPTIONS");
 	lines.push("  -h, --help   Show help for command");
+
+	if (sections) {
+		for (const sectionName in sections) {
+			const content = dedent(sections[sectionName]);
+			lines.push("");
+			lines.push(sectionName);
+			for (const line of content.split("\n")) {
+				lines.push(line ? `  ${line}` : "");
+			}
+		}
+	}
 
 	lines.push("");
 	lines.push("LEARN MORE");

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -144,9 +144,7 @@ type CreateCommandRouterConfig = {
 type RouterCommand = { handler: () => Promise<void>; description: string };
 
 export function createCommandRouter(config: CreateCommandRouterConfig): () => Promise<void> {
-	const { name, description, commands } = config;
-
-	const depth = name.split(" ").length;
+	const depth = config.name.split(" ").length;
 
 	return async function () {
 		const args = process.argv.slice(1 + depth);
@@ -170,7 +168,7 @@ export function createCommandRouter(config: CreateCommandRouterConfig): () => Pr
 			throw new CommandError(`Unknown command: ${subcommand}`);
 		}
 
-		console.info(buildRouterHelp({ name, description, commands }));
+		console.info(buildRouterHelp(config));
 	};
 }
 


### PR DESCRIPTION
Resolves: #139

### Description

Documents the dot notation syntax for adding fields inside groups (e.g. `prismic field add text my_group.description --to-type blog_post`). Adds `sections` support to command routers so the `field add` router can show a GROUP FIELDS section in its `--help` output.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic field add --help` and verify the GROUP FIELDS section appears explaining dot notation.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only CLI help text rendering and adds an optional `sections` block to router help output, with no impact on command execution paths beyond printing help.
> 
> **Overview**
> Adds optional `sections` support to `createCommandRouter` help generation so routers can display additional formatted documentation blocks.
> 
> Updates `prismic field add --help` to include a **GROUP FIELDS** section describing dot-notation (`my_group.description`) for adding fields inside existing groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84c514b72af84481d4dd96e23a9a63dd6ee6ffe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->