### PR TITLE
feat: surface prismic docs command in top-level help

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const router = createCommandRouter({
 	sections: {
 		DOCUMENTATION: `
 			Run \`prismic docs list\` to browse available documentation topics.
-			Run \`prismic docs view <path>\` to read a topic in your terminal.
+			Run \`prismic docs view <path>\` to read a topic.
 		`,
 	},
 	commands: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,12 @@ const UNTRACKED_COMMANDS = ["login", "logout", "whoami", "sync", "docs"];
 const router = createCommandRouter({
 	name: "prismic",
 	description: "Prismic CLI for managing repositories and configurations.",
+	sections: {
+		DOCUMENTATION: `
+			Run \`prismic docs list\` to browse available documentation topics.
+			Run \`prismic docs view <path>\` to read a topic in your terminal.
+		`,
+	},
 	commands: {
 		init: {
 			handler: init,

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -138,6 +138,7 @@ function buildCommandHelp(config: CommandConfig): string {
 type CreateCommandRouterConfig = {
 	name: string;
 	description: string;
+	sections?: Record<string, string>;
 	commands: Record<string, RouterCommand>;
 };
 type RouterCommand = { handler: () => Promise<void>; description: string };
@@ -174,7 +175,7 @@ export function createCommandRouter(config: CreateCommandRouterConfig): () => Pr
 }
 
 function buildRouterHelp(config: CreateCommandRouterConfig): string {
-	const { name, description, commands } = config;
+	const { name, description, sections, commands } = config;
 
 	const lines = [description];
 
@@ -190,6 +191,17 @@ function buildRouterHelp(config: CreateCommandRouterConfig): string {
 	lines.push("");
 	lines.push("OPTIONS");
 	lines.push("  -h, --help   Show help for command");
+
+	if (sections) {
+		for (const sectionName in sections) {
+			const content = dedent(sections[sectionName]);
+			lines.push("");
+			lines.push(sectionName);
+			for (const line of content.split("\n")) {
+				lines.push(line ? `  ${line}` : "");
+			}
+		}
+	}
 
 	lines.push("");
 	lines.push("LEARN MORE");

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -144,9 +144,7 @@ type CreateCommandRouterConfig = {
 type RouterCommand = { handler: () => Promise<void>; description: string };
 
 export function createCommandRouter(config: CreateCommandRouterConfig): () => Promise<void> {
-	const { name, description, commands } = config;
-
-	const depth = name.split(" ").length;
+	const depth = config.name.split(" ").length;
 
 	return async function () {
 		const args = process.argv.slice(1 + depth);
@@ -170,7 +168,7 @@ export function createCommandRouter(config: CreateCommandRouterConfig): () => Pr
 			throw new CommandError(`Unknown command: ${subcommand}`);
 		}
 
-		console.info(buildRouterHelp({ name, description, commands }));
+		console.info(buildRouterHelp(config));
 	};
 }
 


### PR DESCRIPTION
Resolves: #141

### Description

Adds a DOCUMENTATION section to the top-level `prismic --help` output pointing users to `prismic docs list` and `prismic docs view`. Also adds `sections` support to command routers to enable this.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic --help` and verify the DOCUMENTATION section appears with `prismic docs list` and `prismic docs view` hints.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes `--help` output formatting and adds optional router help sections, without affecting command execution paths.
> 
> **Overview**
> Surfaces the `docs` command in the top-level `prismic --help` output by adding a **DOCUMENTATION** section with quick pointers to `prismic docs list` and `prismic docs view`.
> 
> Extends `createCommandRouter` to accept optional `sections` and renders them in router help output (similar to command-level help), keeping existing routing behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9784e9091579dbfd163bd4c4aa6231f2a5bcbe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->