### PR TITLE
feat: surface content-relationship --field flag in help text

### DIFF
--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -22,6 +22,21 @@ const config = {
 		selected. These filters define exactly which documents are queryable
 		through this field. If neither is specified, all documents are allowed.
 	`,
+	sections: {
+		"FETCHED FIELDS": `
+			By default, a content relationship only returns the linked
+			document's metadata (ID, type, tags). Use --field to fetch
+			specific fields from the related document so you can display
+			them without a separate query.
+
+			--field requires exactly one --custom-type so the CLI knows
+			which schema to validate against. Dot notation is supported
+			for fields inside groups (e.g. --field bio_group.summary).
+
+			Learn more:
+			  prismic docs view fields/content-relationship#select-the-fields-to-fetch
+		`,
+	},
 	positionals: {
 		id: { description: "Field ID", required: true },
 	},

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -31,10 +31,7 @@ const config = {
 
 			--field requires exactly one --custom-type so the CLI knows
 			which schema to validate against. Dot notation is supported
-			for fields inside groups (e.g. --field bio_group.summary).
-
-			Learn more:
-			  prismic docs view fields/content-relationship#select-the-fields-to-fetch
+			for fields inside groups (e.g. --field authors.name).
 		`,
 	},
 	positionals: {

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -29,9 +29,9 @@ const config = {
 			specific fields from the related document so you can display
 			them without a separate query.
 
-			--field requires exactly one --custom-type so the CLI knows
-			which schema to validate against. Dot notation is supported
-			for fields inside groups (e.g. --field authors.name).
+			--field requires exactly one --custom-type. Dot notation is
+			supported for fields inside groups (e.g. --field
+			authors.name).
 		`,
 	},
 	positionals: {


### PR DESCRIPTION
Resolves: #140

### Description

Adds a FETCHED FIELDS section to `prismic field add content-relationship --help` explaining how `--field` fetches specific fields from related documents, its requirements, and dot notation support.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic field add content-relationship --help` and verify the FETCHED FIELDS section appears.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates CLI help text/documentation for the content-relationship field and does not change command behavior or data handling.
> 
> **Overview**
> Adds a new **"FETCHED FIELDS"** section to `prismic field add content-relationship --help` explaining what `--field` does (fetching specific fields from linked documents), that it *requires exactly one* `--custom-type`, and that dot-notation is supported for nested/group fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287d868302ed59ab8501f20733dc4d3c9dda05d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->