### PR TITLE
feat: print suggested next steps after mutating commands

### DIFF
--- a/src/commands/field-add-boolean.ts
+++ b/src/commands/field-add-boolean.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add boolean",
@@ -52,10 +53,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-boolean.ts
+++ b/src/commands/field-add-boolean.ts
@@ -54,8 +54,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-boolean.ts
+++ b/src/commands/field-add-boolean.ts
@@ -34,7 +34,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: BooleanField = {
@@ -52,4 +52,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-boolean.ts
+++ b/src/commands/field-add-boolean.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add boolean",

--- a/src/commands/field-add-color.ts
+++ b/src/commands/field-add-color.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add color",
@@ -42,10 +43,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-color.ts
+++ b/src/commands/field-add-color.ts
@@ -44,8 +44,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-color.ts
+++ b/src/commands/field-add-color.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add color",

--- a/src/commands/field-add-color.ts
+++ b/src/commands/field-add-color.ts
@@ -26,7 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Color = {
@@ -42,4 +42,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -5,9 +5,14 @@ import { capitalCase } from "change-case";
 import { getHost, getToken } from "../auth";
 import { getCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldSelection, resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldSelection,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add content-relationship",

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -7,6 +7,7 @@ import { getCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldSelection, resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add content-relationship",
@@ -94,10 +95,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -96,8 +96,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -63,7 +63,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	let resolvedCustomTypes: NonNullable<Link["config"]>["customtypes"] = customtypes;
@@ -94,4 +94,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-date.ts
+++ b/src/commands/field-add-date.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add date",

--- a/src/commands/field-add-date.ts
+++ b/src/commands/field-add-date.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add date",
@@ -44,10 +45,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-date.ts
+++ b/src/commands/field-add-date.ts
@@ -46,8 +46,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-date.ts
+++ b/src/commands/field-add-date.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: DateField = {
@@ -44,4 +44,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-embed.ts
+++ b/src/commands/field-add-embed.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add embed",
@@ -42,10 +43,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-embed.ts
+++ b/src/commands/field-add-embed.ts
@@ -44,8 +44,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-embed.ts
+++ b/src/commands/field-add-embed.ts
@@ -26,7 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Embed = {
@@ -42,4 +42,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-embed.ts
+++ b/src/commands/field-add-embed.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add embed",

--- a/src/commands/field-add-geopoint.ts
+++ b/src/commands/field-add-geopoint.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add geopoint",

--- a/src/commands/field-add-geopoint.ts
+++ b/src/commands/field-add-geopoint.ts
@@ -42,8 +42,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-geopoint.ts
+++ b/src/commands/field-add-geopoint.ts
@@ -25,7 +25,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: GeoPoint = {
@@ -40,4 +40,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-geopoint.ts
+++ b/src/commands/field-add-geopoint.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add geopoint",
@@ -40,10 +41,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-group.ts
+++ b/src/commands/field-add-group.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add group",

--- a/src/commands/field-add-group.ts
+++ b/src/commands/field-add-group.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add group",
@@ -40,10 +41,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-group.ts
+++ b/src/commands/field-add-group.ts
@@ -42,8 +42,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-group.ts
+++ b/src/commands/field-add-group.ts
@@ -25,7 +25,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Group = {
@@ -40,4 +40,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-image.ts
+++ b/src/commands/field-add-image.ts
@@ -26,7 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Image = {
@@ -42,4 +42,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-image.ts
+++ b/src/commands/field-add-image.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add image",

--- a/src/commands/field-add-image.ts
+++ b/src/commands/field-add-image.ts
@@ -44,8 +44,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-image.ts
+++ b/src/commands/field-add-image.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add image",
@@ -42,10 +43,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-integration.ts
+++ b/src/commands/field-add-integration.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: IntegrationField = {
@@ -44,4 +44,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-integration.ts
+++ b/src/commands/field-add-integration.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add integration",

--- a/src/commands/field-add-integration.ts
+++ b/src/commands/field-add-integration.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add integration",
@@ -44,10 +45,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-integration.ts
+++ b/src/commands/field-add-integration.ts
@@ -46,8 +46,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add link",
@@ -69,10 +70,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add link",

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -71,8 +71,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -49,7 +49,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Link = {
@@ -69,4 +69,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-number.ts
+++ b/src/commands/field-add-number.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add number",
@@ -52,12 +53,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });
 
 function parseNumber(value: string | undefined, optionName: string): number | undefined {

--- a/src/commands/field-add-number.ts
+++ b/src/commands/field-add-number.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add number",

--- a/src/commands/field-add-number.ts
+++ b/src/commands/field-add-number.ts
@@ -33,7 +33,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: NumberField = {
@@ -52,6 +52,12 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });
 
 function parseNumber(value: string | undefined, optionName: string): number | undefined {

--- a/src/commands/field-add-number.ts
+++ b/src/commands/field-add-number.ts
@@ -54,9 +54,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });
 

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -69,8 +69,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -49,7 +49,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: RichText = {
@@ -67,4 +67,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const ALL_BLOCKS =
 	"paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl";

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const ALL_BLOCKS =
 	"paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl";
@@ -67,10 +68,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add select",

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -38,7 +38,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Select = {
@@ -56,4 +56,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -58,8 +58,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add select",
@@ -56,10 +57,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-table.ts
+++ b/src/commands/field-add-table.ts
@@ -25,7 +25,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Table = {
@@ -40,4 +40,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-table.ts
+++ b/src/commands/field-add-table.ts
@@ -42,8 +42,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-table.ts
+++ b/src/commands/field-add-table.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add table",
@@ -40,10 +41,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-table.ts
+++ b/src/commands/field-add-table.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add table",

--- a/src/commands/field-add-text.ts
+++ b/src/commands/field-add-text.ts
@@ -26,7 +26,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Text = {
@@ -42,4 +42,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-text.ts
+++ b/src/commands/field-add-text.ts
@@ -44,8 +44,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-text.ts
+++ b/src/commands/field-add-text.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add text",

--- a/src/commands/field-add-text.ts
+++ b/src/commands/field-add-text.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add text",
@@ -42,10 +43,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-timestamp.ts
+++ b/src/commands/field-add-timestamp.ts
@@ -4,9 +4,13 @@ import { capitalCase } from "change-case";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
+import {
+	getPostFieldAddMessage,
+	resolveFieldTarget,
+	resolveModel,
+	TARGET_OPTIONS,
+} from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add timestamp",

--- a/src/commands/field-add-timestamp.ts
+++ b/src/commands/field-add-timestamp.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Timestamp = {
@@ -44,4 +44,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+	const targetId = values["to-slice"] ?? values["to-type"]!;
+	if (modelKind === "slice") {
+		console.info(`  View slice:  prismic slice view ${targetId}`);
+	} else {
+		console.info(`  View type:   prismic type view ${targetId}`);
+	}
 });

--- a/src/commands/field-add-timestamp.ts
+++ b/src/commands/field-add-timestamp.ts
@@ -46,8 +46,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Field added: ${id}`);
 	const targetId = values["to-slice"] ?? values["to-type"]!;
 	if (modelKind === "slice") {
-		console.info(`  View slice:  prismic slice view ${targetId}`);
+		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
 	} else {
-		console.info(`  View type:   prismic type view ${targetId}`);
+		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
 	}
 });

--- a/src/commands/field-add-timestamp.ts
+++ b/src/commands/field-add-timestamp.ts
@@ -6,6 +6,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldTarget, resolveModel, TARGET_OPTIONS } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add timestamp",
@@ -44,10 +45,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await saveModel();
 
 	console.info(`Field added: ${id}`);
+
 	const targetId = values["to-slice"] ?? values["to-type"]!;
-	if (modelKind === "slice") {
-		console.info(`Run \`prismic slice view ${targetId}\` to view the updated slice.`);
-	} else {
-		console.info(`Run \`prismic type view ${targetId}\` to view the updated type.`);
-	}
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-uid.ts
+++ b/src/commands/field-add-uid.ts
@@ -4,6 +4,7 @@ import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveModel } from "../models";
 import { getRepositoryName } from "../project";
+import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add uid",
@@ -22,7 +23,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const [fields, saveModel] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
 
 	const field: UID = {
 		type: "UID",
@@ -37,5 +38,7 @@ export default createCommand(config, async ({ values }) => {
 	await saveModel();
 
 	console.info("Field added: uid");
-	console.info(`Run \`prismic type view ${values["to-type"]!}\` to view the updated type.`);
+
+	const targetId = values["to-type"]!;
+	console.info(getPostFieldAddMessage({ targetId, modelKind }));
 });

--- a/src/commands/field-add-uid.ts
+++ b/src/commands/field-add-uid.ts
@@ -2,9 +2,8 @@ import type { UID } from "@prismicio/types-internal/lib/customtypes";
 
 import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { resolveModel } from "../models";
+import { getPostFieldAddMessage, resolveModel } from "../models";
 import { getRepositoryName } from "../project";
-import { getPostFieldAddMessage } from "./field-add";
 
 const config = {
 	name: "prismic field add uid",

--- a/src/commands/field-add-uid.ts
+++ b/src/commands/field-add-uid.ts
@@ -37,5 +37,5 @@ export default createCommand(config, async ({ values }) => {
 	await saveModel();
 
 	console.info("Field added: uid");
-	console.info(`  View type:  prismic type view ${values["to-type"]!}`);
+	console.info(`Run \`prismic type view ${values["to-type"]!}\` to view the updated type.`);
 });

--- a/src/commands/field-add-uid.ts
+++ b/src/commands/field-add-uid.ts
@@ -37,4 +37,5 @@ export default createCommand(config, async ({ values }) => {
 	await saveModel();
 
 	console.info("Field added: uid");
+	console.info(`  View type:  prismic type view ${values["to-type"]!}`);
 });

--- a/src/commands/field-add.ts
+++ b/src/commands/field-add.ts
@@ -92,3 +92,16 @@ export default createCommandRouter({
 		},
 	},
 });
+
+export function getPostFieldAddMessage(args: {
+	targetId: string;
+	modelKind: "slice" | "customType";
+}): string {
+	const { modelKind, targetId } = args;
+
+	if (modelKind === "slice") {
+		return `Run \`prismic slice view ${targetId}\` to view the updated slice.`;
+	} else {
+		return `Run \`prismic type view ${targetId}\` to view the updated type.`;
+	}
+}

--- a/src/commands/field-add.ts
+++ b/src/commands/field-add.ts
@@ -92,16 +92,3 @@ export default createCommandRouter({
 		},
 	},
 });
-
-export function getPostFieldAddMessage(args: {
-	targetId: string;
-	modelKind: "slice" | "customType";
-}): string {
-	const { modelKind, targetId } = args;
-
-	if (modelKind === "slice") {
-		return `Run \`prismic slice view ${targetId}\` to view the updated slice.`;
-	} else {
-		return `Run \`prismic type view ${targetId}\` to view the updated type.`;
-	}
-}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -153,8 +153,6 @@ export default createCommand(config, async ({ values }) => {
 	await adapter.syncModels({ repo, token, host });
 
 	console.info(`\nInitialized Prismic for repository "${repo}".`);
-	console.info("");
-	console.info("Next steps:");
-	console.info("  Create a type:  prismic type create <name>");
-	console.info("  Sync models:    prismic sync");
+	console.info("Run `prismic type create <name>` to create a content type.");
+	console.info("Run `prismic sync` to sync models from Prismic.");
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -153,4 +153,8 @@ export default createCommand(config, async ({ values }) => {
 	await adapter.syncModels({ repo, token, host });
 
 	console.info(`\nInitialized Prismic for repository "${repo}".`);
+	console.info("");
+	console.info("Next steps:");
+	console.info("  Create a type:  prismic type create <name>");
+	console.info("  Sync models:    prismic sync");
 });

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -52,5 +52,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	console.info(`Preview added: ${previewUrl}`);
 	console.info("");
 	console.info("Next steps:");
-	console.info("  Set simulator:  prismic preview set-simulator");
+	console.info("  Set simulator:  prismic preview set-simulator <url>");
 });

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -50,7 +50,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	console.info(`Preview added: ${previewUrl}`);
-	console.info("");
-	console.info("Next steps:");
-	console.info("  Set simulator:  prismic preview set-simulator <url>");
+	console.info("Run `prismic preview set-simulator <url>` to set the slice simulator URL.");
 });

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -50,4 +50,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	console.info(`Preview added: ${previewUrl}`);
+	console.info("");
+	console.info("Next steps:");
+	console.info("  Set simulator:  prismic preview set-simulator");
 });

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -40,6 +40,9 @@ export default createCommand(config, async ({ values }) => {
 
 	console.info(`Repository created: ${domain}`);
 	console.info(`URL: https://${domain}.${host}/`);
+	console.info("");
+	console.info("Next steps:");
+	console.info(`  Initialize project:  prismic init --repo ${domain}`);
 });
 
 async function findAvailableDomain(config: {

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -40,9 +40,7 @@ export default createCommand(config, async ({ values }) => {
 
 	console.info(`Repository created: ${domain}`);
 	console.info(`URL: https://${domain}.${host}/`);
-	console.info("");
-	console.info("Next steps:");
-	console.info(`  Initialize project:  prismic init --repo ${domain}`);
+	console.info(`Run \`prismic init --repo ${domain}\` to initialize a project.`);
 });
 
 async function findAvailableDomain(config: {

--- a/src/commands/slice-create.ts
+++ b/src/commands/slice-create.ts
@@ -60,8 +60,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await adapter.generateTypes();
 
 	console.info(`Created slice "${name}" (id: "${id}")`);
-	console.info("");
-	console.info("Next steps:");
-	console.info(`  Add fields:       prismic field add <type> --to-slice ${id}`);
-	console.info(`  Connect to type:  prismic slice connect ${id} --to <type>`);
+	console.info(`Run \`prismic field add <type> --to-slice ${id}\` to add fields.`);
+	console.info(`Run \`prismic slice connect ${id} --to <type>\` to connect the slice to a type.`);
 });

--- a/src/commands/slice-create.ts
+++ b/src/commands/slice-create.ts
@@ -60,4 +60,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await adapter.generateTypes();
 
 	console.info(`Created slice "${name}" (id: "${id}")`);
+	console.info("");
+	console.info("Next steps:");
+	console.info(`  Add fields:       prismic field add <type> --to-slice ${id}`);
+	console.info(`  Connect to type:  prismic slice connect ${id} --to <type>`);
 });

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -39,10 +39,11 @@ export default createCommand(config, async ({ values }) => {
 	const token = await getToken();
 	const host = await getHost();
 
+	let createdToken: string;
 	try {
 		if (write) {
 			const writeToken = await createWriteToken(CLI_APP_NAME, { repo, token, host });
-			console.info(`Token created: ${writeToken.token}`);
+			createdToken = writeToken.token;
 		} else {
 			const scope = allowReleases ? "master+releases" : "master";
 
@@ -52,7 +53,7 @@ export default createCommand(config, async ({ values }) => {
 			if (!app) app = await createOAuthApp(CLI_APP_NAME, { repo, token, host });
 
 			const accessToken = await createOAuthAuthorization(app.id, scope, { repo, token, host });
-			console.info(`Token created: ${accessToken.token}`);
+			createdToken = accessToken.token;
 		}
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
@@ -61,4 +62,9 @@ export default createCommand(config, async ({ values }) => {
 		}
 		throw error;
 	}
+
+	console.info(`Token created: ${createdToken}`);
+	console.info("");
+	console.info("Next steps:");
+	console.info(`  Add to .env:  PRISMIC_TOKEN=${createdToken}`);
 });

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -64,7 +64,5 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	console.info(`Token created: ${createdToken}`);
-	console.info("");
-	console.info("Next steps:");
-	console.info(`  Add to .env:  PRISMIC_TOKEN=${createdToken}`);
+	console.info(`Add it to your .env file: PRISMIC_TOKEN=${createdToken}`);
 });

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -64,5 +64,6 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	console.info(`Token created: ${createdToken}`);
-	console.info(`Add it to your .env file: PRISMIC_TOKEN=${createdToken}`);
+	const envVar = write ? "PRISMIC_WRITE_TOKEN" : "PRISMIC_ACCESS_TOKEN";
+	console.info(`Add it to your .env file: ${envVar}=${createdToken}`);
 });

--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -113,4 +113,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await adapter.generateTypes();
 
 	console.info(`Created type "${name}" (id: "${id}", format: "${format}")`);
+	console.info("");
+	console.info("Next steps:");
+	console.info(`  Add fields:  prismic field add <type> --to-type ${id}`);
+	console.info(`  View type:   prismic type view ${id}`);
 });

