### PR TITLE
feat: add examples to --help output for complex commands

### DIFF
--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -24,7 +24,7 @@ const config = {
 	`,
 	sections: {
 		EXAMPLES: `
-			Relate to any document:
+			Allow any document:
 			  prismic field add content-relationship author --to-type blog_post
 
 			Restrict to a specific type:

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -22,6 +22,18 @@ const config = {
 		selected. These filters define exactly which documents are queryable
 		through this field. If neither is specified, all documents are allowed.
 	`,
+	sections: {
+		EXAMPLES: `
+			Relate to any document:
+			  prismic field add content-relationship author --to-type blog_post
+
+			Restrict to a specific type:
+			  prismic field add content-relationship category --to-type blog_post --custom-type blog_category
+
+			Fetch fields from the related document:
+			  prismic field add content-relationship author --to-type blog_post --custom-type author --field name --field bio
+		`,
+	},
 	positionals: {
 		id: { description: "Field ID", required: true },
 	},

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -11,6 +11,18 @@ const config = {
 	name: "prismic field add link",
 	description:
 		"Add a link field to a slice or custom type. Use for navigational links to URLs, documents, or media. For data-level relations between documents, use content-relationship instead.",
+	sections: {
+		EXAMPLES: `
+			Add a link that opens in a new tab:
+			  prismic field add link cta --to-type landing_page --allow-target-blank
+
+			Restrict to media links only:
+			  prismic field add link download --to-type blog_post --allow media
+
+			Add a repeatable link with custom text:
+			  prismic field add link nav_item --to-type navigation --repeatable --allow-text
+		`,
+	},
 	positionals: {
 		id: { description: "Field ID", required: true },
 	},

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -19,6 +19,13 @@ const config = {
 			paragraph, strong, em, preformatted, hyperlink, image, embed,
 			list-item, o-list-item, rtl
 		`,
+		EXAMPLES: `
+			Add a title field (single heading):
+			  prismic field add rich-text title --to-type blog_post --allow heading1 --single
+
+			Add a body field with common blocks:
+			  prismic field add rich-text body --to-type blog_post --allow heading1,heading2,paragraph,strong,em,hyperlink,image,list-item,o-list-item
+		`,
 	},
 	positionals: {
 		id: { description: "Field ID", required: true },

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -23,8 +23,8 @@ const config = {
 			Add a title field (single heading):
 			  prismic field add rich-text title --to-type blog_post --allow heading1 --single
 
-			Add a body field with common blocks:
-			  prismic field add rich-text body --to-type blog_post --allow heading1,heading2,paragraph,strong,em,hyperlink,image,list-item,o-list-item
+			Add a body field with only headings and paragraphs:
+			  prismic field add rich-text body --to-type blog_post --allow heading1,heading2,paragraph,strong,em,hyperlink
 		`,
 	},
 	positionals: {

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -10,6 +10,15 @@ import { getRepositoryName } from "../project";
 const config = {
 	name: "prismic field add select",
 	description: "Add a select field to a slice or custom type.",
+	sections: {
+		EXAMPLES: `
+			Add a select with options:
+			  prismic field add select status --to-type blog_post --option draft --option published --option archived
+
+			With a default value:
+			  prismic field add select priority --to-type task --option low --option medium --option high --default-value medium
+		`,
+	},
 	positionals: {
 		id: { description: "Field ID", required: true },
 	},

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -13,10 +13,10 @@ const config = {
 	sections: {
 		EXAMPLES: `
 			Add a select with options:
-			  prismic field add select status --to-type blog_post --option draft --option published --option archived
+			  prismic field add select theme --to-type landing_page --option light --option dark --option brand
 
 			With a default value:
-			  prismic field add select priority --to-type task --option low --option medium --option high --default-value medium
+			  prismic field add select layout --to-type landing_page --option full --option centered --option sidebar --default-value full
 		`,
 	},
 	positionals: {

--- a/src/commands/field-edit.ts
+++ b/src/commands/field-edit.ts
@@ -18,6 +18,16 @@ const config = {
 			type will be applied. See \`prismic field add <type> --help\`
 			for type-specific option details.
 		`,
+		EXAMPLES: `
+			Rename a field's label:
+			  prismic field edit title --from-type blog_post --label "Page Title"
+
+			Change a select field's options:
+			  prismic field edit theme --from-type landing_page --option light --option dark
+
+			Restrict a rich text field to a single block:
+			  prismic field edit subtitle --from-type blog_post --single
+		`,
 	},
 	positionals: {
 		id: { description: "Field ID", required: true },

--- a/src/commands/slice-connect.ts
+++ b/src/commands/slice-connect.ts
@@ -10,6 +10,15 @@ import { getRepositoryName } from "../project";
 const config = {
 	name: "prismic slice connect",
 	description: "Connect a slice to a type's slice zone.",
+	sections: {
+		EXAMPLES: `
+			Connect a slice to a type's default slice zone:
+			  prismic slice connect hero --to blog_post
+
+			Connect to a named slice zone:
+			  prismic slice connect hero --to blog_post --slice-zone page_slices
+		`,
+	},
 	positionals: {
 		id: { description: "ID of the slice", required: true },
 	},

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -19,6 +19,18 @@ const config = {
 		By default, this command reads the repository from prismic.config.json at the
 		project root.
 	`,
+	sections: {
+		EXAMPLES: `
+			Create a read token:
+			  prismic token create
+
+			Create a read token with release access:
+			  prismic token create --allow-releases
+
+			Create a write token:
+			  prismic token create --write
+		`,
+	},
 	options: {
 		write: { type: "boolean", description: "Create a write token" },
 		"allow-releases": {

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -19,18 +19,6 @@ const config = {
 		By default, this command reads the repository from prismic.config.json at the
 		project root.
 	`,
-	sections: {
-		EXAMPLES: `
-			Create a read token:
-			  prismic token create
-
-			Create a read token with release access:
-			  prismic token create --allow-releases
-
-			Create a write token:
-			  prismic token create --write
-		`,
-	},
 	options: {
 		write: { type: "boolean", description: "Create a write token" },
 		"allow-releases": {

--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -33,6 +33,16 @@ const config = {
 			         page). Includes a slice zone and SEO & Metadata tab by
 			         default, and configures a route in prismic.config.json.
 		`,
+		EXAMPLES: `
+			Create a page type:
+			  prismic type create "Blog Post" --format page
+
+			Create a singleton custom type:
+			  prismic type create Settings --single
+
+			Create with a custom ID:
+			  prismic type create "Landing Page" --format page --id landing
+		`,
 	},
 } satisfies CommandConfig;
 

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -37,6 +37,16 @@ const config = {
 
 			If no triggers specified, all are enabled.
 		`,
+		EXAMPLES: `
+			Create a webhook for all events:
+			  prismic webhook create https://example.com/webhook
+
+			Create a webhook for specific events:
+			  prismic webhook create https://example.com/webhook -t documentsPublished -t documentsUnpublished
+
+			Create a named webhook with a secret:
+			  prismic webhook create https://example.com/webhook --name "Deploy" --secret my-secret
+		`,
 	},
 } satisfies CommandConfig;
 


### PR DESCRIPTION
Resolves: #148

### Description

Adds EXAMPLES sections to `--help` output for commands with non-obvious flag combinations: `field add rich-text`, `field add content-relationship`, `field add select`, `type create`, and `slice connect`.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `--help` for each modified command and verify the EXAMPLES section appears:
- `prismic field add rich-text --help`
- `prismic field add content-relationship --help`
- `prismic field add select --help`
- `prismic type create --help`
- `prismic slice connect --help`

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add `EXAMPLES` text blocks to `--help` output and do not modify command execution logic.
> 
> **Overview**
> Improves CLI discoverability by adding **`EXAMPLES` sections** to `--help` output for several commands with non-obvious flag combinations.
> 
> Examples were added to `field add content-relationship`, `field add link`, `field add rich-text`, `field add select`, `field edit`, `slice connect`, `type create`, and `webhook create`, without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15fc6fdecce0541c8d96f79277640a341bf2cdea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->