### PR TITLE
fix(win32): don't open extra terminal

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,7 +1,6 @@
-import { exec } from "node:child_process";
-
 import { createLoginSession } from "../auth";
 import { createCommand, type CommandConfig } from "../lib/command";
+import { openBrowser } from "../lib/browser";
 
 const config = {
 	name: "prismic login",
@@ -28,9 +27,3 @@ export default createCommand(config, async ({ values }) => {
 
 	console.info(`Logged in to Prismic as ${email}`);
 });
-
-function openBrowser(url: URL): void {
-	const cmd =
-		process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
-	exec(`${cmd} "${url.toString()}"`);
-}

--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -2,6 +2,6 @@ import { exec } from "node:child_process";
 
 export function openBrowser(url: URL): void {
 	const cmd =
-		process.platform === "darwin" ? "open" : process.platform === "win32" ? "start" : "xdg-open";
+		process.platform === "darwin" ? "open" : process.platform === "win32" ? 'start ""' : "xdg-open";
 	exec(`${cmd} "${url.toString()}"`);
 }


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: N/A

### Description

This updates the CLI's browser launcher so Windows opens authentication URLs without spawning an extra terminal window. It does that by using `start "" "<url>"`, which avoids having the quoted URL interpreted as the window title.

It also routes `login` through the shared `openBrowser()` helper so browser-opening behavior stays centralized and consistent anywhere the CLI launches the user's browser.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

N/A

### How to QA [^1]

1. On Windows, run the CLI command that opens the browser, such as `prismic login`.
2. Confirm the default browser opens to the login URL without a separate terminal window appearing.
3. Run `prismic login --no-browser` and confirm the CLI prints the login URL instead of trying to open a browser.

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to how the CLI shells out to open URLs, primarily affecting Windows `start` behavior; could only impact browser-launching flows.
> 
> **Overview**
> Centralizes `prismic login` browser launching by switching it to the shared `openBrowser()` helper instead of an inline `exec` implementation.
> 
> Updates `openBrowser()` on Windows to use `start "" "<url>"` so opening authentication URLs no longer spawns an extra terminal window and avoids the URL being treated as the window title.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d179d1e96197915e28bb0a90295445303e971f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->