--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -113,8 +113,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	await adapter.generateTypes();
 
 	console.info(`Created type "${name}" (id: "${id}", format: "${format}")`);
-	console.info("");
-	console.info("Next steps:");
-	console.info(`  Add fields:  prismic field add <type> --to-type ${id}`);
-	console.info(`  View type:   prismic type view ${id}`);
+	console.info(`Run \`prismic field add <type> --to-type ${id}\` to add fields.`);
+	console.info(`Run \`prismic type view ${id}\` to view the type.`);
 });

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -82,7 +82,5 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	console.info(`Webhook created: ${webhookUrl}`);
-	console.info("");
-	console.info("Next steps:");
-	console.info(`  Set triggers:  prismic webhook set-triggers ${webhookUrl}`);
+	console.info(`Run \`prismic webhook set-triggers ${webhookUrl}\` to configure triggers.`);
 });

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -82,4 +82,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 
 	console.info(`Webhook created: ${webhookUrl}`);
+	console.info("");
+	console.info("Next steps:");
+	console.info(`  Set triggers:  prismic webhook set-triggers ${webhookUrl}`);
 });

--- a/src/models.ts
+++ b/src/models.ts
@@ -435,3 +435,16 @@ function validateLeafField(id: string, fields: Record<string, Field>, context: s
 		);
 	}
 }
+
+export function getPostFieldAddMessage(args: {
+	targetId: string;
+	modelKind: "slice" | "customType";
+}): string {
+	const { modelKind, targetId } = args;
+
+	if (modelKind === "slice") {
+		return `Run \`prismic slice view ${targetId}\` to view the updated slice.`;
+	} else {
+		return `Run \`prismic type view ${targetId}\` to view the updated type.`;
+	}
+}

--- a/test/token-create.test.ts
+++ b/test/token-create.test.ts
@@ -12,7 +12,8 @@ it("creates an access token", async ({ expect, prismic, repo, token, host }) => 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Token created:");
 
-	const createdToken = stdout.replace("Token created:", "").trim();
+	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
+	expect(createdToken).toBeDefined();
 
 	const apps = await getAccessTokens({ repo, token, host });
 	const app = apps.find((a) => a.name === "Prismic CLI");
@@ -32,7 +33,8 @@ it("creates an access token with --allow-releases", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Token created:");
 
-	const createdToken = stdout.replace("Token created:", "").trim();
+	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
+	expect(createdToken).toBeDefined();
 
 	const apps = await getAccessTokens({ repo, token, host });
 	const app = apps.find((a) => a.name === "Prismic CLI");
@@ -47,7 +49,8 @@ it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Token created:");
 
-	const createdToken = stdout.replace("Token created:", "").trim();
+	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
+	expect(createdToken).toBeDefined();
 
 	const writeTokensInfo = await getWriteTokens({ repo, token, host });
 	const found = writeTokensInfo.tokens.find((t) => t.token === createdToken);


### PR DESCRIPTION
Resolves: #149

### Description

After mutating commands (create/add) complete, prints a hint about the next logical action. This helps discoverability so users don't need to know the full command tree.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run any mutating command and verify the next-step hint appears after the success message. For example:
- `prismic type create "Test"` should suggest `prismic field add` and `prismic type view`
- `prismic field add text title --to-type test` should suggest `prismic type view test`

[^1]:
	Please use these labels when submitting a review:
	:question: #ask: Ask a question.
	:bulb: #idea: Suggest an idea.
	:warning: #issue: Strongly suggest a change.
	:tada: #nice: Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to additional CLI output strings and minor plumbing to determine whether the target is a slice vs custom type; no API behavior or data mutation logic changes.
> 
> **Overview**
> After successful *mutating* CLI commands, the CLI now prints suggested next actions to improve discoverability (e.g. `init`, `repo create`, `type create`, `slice create`, `preview add`, `webhook create`).
> 
> All `field add ...` commands now print a follow-up message pointing to `prismic slice view` vs `prismic type view` depending on the target; this is centralized via new `getPostFieldAddMessage()` in `models.ts` and requires `resolveModel()` callers to consume the returned `modelKind`.
> 
> `token create` now prints the created token once plus a `.env` snippet (`PRISMIC_ACCESS_TOKEN`/`PRISMIC_WRITE_TOKEN`), and the token-create tests were updated to parse the token from the new multi-line output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73976d5feb85f0f404a13bf42f2fbb4b1cccaad8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->