### PR TITLE
feat: operate on local models only

### DIFF
--- a/src/commands/field-add-boolean.ts
+++ b/src/commands/field-add-boolean.ts
@@ -2,7 +2,6 @@ import type { BooleanField } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add boolean",
@@ -34,12 +32,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 		"default-value": default_value,
 		"true-label": placeholder_true,
 		"false-label": placeholder_false,
-		repo = await getRepositoryName(),
 	} = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: BooleanField = {

--- a/src/commands/field-add-color.ts
+++ b/src/commands/field-add-color.ts
@@ -2,7 +2,6 @@ import type { Color } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add color",
@@ -27,11 +25,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, repo = await getRepositoryName() } = values;
+	const { label, placeholder } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Color = {

--- a/src/commands/field-add-content-relationship.ts
+++ b/src/commands/field-add-content-relationship.ts
@@ -2,8 +2,6 @@ import type { Link } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
-import { getCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -12,7 +10,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add content-relationship",
@@ -77,31 +74,18 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const {
-		label,
-		tag: tags,
-		"custom-type": customtypes,
-		field: fieldSelection,
-		repo = await getRepositoryName(),
-	} = values;
+	const { label, tag: tags, "custom-type": customtypes, field: fieldSelection } = values;
 
 	if (fieldSelection && (!customtypes || customtypes.length !== 1)) {
 		throw new CommandError("--field requires exactly one --custom-type.");
 	}
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	let resolvedCustomTypes: NonNullable<Link["config"]>["customtypes"] = customtypes;
 	if (fieldSelection && customtypes) {
-		const targetType = await getCustomType(customtypes[0], { repo, token, host });
-		const resolvedFields = await resolveFieldSelection(fieldSelection, targetType, {
-			repo,
-			token,
-			host,
-		});
+		const resolvedFields = await resolveFieldSelection(fieldSelection, customtypes[0]);
 		resolvedCustomTypes = [
 			{ id: customtypes[0], fields: resolvedFields },
 		] as typeof resolvedCustomTypes;

--- a/src/commands/field-add-date.ts
+++ b/src/commands/field-add-date.ts
@@ -2,7 +2,6 @@ import type { Date as DateField } from "@prismicio/types-internal/lib/customtype
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add date",
@@ -28,11 +26,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, default: defaultValue, repo = await getRepositoryName() } = values;
+	const { label, placeholder, default: defaultValue } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: DateField = {

--- a/src/commands/field-add-embed.ts
+++ b/src/commands/field-add-embed.ts
@@ -2,7 +2,6 @@ import type { Embed } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add embed",
@@ -27,11 +25,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, repo = await getRepositoryName() } = values;
+	const { label, placeholder } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Embed = {

--- a/src/commands/field-add-geopoint.ts
+++ b/src/commands/field-add-geopoint.ts
@@ -2,7 +2,6 @@ import type { GeoPoint } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add geopoint",
@@ -26,11 +24,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, repo = await getRepositoryName() } = values;
+	const { label } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: GeoPoint = {

--- a/src/commands/field-add-group.ts
+++ b/src/commands/field-add-group.ts
@@ -2,7 +2,6 @@ import type { Group } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add group",
@@ -26,11 +24,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, repo = await getRepositoryName() } = values;
+	const { label } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Group = {

--- a/src/commands/field-add-image.ts
+++ b/src/commands/field-add-image.ts
@@ -2,7 +2,6 @@ import type { Image } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add image",
@@ -27,11 +25,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, repo = await getRepositoryName() } = values;
+	const { label, placeholder } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Image = {

--- a/src/commands/field-add-integration.ts
+++ b/src/commands/field-add-integration.ts
@@ -2,7 +2,6 @@ import type { IntegrationField } from "@prismicio/types-internal/lib/customtypes
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add integration",
@@ -28,11 +26,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, catalog, repo = await getRepositoryName() } = values;
+	const { label, placeholder, catalog } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: IntegrationField = {

--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -2,7 +2,6 @@ import type { Link } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add link",
@@ -56,7 +54,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 		"allow-text": allowText,
 		repeatable: repeat,
 		variant: variants,
-		repo = await getRepositoryName(),
 	} = values;
 
 	if (allow && !ALLOWED_LINK_TYPES.includes(allow as (typeof ALLOWED_LINK_TYPES)[number])) {
@@ -64,9 +61,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 	}
 	const select = allow as (typeof ALLOWED_LINK_TYPES)[number] | undefined;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Link = {

--- a/src/commands/field-add-number.ts
+++ b/src/commands/field-add-number.ts
@@ -2,7 +2,6 @@ import type { Number as NumberField } from "@prismicio/types-internal/lib/custom
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add number",
@@ -30,15 +28,13 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, repo = await getRepositoryName() } = values;
+	const { label, placeholder } = values;
 
 	const min = parseNumber(values.min, "min");
 	const max = parseNumber(values.max, "max");
 	const step = parseNumber(values.step, "step");
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: NumberField = {

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -2,7 +2,6 @@ import type { RichText } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const ALL_BLOCKS =
 	"paragraph,preformatted,heading1,heading2,heading3,heading4,heading5,heading6,strong,em,hyperlink,image,embed,list-item,o-list-item,rtl";
@@ -56,12 +54,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 		allow = ALL_BLOCKS,
 		single: isSingle,
 		"allow-target-blank": allowTargetBlank,
-		repo = await getRepositoryName(),
 	} = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: RichText = {

--- a/src/commands/field-add-select.ts
+++ b/src/commands/field-add-select.ts
@@ -2,7 +2,6 @@ import type { Select } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add select",
@@ -47,12 +45,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 		placeholder,
 		"default-value": default_value,
 		option: options,
-		repo = await getRepositoryName(),
 	} = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Select = {

--- a/src/commands/field-add-table.ts
+++ b/src/commands/field-add-table.ts
@@ -2,7 +2,6 @@ import type { Table } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add table",
@@ -26,11 +24,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, repo = await getRepositoryName() } = values;
+	const { label } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Table = {

--- a/src/commands/field-add-text.ts
+++ b/src/commands/field-add-text.ts
@@ -2,7 +2,6 @@ import type { Text } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add text",
@@ -27,11 +25,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, repo = await getRepositoryName() } = values;
+	const { label, placeholder } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Text = {

--- a/src/commands/field-add-timestamp.ts
+++ b/src/commands/field-add-timestamp.ts
@@ -2,7 +2,6 @@ import type { Timestamp } from "@prismicio/types-internal/lib/customtypes";
 
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	getPostFieldAddMessage,
@@ -10,7 +9,6 @@ import {
 	resolveModel,
 	TARGET_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add timestamp",
@@ -28,11 +26,9 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { label, placeholder, default: defaultValue, repo = await getRepositoryName() } = values;
+	const { label, placeholder, default: defaultValue } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field: Timestamp = {

--- a/src/commands/field-add-uid.ts
+++ b/src/commands/field-add-uid.ts
@@ -1,9 +1,7 @@
 import type { UID } from "@prismicio/types-internal/lib/customtypes";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { getPostFieldAddMessage, resolveModel } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field add uid",
@@ -11,18 +9,15 @@ const config = {
 	options: {
 		"to-type": { type: "string", description: "Name of the target content type" },
 		tab: { type: "string", description: 'Content type tab name (default: "Main")' },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 		label: { type: "string", description: "Field label" },
 		placeholder: { type: "string", description: "Placeholder text" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { label = "UID", placeholder, repo = await getRepositoryName() } = values;
+	const { label = "UID", placeholder } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel, modelKind] = await resolveModel(values, { repo, token, host });
+	const [fields, saveModel, modelKind] = await resolveModel(values);
 
 	const field: UID = {
 		type: "UID",

--- a/src/commands/field-edit.ts
+++ b/src/commands/field-edit.ts
@@ -1,5 +1,3 @@
-import { getHost, getToken } from "../auth";
-import { getCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import {
 	resolveFieldContainer,
@@ -7,7 +5,6 @@ import {
 	resolveFieldTarget,
 	SOURCE_OPTIONS,
 } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field edit",
@@ -101,11 +98,8 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel] = await resolveFieldContainer(id, values, { repo, token, host });
+	const [fields, saveModel] = await resolveFieldContainer(id, values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field = targetFields[fieldId];
@@ -192,12 +186,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 					);
 				}
 				const ctId = typeof cts[0] === "string" ? cts[0] : cts[0].id;
-				const targetType = await getCustomType(ctId, { repo, token, host });
-				const resolvedFields = await resolveFieldSelection(values.field!, targetType, {
-					repo,
-					token,
-					host,
-				});
+				const resolvedFields = await resolveFieldSelection(values.field!, ctId);
 				field.config.customtypes = [
 					{ id: ctId, fields: resolvedFields },
 				] as typeof field.config.customtypes;

--- a/src/commands/field-remove.ts
+++ b/src/commands/field-remove.ts
@@ -1,7 +1,5 @@
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldContainer, resolveFieldTarget, SOURCE_OPTIONS } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field remove",
@@ -14,11 +12,8 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields, saveModel] = await resolveFieldContainer(id, values, { repo, token, host });
+	const [fields, saveModel] = await resolveFieldContainer(id, values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 	if (!(fieldId in targetFields)) throw new CommandError(`Field "${id}" does not exist.`);
 	delete targetFields[fieldId];

--- a/src/commands/field-reorder.ts
+++ b/src/commands/field-reorder.ts
@@ -1,7 +1,5 @@
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { resolveFieldPair, resolveFieldTarget } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field reorder",
@@ -15,13 +13,12 @@ const config = {
 		"from-slice": { type: "string", description: "ID of the source slice" },
 		"from-type": { type: "string", description: "ID of the source content type" },
 		variation: { type: "string", description: 'Slice variation ID (default: "default")' },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { before, after, repo = await getRepositoryName() } = values;
+	const { before, after } = values;
 
 	if (!before && !after) {
 		throw new CommandError("Specify --before or --after.");
@@ -48,13 +45,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		);
 	}
 
-	const token = await getToken();
-	const host = await getHost();
-	const [sourceFields, anchorFields, saveModel] = await resolveFieldPair(id, anchor, values, {
-		repo,
-		token,
-		host,
-	});
+	const [sourceFields, anchorFields, saveModel] = await resolveFieldPair(id, anchor, values);
 
 	const [sourceLeaf, sourceFieldId] = resolveFieldTarget(sourceFields, id);
 	const [anchorLeaf, anchorFieldId] = resolveFieldTarget(anchorFields, anchor);

--- a/src/commands/field-view.ts
+++ b/src/commands/field-view.ts
@@ -1,10 +1,8 @@
 import { capitalCase } from "change-case";
 
-import { getHost, getToken } from "../auth";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { resolveFieldContainer, resolveFieldTarget, SOURCE_OPTIONS } from "../models";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic field view",
@@ -20,11 +18,8 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const [fields] = await resolveFieldContainer(id, values, { repo, token, host });
+	const [fields] = await resolveFieldContainer(id, values);
 	const [targetFields, fieldId] = resolveFieldTarget(fields, id);
 
 	const field = targetFields[fieldId];

--- a/src/commands/slice-add-variation.ts
+++ b/src/commands/slice-add-variation.ts
@@ -1,19 +1,11 @@
-import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-
 import { camelCase } from "change-case";
 import { pathToFileURL } from "node:url";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import {
-	getSlice,
-	UnsupportedFileTypeError,
-	updateSlice,
-	uploadScreenshot,
-} from "../clients/custom-types";
+import { UnsupportedFileTypeError, uploadScreenshot } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { readURLFile } from "../lib/file";
-import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -26,18 +18,15 @@ const config = {
 		to: { type: "string", required: true, description: "ID of the slice" },
 		id: { type: "string", description: "Custom ID for the variation" },
 		screenshot: { type: "string", short: "s", description: "Screenshot image file path or URL" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const { to, id = camelCase(name), screenshot, repo = await getRepositoryName() } = values;
+	const { to, id = camelCase(name), screenshot } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(to, { repo, token, host });
+	const { model: slice } = await adapter.getSlice(to);
 
 	if (slice.variations.some((v) => v.id === id)) {
 		throw new CommandError(`Variation "${id}" already exists in slice "${to}".`);
@@ -45,6 +34,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	let imageUrl = "";
 	if (screenshot) {
+		const repo = await getRepositoryName();
+		const token = await getToken();
+		const host = await getHost();
+
 		const url = /^https?:\/\//i.test(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
 		const blob = await readURLFile(url);
 		let screenshotUrl;
@@ -65,37 +58,20 @@ export default createCommand(config, async ({ positionals, values }) => {
 		imageUrl = screenshotUrl.toString();
 	}
 
-	const updatedSlice: SharedSlice = {
-		...slice,
-		variations: [
-			...slice.variations,
-			{
-				id,
-				name,
-				description: name,
-				docURL: "",
-				imageUrl,
-				version: "",
-				primary: {},
-			},
-		],
-	};
+	slice.variations = [
+		...slice.variations,
+		{
+			id,
+			name,
+			description: name,
+			docURL: "",
+			imageUrl,
+			version: "",
+			primary: {},
+		},
+	];
 
-	try {
-		await updateSlice(updatedSlice, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to add variation: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateSlice(updatedSlice);
-	} catch {
-		await adapter.createSlice(updatedSlice);
-	}
+	await adapter.updateSlice(slice);
 	await adapter.generateTypes();
 
 	console.info(`Added variation "${name}" (id: "${id}") to slice "${to}"`);

--- a/src/commands/slice-connect.ts
+++ b/src/commands/slice-connect.ts
@@ -1,11 +1,7 @@
 import type { DynamicWidget } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, getSlice, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic slice connect",
@@ -32,21 +28,16 @@ const config = {
 			type: "string",
 			description: 'Slice zone field ID (default: "slices")',
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { to, "slice-zone": sliceZone = "slices", repo = await getRepositoryName() } = values;
+	const { to, "slice-zone": sliceZone = "slices" } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const apiConfig = { repo, token, host };
-
-	const slice = await getSlice(id, apiConfig);
-	const customType = await getCustomType(to, apiConfig);
+	const { model: slice } = await adapter.getSlice(id);
+	const { model: customType } = await adapter.getCustomType(to);
 
 	const allFields: Record<string, DynamicWidget> = Object.assign(
 		{},
@@ -69,21 +60,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	sliceZoneField.config.choices[slice.id] = { type: "SharedSlice" };
 
-	try {
-		await updateCustomType(customType, apiConfig);
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to connect slice: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Connected slice "${id}" to "${to}"`);

--- a/src/commands/slice-create.ts
+++ b/src/commands/slice-create.ts
@@ -3,11 +3,7 @@ import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import { snakeCase } from "change-case";
 
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { insertSlice } from "../clients/custom-types";
-import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
+import { createCommand, type CommandConfig } from "../lib/command";
 
 const config = {
 	name: "prismic slice create",
@@ -17,13 +13,12 @@ const config = {
 	},
 	options: {
 		id: { type: "string", description: "Custom ID for the slice" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const { id = snakeCase(name), repo = await getRepositoryName() } = values;
+	const { id = snakeCase(name) } = values;
 
 	const model: SharedSlice = {
 		id,
@@ -43,19 +38,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	};
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-
-	try {
-		await insertSlice(model, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to create slice: ${message}`);
-		}
-		throw error;
-	}
-
 	await adapter.createSlice(model);
 	await adapter.generateTypes();
 

--- a/src/commands/slice-disconnect.ts
+++ b/src/commands/slice-disconnect.ts
@@ -1,11 +1,7 @@
 import type { DynamicWidget } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, getSlice, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic slice disconnect",
@@ -23,21 +19,16 @@ const config = {
 			type: "string",
 			description: 'Slice zone field ID (default: "slices")',
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { from, "slice-zone": sliceZone = "slices", repo = await getRepositoryName() } = values;
+	const { from, "slice-zone": sliceZone = "slices" } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const apiConfig = { repo, token, host };
-
-	const slice = await getSlice(id, apiConfig);
-	const customType = await getCustomType(from, apiConfig);
+	const { model: slice } = await adapter.getSlice(id);
+	const { model: customType } = await adapter.getCustomType(from);
 
 	const allFields: Record<string, DynamicWidget> = Object.assign(
 		{},
@@ -57,21 +48,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	delete sliceZoneField.config.choices[slice.id];
 
-	try {
-		await updateCustomType(customType, apiConfig);
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to disconnect slice: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Disconnected slice "${id}" from "${from}"`);

--- a/src/commands/slice-edit-variation.ts
+++ b/src/commands/slice-edit-variation.ts
@@ -2,15 +2,9 @@ import { pathToFileURL } from "node:url";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
-import {
-	getSlice,
-	UnsupportedFileTypeError,
-	updateSlice,
-	uploadScreenshot,
-} from "../clients/custom-types";
+import { UnsupportedFileTypeError, uploadScreenshot } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { readURLFile } from "../lib/file";
-import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
 
 const config = {
@@ -23,18 +17,15 @@ const config = {
 		"from-slice": { type: "string", required: true, description: "ID of the slice" },
 		name: { type: "string", short: "n", description: "New name for the variation" },
 		screenshot: { type: "string", short: "s", description: "Screenshot image file path or URL" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { "from-slice": sliceId, screenshot, repo = await getRepositoryName() } = values;
+	const { "from-slice": sliceId, screenshot } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(sliceId, { repo, token, host });
+	const { model: slice } = await adapter.getSlice(sliceId);
 
 	const variation = slice.variations.find((v) => v.id === id);
 	if (!variation) {
@@ -44,6 +35,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 	if ("name" in values) variation.name = values.name!;
 
 	if (screenshot) {
+		const repo = await getRepositoryName();
+		const token = await getToken();
+		const host = await getHost();
+
 		const url = /^https?:\/\//i.test(screenshot) ? new URL(screenshot) : pathToFileURL(screenshot);
 		const blob = await readURLFile(url);
 		let screenshotUrl;
@@ -64,21 +59,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		variation.imageUrl = screenshotUrl.toString();
 	}
 
-	try {
-		await updateSlice(slice, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to update variation: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateSlice(slice);
-	} catch {
-		await adapter.createSlice(slice);
-	}
+	await adapter.updateSlice(slice);
 	await adapter.generateTypes();
 
 	console.info(`Variation updated: "${id}" in slice "${sliceId}"`);

--- a/src/commands/slice-edit.ts
+++ b/src/commands/slice-edit.ts
@@ -1,11 +1,5 @@
-import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice } from "../clients/custom-types";
-import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
+import { createCommand, type CommandConfig } from "../lib/command";
 
 const config = {
 	name: "prismic slice edit",
@@ -15,39 +9,19 @@ const config = {
 	},
 	options: {
 		name: { type: "string", short: "n", description: "New name for the slice" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(id, { repo, token, host });
+	const { model: slice } = await adapter.getSlice(id);
 
-	const updatedSlice: SharedSlice = { ...slice };
+	if ("name" in values) slice.name = values.name!;
 
-	if ("name" in values) updatedSlice.name = values.name!;
-
-	try {
-		await updateSlice(updatedSlice, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to update slice: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateSlice(updatedSlice);
-	} catch {
-		await adapter.createSlice(updatedSlice);
-	}
+	await adapter.updateSlice(slice);
 	await adapter.generateTypes();
 
-	console.info(`Slice updated: "${updatedSlice.name}" (id: ${updatedSlice.id})`);
+	console.info(`Slice updated: "${slice.name}" (id: ${slice.id})`);
 });

--- a/src/commands/slice-list.ts
+++ b/src/commands/slice-list.ts
@@ -1,28 +1,24 @@
-import { getHost, getToken } from "../auth";
-import { getSlices } from "../clients/custom-types";
+import { getAdapter } from "../adapters";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic slice list",
 	description: "List all slices.",
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { json, repo = await getRepositoryName() } = values;
+	const { json } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const slices = await getSlices({ repo, token, host });
+	const adapter = await getAdapter();
+	const slices = await adapter.getSlices();
 
 	if (json) {
-		console.info(stringify(slices));
+		console.info(stringify(slices.map((s) => s.model)));
 		return;
 	}
 
@@ -31,6 +27,6 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	const rows = slices.map((slice) => [slice.name, slice.id]);
+	const rows = slices.map(({ model }) => [model.name, model.id]);
 	console.info(formatTable(rows, { headers: ["NAME", "ID"] }));
 });

--- a/src/commands/slice-remove-variation.ts
+++ b/src/commands/slice-remove-variation.ts
@@ -1,11 +1,5 @@
-import type { SharedSlice } from "@prismicio/types-internal/lib/customtypes";
-
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getSlice, updateSlice } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic slice remove-variation",
@@ -15,45 +9,24 @@ const config = {
 	},
 	options: {
 		from: { type: "string", required: true, description: "ID of the slice" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { from, repo = await getRepositoryName() } = values;
+	const { from } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(from, { repo, token, host });
+	const { model: slice } = await adapter.getSlice(from);
 
 	const variation = slice.variations.find((v) => v.id === id);
-
 	if (!variation) {
 		throw new CommandError(`Variation "${id}" not found in slice "${from}".`);
 	}
 
-	const updatedSlice: SharedSlice = {
-		...slice,
-		variations: slice.variations.filter((v) => v.id !== variation.id),
-	};
+	slice.variations = slice.variations.filter((v) => v.id !== variation.id);
 
-	try {
-		await updateSlice(updatedSlice, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to remove variation: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateSlice(updatedSlice);
-	} catch {
-		await adapter.createSlice(updatedSlice);
-	}
+	await adapter.updateSlice(slice);
 	await adapter.generateTypes();
 
 	console.info(`Removed variation "${id}" from slice "${from}"`);

--- a/src/commands/slice-remove.ts
+++ b/src/commands/slice-remove.ts
@@ -1,9 +1,5 @@
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getSlice, removeSlice } from "../clients/custom-types";
-import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
+import { createCommand, type CommandConfig } from "../lib/command";
 
 const config = {
 	name: "prismic slice remove",
@@ -11,33 +7,15 @@ const config = {
 	positionals: {
 		id: { description: "ID of the slice", required: true },
 	},
-	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-	},
 } satisfies CommandConfig;
 
-export default createCommand(config, async ({ positionals, values }) => {
+export default createCommand(config, async ({ positionals }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(id, { repo, token, host });
+	const { model: slice } = await adapter.getSlice(id);
 
-	try {
-		await removeSlice(slice.id, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to remove slice: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.deleteSlice(slice.id);
-	} catch {}
+	await adapter.deleteSlice(slice.id);
 	await adapter.generateTypes();
 
 	console.info(`Slice removed: ${id}`);

--- a/src/commands/slice-view.ts
+++ b/src/commands/slice-view.ts
@@ -1,9 +1,7 @@
-import { getHost, getToken } from "../auth";
-import { getSlice } from "../clients/custom-types";
+import { getAdapter } from "../adapters";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic slice view",
@@ -13,17 +11,15 @@ const config = {
 	},
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { json, repo = await getRepositoryName() } = values;
+	const { json } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const slice = await getSlice(id, { repo, token, host });
+	const adapter = await getAdapter();
+	const { model: slice } = await adapter.getSlice(id);
 
 	if (json) {
 		console.info(stringify(slice));

--- a/src/commands/type-add-tab.ts
+++ b/src/commands/type-add-tab.ts
@@ -1,9 +1,5 @@
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type add-tab",
@@ -14,18 +10,15 @@ const config = {
 	options: {
 		to: { type: "string", required: true, description: "ID of the content type" },
 		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const { to, "with-slice-zone": withSliceZone, repo = await getRepositoryName() } = values;
+	const { to, "with-slice-zone": withSliceZone } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const customType = await getCustomType(to, { repo, token, host });
+	const { model: customType } = await adapter.getCustomType(to);
 
 	if (name in customType.json) {
 		throw new CommandError(`Tab "${name}" already exists in "${to}".`);
@@ -41,21 +34,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 			}
 		: {};
 
-	try {
-		await updateCustomType(customType, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to add tab: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Added tab "${name}" to "${to}"`);

--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -3,11 +3,7 @@ import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
 import { snakeCase } from "change-case";
 
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { insertCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type create",
@@ -23,7 +19,6 @@ const config = {
 		},
 		single: { type: "boolean", short: "s", description: "Allow only one document of this type" },
 		id: { type: "string", description: "Custom ID for the content type" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 	sections: {
 		FORMATS: `
@@ -48,12 +43,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const {
-		format = "custom",
-		single = false,
-		id = snakeCase(name),
-		repo = await getRepositoryName(),
-	} = values;
+	const { format = "custom", single = false, id = snakeCase(name) } = values;
 
 	if (format !== "custom" && format !== "page") {
 		throw new CommandError(`Invalid format: "${format}". Use "custom" or "page".`);
@@ -106,19 +96,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	};
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-
-	try {
-		await insertCustomType(model, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to create type: ${message}`);
-		}
-		throw error;
-	}
-
 	await adapter.createCustomType(model);
 	await adapter.generateTypes();
 

--- a/src/commands/type-edit-tab.ts
+++ b/src/commands/type-edit-tab.ts
@@ -1,11 +1,7 @@
 import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
 
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type edit-tab",
@@ -18,18 +14,15 @@ const config = {
 		name: { type: "string", short: "n", description: "New name for the tab" },
 		"with-slice-zone": { type: "boolean", description: "Add a slice zone to the tab" },
 		"without-slice-zone": { type: "boolean", description: "Remove the slice zone from the tab" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [currentName] = positionals;
-	const { "from-type": typeId, repo = await getRepositoryName() } = values;
+	const { "from-type": typeId } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const customType = await getCustomType(typeId, { repo, token, host });
+	const { model: customType } = await adapter.getCustomType(typeId);
 
 	if (!(currentName in customType.json)) {
 		throw new CommandError(`Tab "${currentName}" not found in "${typeId}".`);
@@ -86,21 +79,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		customType.json = newJson;
 	}
 
-	try {
-		await updateCustomType(customType, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to update tab: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Tab updated: "${currentName}" in "${typeId}"`);

--- a/src/commands/type-edit.ts
+++ b/src/commands/type-edit.ts
@@ -1,9 +1,5 @@
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type edit",
@@ -14,41 +10,23 @@ const config = {
 	options: {
 		name: { type: "string", short: "n", description: "New name for the type" },
 		format: { type: "string", short: "f", description: 'Type format: "custom" or "page"' },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
 	if ("format" in values && values.format !== "custom" && values.format !== "page") {
 		throw new CommandError(`Invalid format: "${values.format}". Use "custom" or "page".`);
 	}
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const customType = await getCustomType(id, { repo, token, host });
+	const { model: customType } = await adapter.getCustomType(id);
 
 	if ("name" in values) customType.label = values.name;
 	if ("format" in values) customType.format = values.format as "custom" | "page";
 
-	try {
-		await updateCustomType(customType, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to update type: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Type updated: "${customType.label}" (id: ${customType.id})`);

--- a/src/commands/type-list.ts
+++ b/src/commands/type-list.ts
@@ -1,29 +1,24 @@
-import { getHost, getToken } from "../auth";
-import { getCustomTypes } from "../clients/custom-types";
+import { getAdapter } from "../adapters";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type list",
 	description: "List all content types.",
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { json, repo = await getRepositoryName() } = values;
+	const { json } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-
-	const types = await getCustomTypes({ repo, token, host });
+	const adapter = await getAdapter();
+	const types = await adapter.getCustomTypes();
 
 	if (json) {
-		console.info(stringify(types));
+		console.info(stringify(types.map((t) => t.model)));
 		return;
 	}
 
@@ -32,9 +27,9 @@ export default createCommand(config, async ({ values }) => {
 		return;
 	}
 
-	const rows = types.map((type) => {
-		const label = type.label || "(no name)";
-		return [label, type.id, type.format ?? ""];
+	const rows = types.map(({ model }) => {
+		const label = model.label || "(no name)";
+		return [label, model.id, model.format ?? ""];
 	});
 	console.info(formatTable(rows, { headers: ["NAME", "ID", "FORMAT"] }));
 });

--- a/src/commands/type-remove-tab.ts
+++ b/src/commands/type-remove-tab.ts
@@ -1,9 +1,5 @@
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, updateCustomType } from "../clients/custom-types";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type remove-tab",
@@ -13,18 +9,15 @@ const config = {
 	},
 	options: {
 		from: { type: "string", required: true, description: "ID of the content type" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [name] = positionals;
-	const { from, repo = await getRepositoryName() } = values;
+	const { from } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const customType = await getCustomType(from, { repo, token, host });
+	const { model: customType } = await adapter.getCustomType(from);
 
 	if (!(name in customType.json)) {
 		throw new CommandError(`Tab "${name}" not found in "${from}".`);
@@ -36,21 +29,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	delete customType.json[name];
 
-	try {
-		await updateCustomType(customType, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			throw new CommandError(`Failed to remove tab: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.updateCustomType(customType);
-	} catch {
-		await adapter.createCustomType(customType);
-	}
+	await adapter.updateCustomType(customType);
 	await adapter.generateTypes();
 
 	console.info(`Removed tab "${name}" from "${from}"`);

--- a/src/commands/type-remove.ts
+++ b/src/commands/type-remove.ts
@@ -1,9 +1,5 @@
 import { getAdapter } from "../adapters";
-import { getHost, getToken } from "../auth";
-import { getCustomType, removeCustomType } from "../clients/custom-types";
-import { CommandError, createCommand, type CommandConfig } from "../lib/command";
-import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
+import { createCommand, type CommandConfig } from "../lib/command";
 
 const config = {
 	name: "prismic type remove",
@@ -11,38 +7,15 @@ const config = {
 	positionals: {
 		id: { description: "ID of the content type", required: true },
 	},
-	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-	},
 } satisfies CommandConfig;
 
-export default createCommand(config, async ({ positionals, values }) => {
+export default createCommand(config, async ({ positionals }) => {
 	const [id] = positionals;
-	const { repo = await getRepositoryName() } = values;
 
 	const adapter = await getAdapter();
-	const token = await getToken();
-	const host = await getHost();
-	const customType = await getCustomType(id, { repo, token, host });
+	const { model: customType } = await adapter.getCustomType(id);
 
-	try {
-		await removeCustomType(customType.id, { repo, host, token });
-	} catch (error) {
-		if (error instanceof UnknownRequestError) {
-			const message = await error.text();
-			if (message.includes("associated documents")) {
-				throw new CommandError(
-					`Type "${id}" has documents. Delete its documents before removing the type.`,
-				);
-			}
-			throw new CommandError(`Failed to remove type: ${message}`);
-		}
-		throw error;
-	}
-
-	try {
-		await adapter.deleteCustomType(customType.id);
-	} catch {}
+	await adapter.deleteCustomType(customType.id);
 	await adapter.generateTypes();
 
 	console.info(`Type removed: ${id}`);

--- a/src/commands/type-view.ts
+++ b/src/commands/type-view.ts
@@ -1,9 +1,7 @@
-import { getHost, getToken } from "../auth";
-import { getCustomType } from "../clients/custom-types";
+import { getAdapter } from "../adapters";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic type view",
@@ -13,17 +11,15 @@ const config = {
 	},
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [id] = positionals;
-	const { json, repo = await getRepositoryName() } = values;
+	const { json } = values;
 
-	const token = await getToken();
-	const host = await getHost();
-	const type = await getCustomType(id, { repo, token, host });
+	const adapter = await getAdapter();
+	const { model: type } = await adapter.getCustomType(id);
 
 	if (json) {
 		console.info(stringify(type));

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,16 +1,14 @@
-import type { CustomType, DynamicWidget, Link } from "@prismicio/types-internal/lib/customtypes";
+import type { DynamicWidget, Link } from "@prismicio/types-internal/lib/customtypes";
 
+import type { Adapter } from "./adapters";
 import type { CommandConfig } from "./lib/command";
 
 import { getAdapter } from "./adapters";
-import { getCustomType, getSlice, updateCustomType, updateSlice } from "./clients/custom-types";
 import { CommandError } from "./lib/command";
-import { UnknownRequestError } from "./lib/request";
 
 type Field = DynamicWidget;
 type Fields = Record<string, Field>;
 type ModelKind = "slice" | "customType";
-type ApiConfig = { repo: string; token: string | undefined; host: string };
 type Target = [fields: Fields, save: () => Promise<void>, modelKind: ModelKind];
 
 export const TARGET_OPTIONS = {
@@ -18,14 +16,12 @@ export const TARGET_OPTIONS = {
 	"to-type": { type: "string", description: "ID of the target content type" },
 	variation: { type: "string", description: 'Slice variation ID (default: "default")' },
 	tab: { type: "string", description: 'Content type tab name (default: "Main")' },
-	repo: { type: "string", short: "r", description: "Repository domain" },
 } satisfies CommandConfig["options"];
 
 export const SOURCE_OPTIONS = {
 	"from-slice": { type: "string", description: "ID of the source slice" },
 	"from-type": { type: "string", description: "ID of the source content type" },
 	variation: TARGET_OPTIONS.variation,
-	repo: TARGET_OPTIONS.repo,
 } satisfies CommandConfig["options"];
 
 export async function resolveFieldContainer(
@@ -35,7 +31,6 @@ export async function resolveFieldContainer(
 		"from-type"?: string;
 		variation?: string;
 	},
-	apiConfig: ApiConfig,
 ): Promise<Target> {
 	const adapter = await getAdapter();
 	const {
@@ -53,10 +48,10 @@ export async function resolveFieldContainer(
 	}
 
 	if (fromSlice) {
-		const slice = await getSlice(fromSlice, apiConfig);
-		const variation = slice.variations.find((v) => v.id === variationId);
+		const slice = await adapter.getSlice(fromSlice);
+		const variation = slice.model.variations.find((v) => v.id === variationId);
 		if (!variation) {
-			const variationIds = slice.variations?.map((v) => v.id).join(", ") || "(none)";
+			const variationIds = slice.model.variations?.map((v) => v.id).join(", ") || "(none)";
 			throw new CommandError(`Variation "${variationId}" not found. Available: ${variationIds}`);
 		}
 		variation.primary ??= {};
@@ -64,39 +59,30 @@ export async function resolveFieldContainer(
 		return [
 			variation.primary,
 			async () => {
-				await updateSlice(slice, apiConfig);
-				try {
-					await adapter.updateSlice(slice);
-				} catch {
-					await adapter.createSlice(slice);
-				}
+				await adapter.updateSlice(slice.model);
 				await adapter.generateTypes();
 			},
 			"slice",
 		];
 	}
 
-	const customType = await getCustomType(fromType!, apiConfig);
+	const customType = await adapter.getCustomType(fromType!);
 	const root = id.includes(".") ? id.split(".")[0] : id;
 	let tab: Record<string, DynamicWidget> | undefined;
-	for (const tabName in customType.json) {
-		if (root in customType.json[tabName]) tab = customType.json[tabName];
+	for (const tabName in customType.model.json) {
+		if (root in customType.model.json[tabName]) tab = customType.model.json[tabName];
 	}
 	if (!tab) {
 		const fieldIds =
-			Object.keys(Object.assign({}, ...Object.values(customType.json))).join(", ") || "(none)";
+			Object.keys(Object.assign({}, ...Object.values(customType.model.json))).join(", ") ||
+			"(none)";
 		throw new CommandError(`Field "${id}" not found. Available: ${fieldIds}`);
 	}
 	resolveFieldTarget(tab, id);
 	return [
 		tab,
 		async () => {
-			await updateCustomType(customType, apiConfig);
-			try {
-				await adapter.updateCustomType(customType);
-			} catch {
-				await adapter.createCustomType(customType);
-			}
+			await adapter.updateCustomType(customType.model);
 			await adapter.generateTypes();
 		},
 		"customType",
@@ -111,7 +97,6 @@ export async function resolveFieldPair(
 		"from-type"?: string;
 		variation?: string;
 	},
-	apiConfig: ApiConfig,
 ): Promise<
 	[sourceFields: Fields, anchorFields: Fields, save: () => Promise<void>, modelKind: ModelKind]
 > {
@@ -131,10 +116,10 @@ export async function resolveFieldPair(
 	}
 
 	if (fromSlice) {
-		const slice = await getSlice(fromSlice, apiConfig);
-		const variation = slice.variations.find((v) => v.id === variationId);
+		const slice = await adapter.getSlice(fromSlice);
+		const variation = slice.model.variations.find((v) => v.id === variationId);
 		if (!variation) {
-			const variationIds = slice.variations?.map((v) => v.id).join(", ") || "(none)";
+			const variationIds = slice.model.variations?.map((v) => v.id).join(", ") || "(none)";
 			throw new CommandError(`Variation "${variationId}" not found. Available: ${variationIds}`);
 		}
 		variation.primary ??= {};
@@ -142,32 +127,27 @@ export async function resolveFieldPair(
 			variation.primary,
 			variation.primary,
 			async () => {
-				await updateSlice(slice, apiConfig);
-				try {
-					await adapter.updateSlice(slice);
-				} catch {
-					await adapter.createSlice(slice);
-				}
+				await adapter.updateSlice(slice.model);
 				await adapter.generateTypes();
 			},
 			"slice",
 		];
 	}
 
-	const customType = await getCustomType(fromType!, apiConfig);
+	const customType = await adapter.getCustomType(fromType!);
 
 	const sourceRoot = sourceId.includes(".") ? sourceId.split(".")[0] : sourceId;
 	const anchorRoot = anchorId.includes(".") ? anchorId.split(".")[0] : anchorId;
 
 	let sourceTab: Record<string, DynamicWidget> | undefined;
 	let anchorTab: Record<string, DynamicWidget> | undefined;
-	for (const tabName in customType.json) {
-		const tab = customType.json[tabName];
+	for (const tabName in customType.model.json) {
+		const tab = customType.model.json[tabName];
 		if (sourceRoot in tab) sourceTab = tab;
 		if (anchorRoot in tab) anchorTab = tab;
 	}
 
-	const allFieldIds = Object.keys(Object.assign({}, ...Object.values(customType.json)));
+	const allFieldIds = Object.keys(Object.assign({}, ...Object.values(customType.model.json)));
 	const available = allFieldIds.join(", ") || "(none)";
 	if (!sourceTab) {
 		throw new CommandError(`Field "${sourceId}" not found. Available: ${available}`);
@@ -180,12 +160,7 @@ export async function resolveFieldPair(
 		sourceTab,
 		anchorTab,
 		async () => {
-			await updateCustomType(customType, apiConfig);
-			try {
-				await adapter.updateCustomType(customType);
-			} catch {
-				await adapter.createCustomType(customType);
-			}
+			await adapter.updateCustomType(customType.model);
 			await adapter.generateTypes();
 		},
 		"customType",
@@ -201,7 +176,6 @@ export async function resolveModel(
 		variation?: string;
 		tab?: string;
 	},
-	apiConfig: ApiConfig,
 ): Promise<Target> {
 	const adapter = await getAdapter();
 	const sliceId = values["to-slice"] ?? values["from-slice"];
@@ -220,34 +194,20 @@ export async function resolveModel(
 			throw new CommandError("--tab is only valid for content types.");
 		}
 
-		const variation = values.variation ?? "default";
-		const slice = await getSlice(sliceId, apiConfig);
+		const variationId = values.variation ?? "default";
+		const slice = await adapter.getSlice(sliceId);
 
-		const newModel = structuredClone(slice);
-		const newVariation = newModel.variations?.find((v) => v.id === variation);
-		if (!newVariation) {
-			const variationIds = slice.variations?.map((v) => v.id).join(", ") || "(none)";
-			throw new CommandError(`Variation "${variation}" not found. Available: ${variationIds}`);
+		const variation = slice.model.variations?.find((v) => v.id === variationId);
+		if (!variation) {
+			const variationIds = slice.model.variations?.map((v) => v.id).join(", ") || "(none)";
+			throw new CommandError(`Variation "${variationId}" not found. Available: ${variationIds}`);
 		}
-		newVariation.primary ??= {};
+		variation.primary ??= {};
 
 		return [
-			newVariation.primary,
+			variation.primary,
 			async () => {
-				try {
-					await updateSlice(newModel, apiConfig);
-				} catch (error) {
-					if (error instanceof UnknownRequestError) {
-						const message = await error.text();
-						throw new CommandError(`Failed to update slice: ${message}`);
-					}
-					throw error;
-				}
-				try {
-					await adapter.updateSlice(newModel);
-				} catch {
-					await adapter.createSlice(newModel);
-				}
+				await adapter.updateSlice(slice.model);
 				await adapter.generateTypes();
 			},
 			"slice",
@@ -258,33 +218,19 @@ export async function resolveModel(
 		throw new CommandError("--variation is only valid for slices.");
 	}
 
-	const tab = values.tab ?? "Main";
-	const customType = await getCustomType(typeId!, apiConfig);
+	const tabName = values.tab ?? "Main";
+	const customType = await adapter.getCustomType(typeId!);
 
-	const newModel = structuredClone(customType);
-	const newTab = newModel.json[tab];
-	if (!newTab) {
-		const tabNames = Object.keys(customType.json).join(", ") || "(none)";
-		throw new CommandError(`Tab "${tab}" not found. Available: ${tabNames}`);
+	const tab = customType.model.json[tabName];
+	if (!tab) {
+		const tabNames = Object.keys(customType.model.json).join(", ") || "(none)";
+		throw new CommandError(`Tab "${tabName}" not found. Available: ${tabNames}`);
 	}
 
 	return [
-		newTab,
+		tab,
 		async () => {
-			try {
-				await updateCustomType(newModel, apiConfig);
-			} catch (error) {
-				if (error instanceof UnknownRequestError) {
-					const message = await error.text();
-					throw new CommandError(`Failed to update type: ${message}`);
-				}
-				throw error;
-			}
-			try {
-				await adapter.updateCustomType(newModel);
-			} catch {
-				await adapter.createCustomType(newModel);
-			}
+			await adapter.updateCustomType(customType.model);
 			await adapter.generateTypes();
 		},
 		"customType",
@@ -341,13 +287,15 @@ const UNFETCHABLE_FIELD_TYPES = ["Slices", "UID", "Choice"];
  */
 export async function resolveFieldSelection(
 	fieldSelection: string[],
-	targetType: CustomType,
-	apiConfig: ApiConfig,
+	targetTypeId: string,
 ): Promise<ResolvedField[]> {
-	// Merge all tabs into one flat field map.
-	const fields: Record<string, Field> = Object.assign({}, ...Object.values(targetType.json));
+	const adapter = await getAdapter();
+	const targetType = await adapter.getCustomType(targetTypeId);
 
-	return resolveFields(fieldSelection, fields, targetType.id, apiConfig, 1);
+	// Merge all tabs into one flat field map.
+	const fields: Record<string, Field> = Object.assign({}, ...Object.values(targetType.model.json));
+
+	return resolveFields(fieldSelection, fields, targetType.model.id, adapter, 1);
 }
 
 /**
@@ -361,7 +309,7 @@ async function resolveFields(
 	paths: string[],
 	fields: Record<string, Field>,
 	context: string,
-	apiConfig: ApiConfig,
+	adapter: Adapter,
 	crDepth: number,
 ): Promise<ResolvedField[]> {
 	const result: ResolvedField[] = [];
@@ -390,7 +338,7 @@ async function resolveFields(
 
 		if (field.type === "Group") {
 			const groupFields = field.config?.fields ?? {};
-			const resolved = await resolveFields(subPaths, groupFields, context, apiConfig, crDepth);
+			const resolved = await resolveFields(subPaths, groupFields, context, adapter, crDepth);
 			result.push({ id, fields: resolved });
 		} else if (field.type === "Link" && field.config?.select === "document") {
 			if (crDepth <= 0) {
@@ -406,13 +354,13 @@ async function resolveFields(
 			}
 			const ctId = typeof cts[0] === "string" ? cts[0] : cts[0].id;
 
-			// Cross the CR boundary: fetch the target type and resolve sub-paths against it.
-			const nestedType = await getCustomType(ctId, apiConfig);
+			// Cross the CR boundary: read the target type and resolve sub-paths against it.
+			const nestedType = await adapter.getCustomType(ctId);
 			const nestedFields: Record<string, Field> = Object.assign(
 				{},
-				...Object.values(nestedType.json),
+				...Object.values(nestedType.model.json),
 			);
-			const resolved = await resolveFields(subPaths, nestedFields, ctId, apiConfig, crDepth - 1);
+			const resolved = await resolveFields(subPaths, nestedFields, ctId, adapter, crDepth - 1);
 			result.push({ id, customtypes: [{ id: ctId, fields: resolved }] });
 		} else {
 			throw new CommandError(`Field "${id}" is not a group or content relationship field.`);

--- a/test/field-add-boolean.test.ts
+++ b/test/field-add-boolean.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "boolean", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add boolean <id> [options]");
 });
 
-it("adds a boolean field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a boolean field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a boolean field to a slice", async ({ expect, prismic, repo, token, hos
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_field");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_field;
 	expect(field).toMatchObject({ type: "Boolean" });
 });
 
-it("adds a boolean field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a boolean field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a boolean field to a custom type", async ({ expect, prismic, repo, toke
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: is_active");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.is_active;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.is_active;
 	expect(field).toMatchObject({ type: "Boolean" });
 });

--- a/test/field-add-color.test.ts
+++ b/test/field-add-color.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "color", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add color <id> [options]");
 });
 
-it("adds a color field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a color field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a color field to a slice", async ({ expect, prismic, repo, token, host 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_color");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_color;
 	expect(field).toMatchObject({ type: "Color" });
 });
 
-it("adds a color field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a color field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a color field to a custom type", async ({ expect, prismic, repo, token,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_color");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_color;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_color;
 	expect(field).toMatchObject({ type: "Color" });
 });

--- a/test/field-add-content-relationship.test.ts
+++ b/test/field-add-content-relationship.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "content-relationship", "--help"]);
@@ -7,15 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add content-relationship <id> [options]");
 });
 
-it("adds a content relationship field to a slice", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("adds a content relationship field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -27,21 +28,14 @@ it("adds a content relationship field to a slice", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_link;
 	expect(field).toMatchObject({ type: "Link", config: { select: "document" } });
 });
 
-it("adds a content relationship field to a custom type", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("adds a content relationship field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -53,25 +47,18 @@ it("adds a content relationship field to a custom type", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_link;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_link;
 	expect(field).toMatchObject({ type: "Link", config: { select: "document" } });
 });
 
-it("adds a content relationship field with --field", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("adds a content relationship field with --field", async ({ expect, prismic, project }) => {
 	const target = buildCustomType();
 	target.json.Main.title = { type: "Text", config: { label: "Title" } };
-	await insertCustomType(target, { repo, token, host });
+	await writeLocalCustomType(project, target);
 
 	const owner = buildCustomType();
-	await insertCustomType(owner, { repo, token, host });
+	await writeLocalCustomType(project, owner);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -87,9 +74,8 @@ it("adds a content relationship field with --field", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === owner.id);
-	const field = updated!.json.Main.my_link;
+	const updated = await readLocalCustomType(project, owner.id);
+	const field = updated.json.Main.my_link;
 	expect(field).toMatchObject({
 		type: "Link",
 		config: {

--- a/test/field-add-date.test.ts
+++ b/test/field-add-date.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "date", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add date <id> [options]");
 });
 
-it("adds a date field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a date field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a date field to a slice", async ({ expect, prismic, repo, token, host }
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_date");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_date;
 	expect(field).toMatchObject({ type: "Date" });
 });
 
-it("adds a date field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a date field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a date field to a custom type", async ({ expect, prismic, repo, token, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_date");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_date;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_date;
 	expect(field).toMatchObject({ type: "Date" });
 });

--- a/test/field-add-embed.test.ts
+++ b/test/field-add-embed.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "embed", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add embed <id> [options]");
 });
 
-it("adds an embed field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds an embed field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds an embed field to a slice", async ({ expect, prismic, repo, token, host
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_embed;
 	expect(field).toMatchObject({ type: "Embed" });
 });
 
-it("adds an embed field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds an embed field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds an embed field to a custom type", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_embed;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_embed;
 	expect(field).toMatchObject({ type: "Embed" });
 });

--- a/test/field-add-geopoint.test.ts
+++ b/test/field-add-geopoint.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "geopoint", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add geopoint <id> [options]");
 });
 
-it("adds a geopoint field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a geopoint field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a geopoint field to a slice", async ({ expect, prismic, repo, token, ho
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_location");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_location;
 	expect(field).toMatchObject({ type: "GeoPoint" });
 });
 
-it("adds a geopoint field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a geopoint field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a geopoint field to a custom type", async ({ expect, prismic, repo, tok
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_location");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_location;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_location;
 	expect(field).toMatchObject({ type: "GeoPoint" });
 });

--- a/test/field-add-group.test.ts
+++ b/test/field-add-group.test.ts
@@ -1,7 +1,14 @@
 import type { Group } from "@prismicio/types-internal/lib/customtypes";
 
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "group", "--help"]);
@@ -9,9 +16,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add group <id> [options]");
 });
 
-it("adds a group field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a group field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -23,15 +30,14 @@ it("adds a group field to a slice", async ({ expect, prismic, repo, token, host 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_group;
 	expect(field).toMatchObject({ type: "Group" });
 });
 
-it("adds a group field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a group field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -43,22 +49,15 @@ it("adds a group field to a custom type", async ({ expect, prismic, repo, token,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_group;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_group;
 	expect(field).toMatchObject({ type: "Group" });
 });
 
-it("adds a field inside a group using dot syntax", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("adds a field inside a group using dot syntax", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.my_group = { type: "Group", config: { label: "My Group" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -70,23 +69,16 @@ it("adds a field inside a group using dot syntax", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_group.subtitle");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const group = updated!.variations[0].primary!.my_group as Group;
 	expect(group.config?.fields).toMatchObject({
 		subtitle: { type: "Text", config: { label: "Subtitle" } },
 	});
 });
 
-it("errors when dot syntax targets a non-existent field", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("errors when dot syntax targets a non-existent field", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stderr, exitCode } = await prismic("field", [
 		"add",
@@ -99,16 +91,10 @@ it("errors when dot syntax targets a non-existent field", async ({
 	expect(stderr).toContain('Field "nonexistent" does not exist.');
 });
 
-it("errors when dot syntax targets a non-group field", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("errors when dot syntax targets a non-group field", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.my_text = { type: "Text", config: { label: "My Text" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stderr, exitCode } = await prismic("field", [
 		"add",

--- a/test/field-add-image.test.ts
+++ b/test/field-add-image.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "image", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add image <id> [options]");
 });
 
-it("adds an image field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds an image field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds an image field to a slice", async ({ expect, prismic, repo, token, host
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_image");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_image;
 	expect(field).toMatchObject({ type: "Image" });
 });
 
-it("adds an image field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds an image field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds an image field to a custom type", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_image");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_image;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_image;
 	expect(field).toMatchObject({ type: "Image" });
 });

--- a/test/field-add-integration.test.ts
+++ b/test/field-add-integration.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "integration", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add integration <id> [options]");
 });
 
-it("adds an integration field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds an integration field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds an integration field to a slice", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_integration;
 	expect(field).toMatchObject({ type: "IntegrationFields" });
 });
 
-it("adds an integration field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds an integration field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds an integration field to a custom type", async ({ expect, prismic, repo,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_integration;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_integration;
 	expect(field).toMatchObject({ type: "IntegrationFields" });
 });

--- a/test/field-add-link.test.ts
+++ b/test/field-add-link.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "link", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add link <id> [options]");
 });
 
-it("adds a link field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a link field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a link field to a slice", async ({ expect, prismic, repo, token, host }
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_link;
 	expect(field).toMatchObject({ type: "Link" });
 });
 
-it("adds a link field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a link field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,15 +47,14 @@ it("adds a link field to a custom type", async ({ expect, prismic, repo, token, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_link;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_link;
 	expect(field).toMatchObject({ type: "Link" });
 });
 
-it("adds a media link field with --allow media", async ({ expect, prismic, repo, token, host }) => {
+it("adds a media link field with --allow media", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -63,8 +68,7 @@ it("adds a media link field with --allow media", async ({ expect, prismic, repo,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_media");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_media;
 	expect(field).toMatchObject({ type: "Link", config: { select: "media" } });
 });

--- a/test/field-add-number.test.ts
+++ b/test/field-add-number.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "number", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add number <id> [options]");
 });
 
-it("adds a number field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a number field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a number field to a slice", async ({ expect, prismic, repo, token, host
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_number");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_number;
 	expect(field).toMatchObject({ type: "Number" });
 });
 
-it("adds a number field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a number field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a number field to a custom type", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_number");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_number;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_number;
 	expect(field).toMatchObject({ type: "Number" });
 });

--- a/test/field-add-rich-text.test.ts
+++ b/test/field-add-rich-text.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "rich-text", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add rich-text <id> [options]");
 });
 
-it("adds a rich text field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a rich text field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a rich text field to a slice", async ({ expect, prismic, repo, token, h
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_content");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_content;
 	expect(field).toMatchObject({ type: "StructuredText" });
 });
 
-it("adds a rich text field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a rich text field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a rich text field to a custom type", async ({ expect, prismic, repo, to
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_content");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_content;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_content;
 	expect(field).toMatchObject({ type: "StructuredText" });
 });

--- a/test/field-add-select.test.ts
+++ b/test/field-add-select.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "select", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add select <id> [options]");
 });
 
-it("adds a select field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a select field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a select field to a slice", async ({ expect, prismic, repo, token, host
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_select");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_select;
 	expect(field).toMatchObject({ type: "Select" });
 });
 
-it("adds a select field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a select field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a select field to a custom type", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_select");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_select;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_select;
 	expect(field).toMatchObject({ type: "Select" });
 });

--- a/test/field-add-table.test.ts
+++ b/test/field-add-table.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "table", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add table <id> [options]");
 });
 
-it("adds a table field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a table field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a table field to a slice", async ({ expect, prismic, repo, token, host 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_table");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_table;
 	expect(field).toMatchObject({ type: "Table" });
 });
 
-it("adds a table field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a table field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a table field to a custom type", async ({ expect, prismic, repo, token,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_table");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_table;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_table;
 	expect(field).toMatchObject({ type: "Table" });
 });

--- a/test/field-add-text.test.ts
+++ b/test/field-add-text.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "text", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add text <id> [options]");
 });
 
-it("adds a text field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a text field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a text field to a slice", async ({ expect, prismic, repo, token, host }
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.subtitle;
 	expect(field).toMatchObject({ type: "Text" });
 });
 
-it("adds a text field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a text field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,15 +47,14 @@ it("adds a text field to a custom type", async ({ expect, prismic, repo, token, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.subtitle;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.subtitle;
 	expect(field).toMatchObject({ type: "Text" });
 });
 
-it("adds a text field to a page type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a text field to a page type", async ({ expect, prismic, project }) => {
 	const pageType = buildCustomType({ format: "page" });
-	await insertCustomType(pageType, { repo, token, host });
+	await writeLocalCustomType(project, pageType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -61,8 +66,7 @@ it("adds a text field to a page type", async ({ expect, prismic, repo, token, ho
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === pageType.id);
-	const field = updated!.json.Main.subtitle;
+	const updated = await readLocalCustomType(project, pageType.id);
+	const field = updated.json.Main.subtitle;
 	expect(field).toMatchObject({ type: "Text" });
 });

--- a/test/field-add-timestamp.test.ts
+++ b/test/field-add-timestamp.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "timestamp", "--help"]);
@@ -7,9 +14,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add timestamp <id> [options]");
 });
 
-it("adds a timestamp field to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a timestamp field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -21,15 +28,14 @@ it("adds a timestamp field to a slice", async ({ expect, prismic, repo, token, h
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_timestamp;
 	expect(field).toMatchObject({ type: "Timestamp" });
 });
 
-it("adds a timestamp field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a timestamp field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"add",
@@ -41,8 +47,7 @@ it("adds a timestamp field to a custom type", async ({ expect, prismic, repo, to
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.my_timestamp;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.my_timestamp;
 	expect(field).toMatchObject({ type: "Timestamp" });
 });

--- a/test/field-add-uid.test.ts
+++ b/test/field-add-uid.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--help"]);
@@ -7,30 +6,28 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field add uid [options]");
 });
 
-it("adds a uid field to a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a uid field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--to-type", customType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const field = updated!.json.Main.uid;
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.uid;
 	expect(field).toMatchObject({ type: "UID" });
 });
 
-it("adds a uid field to a page type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a uid field to a page type", async ({ expect, prismic, project }) => {
 	const pageType = buildCustomType({ format: "page" });
-	await insertCustomType(pageType, { repo, token, host });
+	await writeLocalCustomType(project, pageType);
 
 	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--to-type", pageType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === pageType.id);
-	const field = updated!.json.Main.uid;
+	const updated = await readLocalCustomType(project, pageType.id);
+	const field = updated.json.Main.uid;
 	expect(field).toMatchObject({ type: "UID" });
 });

--- a/test/field-edit.test.ts
+++ b/test/field-edit.test.ts
@@ -1,5 +1,12 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["edit", "--help"]);
@@ -7,10 +14,10 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field edit <id> [options]");
 });
 
-it("edits a field label on a slice", async ({ expect, prismic, repo, token, host }) => {
+it("edits a field label on a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.my_field = { type: "Boolean", config: { label: "Old Label" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -23,13 +30,12 @@ it("edits a field label on a slice", async ({ expect, prismic, repo, token, host
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: my_field");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.my_field;
 	expect(field).toMatchObject({ type: "Boolean", config: { label: "New Label" } });
 });
 
-it("edits a field label on a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("edits a field label on a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({
 		json: {
 			Main: {
@@ -40,7 +46,7 @@ it("edits a field label on a custom type", async ({ expect, prismic, repo, token
 			},
 		},
 	});
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -53,18 +59,17 @@ it("edits a field label on a custom type", async ({ expect, prismic, repo, token
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: title");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated!.json.Main.title).toMatchObject({
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main.title).toMatchObject({
 		type: "StructuredText",
 		config: { label: "Page Title" },
 	});
 });
 
-it("edits boolean field options", async ({ expect, prismic, repo, token, host }) => {
+it("edits boolean field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.is_active = { type: "Boolean", config: { label: "Active" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -81,8 +86,7 @@ it("edits boolean field options", async ({ expect, prismic, repo, token, host })
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: is_active");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.is_active;
 	expect(field).toMatchObject({
 		type: "Boolean",
@@ -94,10 +98,10 @@ it("edits boolean field options", async ({ expect, prismic, repo, token, host })
 	});
 });
 
-it("edits number field options", async ({ expect, prismic, repo, token, host }) => {
+it("edits number field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.quantity = { type: "Number", config: { label: "Quantity" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -112,8 +116,7 @@ it("edits number field options", async ({ expect, prismic, repo, token, host }) 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: quantity");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.quantity;
 	expect(field).toMatchObject({
 		type: "Number",
@@ -121,13 +124,13 @@ it("edits number field options", async ({ expect, prismic, repo, token, host }) 
 	});
 });
 
-it("edits select field options", async ({ expect, prismic, repo, token, host }) => {
+it("edits select field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.color = {
 		type: "Select",
 		config: { label: "Color", options: ["red", "blue"] },
 	};
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -146,8 +149,7 @@ it("edits select field options", async ({ expect, prismic, repo, token, host }) 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: color");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.color;
 	expect(field).toMatchObject({
 		type: "Select",
@@ -158,24 +160,18 @@ it("edits select field options", async ({ expect, prismic, repo, token, host }) 
 	});
 });
 
-it("edits content relationship field with --field", async ({
-	expect,
-	prismic,
-	repo,
-	token,
-	host,
-}) => {
+it("edits content relationship field with --field", async ({ expect, prismic, project }) => {
 	const target = buildCustomType({
 		json: { Main: { title: { type: "Text", config: { label: "Title" } } } },
 	});
-	await insertCustomType(target, { repo, token, host });
+	await writeLocalCustomType(project, target);
 
 	const owner = buildCustomType();
 	owner.json.Main.my_link = {
 		type: "Link",
 		config: { label: "My Link", select: "document", customtypes: [target.id] },
 	};
-	await insertCustomType(owner, { repo, token, host });
+	await writeLocalCustomType(project, owner);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -188,9 +184,8 @@ it("edits content relationship field with --field", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: my_link");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === owner.id);
-	expect(updated!.json.Main.my_link).toMatchObject({
+	const updated = await readLocalCustomType(project, owner.id);
+	expect(updated.json.Main.my_link).toMatchObject({
 		type: "Link",
 		config: {
 			select: "document",
@@ -199,13 +194,13 @@ it("edits content relationship field with --field", async ({
 	});
 });
 
-it("edits link field options", async ({ expect, prismic, repo, token, host }) => {
+it("edits link field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.cta_link = {
 		type: "Link",
 		config: { label: "CTA Link", allowTargetBlank: false },
 	};
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"edit",
@@ -217,8 +212,7 @@ it("edits link field options", async ({ expect, prismic, repo, token, host }) =>
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field updated: cta_link");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const field = updated!.variations[0].primary!.cta_link;
 	expect(field).toMatchObject({
 		type: "Link",

--- a/test/field-remove.test.ts
+++ b/test/field-remove.test.ts
@@ -1,7 +1,14 @@
 import type { Group } from "@prismicio/types-internal/lib/customtypes";
 
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["remove", "--help"]);
@@ -9,7 +16,7 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field remove <id> [options]");
 });
 
-it("removes a field from a slice", async ({ expect, prismic, repo, token, host }) => {
+it("removes a field from a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice({
 		variations: [
 			{
@@ -25,7 +32,7 @@ it("removes a field from a slice", async ({ expect, prismic, repo, token, host }
 			},
 		],
 	});
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"remove",
@@ -36,12 +43,11 @@ it("removes a field from a slice", async ({ expect, prismic, repo, token, host }
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: my_field");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	expect(updated!.variations[0].primary!.my_field).toBeUndefined();
 });
 
-it("removes a field from a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("removes a field from a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({
 		json: {
 			Main: {
@@ -49,7 +55,7 @@ it("removes a field from a custom type", async ({ expect, prismic, repo, token, 
 			},
 		},
 	});
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"remove",
@@ -60,12 +66,11 @@ it("removes a field from a custom type", async ({ expect, prismic, repo, token, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: title");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated!.json.Main.title).toBeUndefined();
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main.title).toBeUndefined();
 });
 
-it("removes a nested field using dot notation", async ({ expect, prismic, repo, token, host }) => {
+it("removes a nested field using dot notation", async ({ expect, prismic, project }) => {
 	const slice = buildSlice({
 		variations: [
 			{
@@ -89,7 +94,7 @@ it("removes a nested field using dot notation", async ({ expect, prismic, repo, 
 			},
 		],
 	});
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"remove",
@@ -100,8 +105,7 @@ it("removes a nested field using dot notation", async ({ expect, prismic, repo, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field removed: my_group.subtitle");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const group = updated!.variations[0].primary!.my_group as Group;
 	expect(group.config?.fields).toMatchObject({});
 	expect(group.config?.fields?.subtitle).toBeUndefined();

--- a/test/field-reorder.test.ts
+++ b/test/field-reorder.test.ts
@@ -1,7 +1,14 @@
 import type { Group } from "@prismicio/types-internal/lib/customtypes";
 
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, getSlices, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	readLocalSlice,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["reorder", "--help"]);
@@ -9,12 +16,12 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field reorder <id> [options]");
 });
 
-it("reorders a field in a slice", async ({ expect, prismic, repo, token, host }) => {
+it("reorders a field in a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.field_a = { type: "Boolean", config: { label: "A" } };
 	slice.variations[0].primary!.field_b = { type: "Boolean", config: { label: "B" } };
 	slice.variations[0].primary!.field_c = { type: "Boolean", config: { label: "C" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"reorder",
@@ -27,17 +34,16 @@ it("reorders a field in a slice", async ({ expect, prismic, repo, token, host })
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field reordered: field_a");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	expect(Object.keys(updated!.variations[0].primary!)).toEqual(["field_b", "field_c", "field_a"]);
 });
 
-it("reorders a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("reorders a field in a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
 	customType.json.Main.title = { type: "StructuredText", config: { label: "Title" } };
 	customType.json.Main.body = { type: "StructuredText", config: { label: "Body" } };
 	customType.json.Main.image = { type: "Image", config: { label: "Image" } };
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"reorder",
@@ -50,12 +56,11 @@ it("reorders a field in a custom type", async ({ expect, prismic, repo, token, h
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field reordered: image");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(Object.keys(updated!.json.Main)).toEqual(["title", "image", "body"]);
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(Object.keys(updated.json.Main)).toEqual(["title", "image", "body"]);
 });
 
-it("moves a field across tabs in a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("moves a field across tabs in a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
 	customType.json.Main.title = { type: "StructuredText", config: { label: "Title" } };
 	customType.json.Main.body = { type: "StructuredText", config: { label: "Body" } };
@@ -63,7 +68,7 @@ it("moves a field across tabs in a custom type", async ({ expect, prismic, repo,
 		meta_title: { type: "Text", config: { label: "Meta Title" } },
 		meta_desc: { type: "Text", config: { label: "Meta Description" } },
 	};
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"reorder",
@@ -76,13 +81,12 @@ it("moves a field across tabs in a custom type", async ({ expect, prismic, repo,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field reordered: body");
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(Object.keys(updated!.json.Main)).toEqual(["title"]);
-	expect(Object.keys(updated!.json.SEO)).toEqual(["meta_title", "body", "meta_desc"]);
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(Object.keys(updated.json.Main)).toEqual(["title"]);
+	expect(Object.keys(updated.json.SEO)).toEqual(["meta_title", "body", "meta_desc"]);
 });
 
-it("reorders a nested field in a group", async ({ expect, prismic, repo, token, host }) => {
+it("reorders a nested field in a group", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.my_group = {
 		type: "Group",
@@ -95,7 +99,7 @@ it("reorders a nested field in a group", async ({ expect, prismic, repo, token, 
 			},
 		},
 	};
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"reorder",
@@ -108,16 +112,15 @@ it("reorders a nested field in a group", async ({ expect, prismic, repo, token, 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Field reordered: my_group.sub_c");
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const group = updated!.variations[0].primary!.my_group as Group;
 	expect(Object.keys(group.config!.fields!)).toEqual(["sub_c", "sub_a", "sub_b"]);
 });
 
-it("errors when the field does not exist", async ({ expect, prismic, repo, token, host }) => {
+it("errors when the field does not exist", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.field_a = { type: "Boolean", config: { label: "A" } };
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stderr, exitCode } = await prismic("field", [
 		"reorder",

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, buildSlice, it } from "./it";
-import { insertCustomType, insertSlice } from "./prismic";
+import { buildCustomType, buildSlice, it, writeLocalCustomType, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("field", ["view", "--help"]);
@@ -7,13 +6,13 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic field view <id> [options]");
 });
 
-it("views a field in a slice", async ({ expect, prismic, repo, token, host }) => {
+it("views a field in a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.title = {
 		type: "StructuredText",
 		config: { label: "Title", placeholder: "Enter title" },
 	};
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", ["view", "title", "--from-slice", slice.id]);
 	expect(exitCode).toBe(0);
@@ -22,13 +21,13 @@ it("views a field in a slice", async ({ expect, prismic, repo, token, host }) =>
 	expect(stdout).toContain("Placeholder: Enter title");
 });
 
-it("views a field in a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("views a field in a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
 	customType.json.Main.count = {
 		type: "Number",
 		config: { label: "Count", placeholder: "Enter number", min: 0, max: 100 },
 	};
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"view",
@@ -43,13 +42,13 @@ it("views a field in a custom type", async ({ expect, prismic, repo, token, host
 	expect(stdout).toContain("Max: 100");
 });
 
-it("outputs JSON with --json", async ({ expect, prismic, repo, token, host }) => {
+it("outputs JSON with --json", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.is_active = {
 		type: "Boolean",
 		config: { label: "Is Active", default_value: true },
 	};
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("field", [
 		"view",
@@ -66,9 +65,9 @@ it("outputs JSON with --json", async ({ expect, prismic, repo, token, host }) =>
 	expect(field.config.label).toBe("Is Active");
 });
 
-it("errors for non-existent field", async ({ expect, prismic, repo, token, host }) => {
+it("errors for non-existent field", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stderr, exitCode } = await prismic("field", [
 		"view",

--- a/test/it.ts
+++ b/test/it.ts
@@ -1,7 +1,8 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 import type { Result } from "tinyexec";
 
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { pascalCase } from "change-case";
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -163,4 +164,50 @@ export function buildSlice(overrides?: Partial<SharedSlice>): SharedSlice {
 		],
 		...overrides,
 	};
+}
+
+export async function writeLocalCustomType(project: URL, model: CustomType): Promise<void> {
+	const path = new URL(`customtypes/${model.id}/index.json`, project);
+	await mkdir(new URL(".", path), { recursive: true });
+	await writeFile(path, JSON.stringify(model, null, 2));
+}
+
+export async function readLocalCustomType(project: URL, id: string): Promise<CustomType> {
+	const path = new URL(`customtypes/${id}/index.json`, project);
+	return JSON.parse(await readFile(path, "utf8"));
+}
+
+export async function readLocalCustomTypes(project: URL): Promise<CustomType[]> {
+	const dir = new URL("customtypes/", project);
+	const entries = await readdir(dir).catch(() => [] as string[]);
+	const result: CustomType[] = [];
+	for (const id of entries) {
+		try {
+			result.push(JSON.parse(await readFile(new URL(`${id}/index.json`, dir), "utf8")));
+		} catch {}
+	}
+	return result;
+}
+
+export async function writeLocalSlice(project: URL, model: SharedSlice): Promise<void> {
+	const path = new URL(`slices/${pascalCase(model.name)}/model.json`, project);
+	await mkdir(new URL(".", path), { recursive: true });
+	await writeFile(path, JSON.stringify(model, null, 2));
+}
+
+export async function readLocalSlice(project: URL, id: string): Promise<SharedSlice | undefined> {
+	const slices = await readLocalSlices(project);
+	return slices.find((s) => s.id === id);
+}
+
+export async function readLocalSlices(project: URL): Promise<SharedSlice[]> {
+	const dir = new URL("slices/", project);
+	const entries = await readdir(dir).catch(() => [] as string[]);
+	const result: SharedSlice[] = [];
+	for (const name of entries) {
+		try {
+			result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, dir), "utf8")));
+		} catch {}
+	}
+	return result;
 }

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -1,8 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { buildSlice, it } from "./it";
-import { getSlices, insertSlice } from "./prismic";
+import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["add-variation", "--help"]);
@@ -10,9 +9,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice add-variation <name> [options]");
 });
 
-it("adds a variation to a slice", async ({ expect, prismic, repo, token, host }) => {
+it("adds a variation to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
@@ -26,15 +25,14 @@ it("adds a variation to a slice", async ({ expect, prismic, repo, token, host })
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 	expect(stdout).toContain(`to slice "${slice.id}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.name === variationName);
 	expect(variation).toBeDefined();
 });
 
-it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, token, host }) => {
+it("adds a variation with a screenshot URL", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
@@ -49,24 +47,16 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, repo, tok
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.name === variationName);
 	expect(variation).toBeDefined();
 	expect(variation?.imageUrl).toContain("https://");
 	expect(variation?.imageUrl).toContain(".png");
 });
 
-it("adds a variation with a local screenshot file", async ({
-	expect,
-	prismic,
-	project,
-	repo,
-	token,
-	host,
-}) => {
+it("adds a variation with a local screenshot file", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const screenshotUrl =
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png";
@@ -89,8 +79,7 @@ it("adds a variation with a local screenshot file", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.name === variationName);
 	expect(variation).toBeDefined();
 	expect(variation?.imageUrl).toContain("https://");

--- a/test/slice-connect.test.ts
+++ b/test/slice-connect.test.ts
@@ -1,7 +1,13 @@
 import type { DynamicSlices } from "@prismicio/types-internal/lib/customtypes";
 
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["connect", "--help"]);
@@ -9,7 +15,7 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice connect <id> [options]");
 });
 
-it("connects a slice to a type", async ({ expect, prismic, repo, token, host }) => {
+it("connects a slice to a type", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	const customType = buildCustomType({
 		format: "page",
@@ -24,15 +30,14 @@ it("connects a slice to a type", async ({ expect, prismic, repo, token, host }) 
 		},
 	});
 
-	await insertSlice(slice, { repo, token, host });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalSlice(project, slice);
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("slice", ["connect", slice.id, "--to", customType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Connected slice "${slice.id}" to "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const choices = (updated!.json.Main.slices as DynamicSlices).config!.choices!;
+	const updated = await readLocalCustomType(project, customType.id);
+	const choices = (updated.json.Main.slices as DynamicSlices).config!.choices!;
 	expect(choices[slice.id]).toEqual({ type: "SharedSlice" });
 });

--- a/test/slice-create.test.ts
+++ b/test/slice-create.test.ts
@@ -1,5 +1,6 @@
-import { buildSlice, it } from "./it";
-import { getSlices } from "./prismic";
+import { snakeCase } from "change-case";
+
+import { buildSlice, it, readLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["create", "--help"]);
@@ -7,19 +8,20 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice create <name> [options]");
 });
 
-it("creates a slice", async ({ expect, prismic, repo, token, host }) => {
+it("creates a slice", async ({ expect, prismic, project }) => {
 	const { name } = buildSlice();
 
 	const { stdout, exitCode } = await prismic("slice", ["create", name]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Created slice "${name}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const created = slices.find((s) => s.name === name);
+	const id = snakeCase(name);
+	const created = await readLocalSlice(project, id);
 	expect(created).toBeDefined();
+	expect(created?.name).toBe(name);
 });
 
-it("creates a slice with a custom id", async ({ expect, prismic, repo, token, host }) => {
+it("creates a slice with a custom id", async ({ expect, prismic, project }) => {
 	const { name } = buildSlice();
 	const id = `slice_${crypto.randomUUID().split("-")[0]}`;
 
@@ -27,7 +29,6 @@ it("creates a slice with a custom id", async ({ expect, prismic, repo, token, ho
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Created slice "${name}" (id: "${id}")`);
 
-	const slices = await getSlices({ repo, token, host });
-	const created = slices.find((s) => s.id === id);
+	const created = await readLocalSlice(project, id);
 	expect(created).toBeDefined();
 });

--- a/test/slice-disconnect.test.ts
+++ b/test/slice-disconnect.test.ts
@@ -1,7 +1,13 @@
 import type { DynamicSlices } from "@prismicio/types-internal/lib/customtypes";
 
-import { buildCustomType, buildSlice, it } from "./it";
-import { getCustomTypes, insertCustomType, insertSlice } from "./prismic";
+import {
+	buildCustomType,
+	buildSlice,
+	it,
+	readLocalCustomType,
+	writeLocalCustomType,
+	writeLocalSlice,
+} from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["disconnect", "--help"]);
@@ -9,7 +15,7 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice disconnect <id> [options]");
 });
 
-it("disconnects a slice from a type", async ({ expect, prismic, repo, token, host }) => {
+it("disconnects a slice from a type", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	const customType = buildCustomType({
 		format: "page",
@@ -24,8 +30,8 @@ it("disconnects a slice from a type", async ({ expect, prismic, repo, token, hos
 		},
 	});
 
-	await insertSlice(slice, { repo, token, host });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalSlice(project, slice);
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"disconnect",
@@ -36,8 +42,7 @@ it("disconnects a slice from a type", async ({ expect, prismic, repo, token, hos
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Disconnected slice "${slice.id}" from "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const choices = (updated!.json.Main.slices as DynamicSlices).config!.choices!;
+	const updated = await readLocalCustomType(project, customType.id);
+	const choices = (updated.json.Main.slices as DynamicSlices).config!.choices!;
 	expect(choices[slice.id]).toBeUndefined();
 });

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -1,8 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
-import { buildSlice, it } from "./it";
-import { getSlices, insertSlice } from "./prismic";
+import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["edit-variation", "--help"]);
@@ -10,7 +9,7 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice edit-variation <id> [options]");
 });
 
-it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
+it("edits a variation name", async ({ expect, prismic, project }) => {
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 	const variationId = `variation${crypto.randomUUID().split("-")[0]}`;
 	const slice = buildSlice();
@@ -29,7 +28,7 @@ it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
 		],
 	};
 
-	await insertSlice(sliceWithVariation, { repo, token, host });
+	await writeLocalSlice(project, sliceWithVariation);
 
 	const newName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
@@ -44,15 +43,14 @@ it("edits a variation name", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Variation updated: "${variationId}" in slice "${slice.id}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.id === variationId);
 	expect(variation?.name).toBe(newName);
 });
 
-it("sets a screenshot on a variation", async ({ expect, prismic, repo, token, host }) => {
+it("sets a screenshot on a variation", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"edit-variation",
@@ -65,23 +63,15 @@ it("sets a screenshot on a variation", async ({ expect, prismic, repo, token, ho
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.id === "default");
 	expect(variation?.imageUrl).toContain("https://");
 	expect(variation?.imageUrl).toContain(".png");
 });
 
-it("sets a local screenshot file on a variation", async ({
-	expect,
-	prismic,
-	project,
-	repo,
-	token,
-	host,
-}) => {
+it("sets a local screenshot file on a variation", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const screenshotUrl =
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png";
@@ -102,8 +92,7 @@ it("sets a local screenshot file on a variation", async ({
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const variation = updated?.variations.find((v) => v.id === "default");
 	expect(variation?.imageUrl).toContain("https://");
 	expect(variation?.imageUrl).toContain(".png");

--- a/test/slice-edit.test.ts
+++ b/test/slice-edit.test.ts
@@ -1,5 +1,4 @@
-import { buildSlice, it } from "./it";
-import { getSlices, insertSlice } from "./prismic";
+import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["edit", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice edit <id> [options]");
 });
 
-it("edits a slice name", async ({ expect, prismic, repo, token, host }) => {
+it("edits a slice name", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const newName = `SliceS${crypto.randomUUID().split("-")[0]}`;
 
@@ -17,7 +16,6 @@ it("edits a slice name", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Slice updated: "${newName}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	expect(updated?.name).toBe(newName);
 });

--- a/test/slice-list.test.ts
+++ b/test/slice-list.test.ts
@@ -1,5 +1,4 @@
-import { buildSlice, it } from "./it";
-import { insertSlice } from "./prismic";
+import { buildSlice, it, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["list", "--help"]);
@@ -7,18 +6,18 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice list [options]");
 });
 
-it("lists slices", async ({ expect, prismic, repo, token, host }) => {
+it("lists slices", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["list"]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toMatch(new RegExp(`${slice.name}\\s+${slice.id}`));
 });
 
-it("lists slices as JSON", async ({ expect, prismic, repo, token, host }) => {
+it("lists slices as JSON", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["list", "--json"]);
 	expect(exitCode).toBe(0);

--- a/test/slice-remove-variation.test.ts
+++ b/test/slice-remove-variation.test.ts
@@ -1,5 +1,4 @@
-import { buildSlice, it } from "./it";
-import { getSlices, insertSlice } from "./prismic";
+import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["remove-variation", "--help"]);
@@ -7,7 +6,7 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice remove-variation <id> [options]");
 });
 
-it("removes a variation from a slice", async ({ expect, prismic, repo, token, host }) => {
+it("removes a variation from a slice", async ({ expect, prismic, project }) => {
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 	const variationId = `variation${crypto.randomUUID().split("-")[0]}`;
 	const slice = buildSlice();
@@ -26,7 +25,7 @@ it("removes a variation from a slice", async ({ expect, prismic, repo, token, ho
 		],
 	};
 
-	await insertSlice(sliceWithVariation, { repo, token, host });
+	await writeLocalSlice(project, sliceWithVariation);
 
 	const { stdout, exitCode } = await prismic("slice", [
 		"remove-variation",
@@ -37,8 +36,7 @@ it("removes a variation from a slice", async ({ expect, prismic, repo, token, ho
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Removed variation "${variationId}" from slice "${slice.id}"`);
 
-	const slices = await getSlices({ repo, token, host });
-	const updated = slices.find((s) => s.id === slice.id);
+	const updated = await readLocalSlice(project, slice.id);
 	const removed = updated?.variations.find((v) => v.id === variationId);
 	expect(removed).toBeUndefined();
 });

--- a/test/slice-remove.test.ts
+++ b/test/slice-remove.test.ts
@@ -1,5 +1,4 @@
-import { buildSlice, it } from "./it";
-import { getSlices, insertSlice } from "./prismic";
+import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["remove", "--help"]);
@@ -7,15 +6,14 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice remove <id> [options]");
 });
 
-it("removes a slice", async ({ expect, prismic, repo, token, host }) => {
+it("removes a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["remove", slice.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Slice removed: ${slice.id}`);
 
-	const slices = await getSlices({ repo, token, host });
-	const removed = slices.find((s) => s.id === slice.id);
+	const removed = await readLocalSlice(project, slice.id);
 	expect(removed).toBeUndefined();
 });

--- a/test/slice-view.test.ts
+++ b/test/slice-view.test.ts
@@ -1,5 +1,4 @@
-import { buildSlice, it } from "./it";
-import { insertSlice } from "./prismic";
+import { buildSlice, it, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("slice", ["view", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic slice view <id> [options]");
 });
 
-it("views a slice", async ({ expect, prismic, repo, token, host }) => {
+it("views a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
 	expect(exitCode).toBe(0);
@@ -18,7 +17,7 @@ it("views a slice", async ({ expect, prismic, repo, token, host }) => {
 	expect(stdout).toContain("default:");
 });
 
-it("shows fields per variation", async ({ expect, prismic, repo, token, host }) => {
+it("shows fields per variation", async ({ expect, prismic, project }) => {
 	const slice = buildSlice({
 		variations: [
 			{
@@ -46,7 +45,7 @@ it("shows fields per variation", async ({ expect, prismic, repo, token, host }) 
 			},
 		],
 	});
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
 	expect(exitCode).toBe(0);
@@ -57,9 +56,9 @@ it("shows fields per variation", async ({ expect, prismic, repo, token, host }) 
 	expect(stdout).toMatch(/image\s+Image\s+Image/);
 });
 
-it("views a slice as JSON", async ({ expect, prismic, repo, token, host }) => {
+it("views a slice as JSON", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
-	await insertSlice(slice, { repo, token, host });
+	await writeLocalSlice(project, slice);
 
 	const { stdout, exitCode } = await prismic("slice", ["view", slice.id, "--json"]);
 	expect(exitCode).toBe(0);

--- a/test/type-add-tab.test.ts
+++ b/test/type-add-tab.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["add-tab", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type add-tab <name> [options]");
 });
 
-it("adds a tab to a type", async ({ expect, prismic, repo, token, host }) => {
+it("adds a tab to a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
@@ -17,15 +16,14 @@ it("adds a tab to a type", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.json).toHaveProperty(tabName);
-	expect(updated?.json[tabName]).toEqual({});
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json).toHaveProperty(tabName);
+	expect(updated.json[tabName]).toEqual({});
 });
 
-it("adds a tab with a slice zone", async ({ expect, prismic, repo, token, host }) => {
+it("adds a tab with a slice zone", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
@@ -39,9 +37,8 @@ it("adds a tab with a slice zone", async ({ expect, prismic, repo, token, host }
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	const tab = updated?.json[tabName];
+	const updated = await readLocalCustomType(project, customType.id);
+	const tab = updated.json[tabName];
 	expect(tab).toHaveProperty("slices");
-	expect(tab?.slices).toMatchObject({ type: "Slices" });
+	expect(tab.slices).toMatchObject({ type: "Slices" });
 });

--- a/test/type-create.test.ts
+++ b/test/type-create.test.ts
@@ -1,5 +1,6 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes } from "./prismic";
+import { snakeCase } from "change-case";
+
+import { buildCustomType, it, readLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["create", "--help"]);
@@ -7,54 +8,53 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type create <name> [options]");
 });
 
-it("creates a custom type", async ({ expect, prismic, repo, token, host }) => {
+it("creates a custom type", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "custom" });
 
 	const { stdout, exitCode } = await prismic("type", ["create", label!]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Created type "${label}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const created = customTypes.find((ct) => ct.label === label);
-	expect(created).toMatchObject({ format: "custom", repeatable: true });
+	const id = snakeCase(label!);
+	const created = await readLocalCustomType(project, id);
+	expect(created).toMatchObject({ label, format: "custom", repeatable: true });
 });
 
-it("creates a page type with --format page", async ({ expect, prismic, repo, token, host }) => {
+it("creates a page type with --format page", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "page" });
 
 	const { stdout, exitCode } = await prismic("type", ["create", label!, "--format", "page"]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Created type "${label}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const created = customTypes.find((ct) => ct.label === label);
+	const id = snakeCase(label!);
+	const created = await readLocalCustomType(project, id);
 	expect(created).toMatchObject({ format: "page", repeatable: true });
-	expect(created!.json).toHaveProperty("SEO & Metadata");
-	expect(created!.json.Main).toHaveProperty("slices");
+	expect(created.json).toHaveProperty("SEO & Metadata");
+	expect(created.json.Main).toHaveProperty("slices");
 });
 
-it("creates a single custom type", async ({ expect, prismic, repo, token, host }) => {
+it("creates a single custom type", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "custom" });
 
 	const { exitCode } = await prismic("type", ["create", label!, "--single"]);
 	expect(exitCode).toBe(0);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const created = customTypes.find((ct) => ct.label === label);
+	const id = snakeCase(label!);
+	const created = await readLocalCustomType(project, id);
 	expect(created).toMatchObject({ format: "custom", repeatable: false });
 });
 
-it("creates a custom type with a custom id", async ({ expect, prismic, repo, token, host }) => {
+it("creates a custom type with a custom id", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "custom" });
-	const id = `CustomType${crypto.randomUUID().split("-")[0]}`;
+	const id = `custom_type_${crypto.randomUUID().split("-")[0]}`;
 
 	const { stdout, exitCode } = await prismic("type", ["create", label!, "--id", id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Created type "${label}" (id: "${id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const created = customTypes.find((ct) => ct.id === id);
-	expect(created).toBeDefined();
+	const created = await readLocalCustomType(project, id);
+	expect(created.id).toBe(id);
 });
 
 it("rejects invalid --format", async ({ expect, prismic }) => {

--- a/test/type-edit-tab.test.ts
+++ b/test/type-edit-tab.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["edit-tab", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type edit-tab <name> [options]");
 });
 
-it("edits a tab name", async ({ expect, prismic, repo, token, host }) => {
+it("edits a tab name", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ json: { Main: {}, OldName: {} } });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const newName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
@@ -24,15 +23,14 @@ it("edits a tab name", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Tab updated: "OldName" in "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.json).not.toHaveProperty("OldName");
-	expect(updated?.json).toHaveProperty(newName);
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json).not.toHaveProperty("OldName");
+	expect(updated.json).toHaveProperty(newName);
 });
 
-it("adds a slice zone to a tab", async ({ expect, prismic, repo, token, host }) => {
+it("adds a slice zone to a tab", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", [
 		"edit-tab",
@@ -44,13 +42,12 @@ it("adds a slice zone to a tab", async ({ expect, prismic, repo, token, host }) 
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.json.Main).toHaveProperty("slices");
-	expect(updated?.json.Main.slices).toMatchObject({ type: "Slices" });
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main).toHaveProperty("slices");
+	expect(updated.json.Main.slices).toMatchObject({ type: "Slices" });
 });
 
-it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, host }) => {
+it("removes a slice zone from a tab", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({
 		json: {
 			Main: {
@@ -62,7 +59,7 @@ it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, hos
 			},
 		},
 	});
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", [
 		"edit-tab",
@@ -74,7 +71,6 @@ it("removes a slice zone from a tab", async ({ expect, prismic, repo, token, hos
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.json.Main).not.toHaveProperty("slices");
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main).not.toHaveProperty("slices");
 });

--- a/test/type-edit.test.ts
+++ b/test/type-edit.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["edit", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type edit <id> [options]");
 });
 
-it("edits a type name", async ({ expect, prismic, repo, token, host }) => {
+it("edits a type name", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const newName = `TypeT${crypto.randomUUID().split("-")[0]}`;
 
@@ -23,20 +22,18 @@ it("edits a type name", async ({ expect, prismic, repo, token, host }) => {
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Type updated: "${newName}" (id: ${customType.id})`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.label).toBe(newName);
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.label).toBe(newName);
 });
 
-it("edits a type format", async ({ expect, prismic, repo, token, host }) => {
+it("edits a type format", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stderr, exitCode } = await prismic("type", ["edit", customType.id, "--format", "page"]);
 	expect(stderr).toBe("");
 	expect(exitCode).toBe(0);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.format).toBe("page");
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.format).toBe("page");
 });

--- a/test/type-list.test.ts
+++ b/test/type-list.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { insertCustomType } from "./prismic";
+import { buildCustomType, it, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["list", "--help"]);
@@ -7,11 +6,11 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type list [options]");
 });
 
-it("lists all types", async ({ expect, prismic, repo, token, host }) => {
+it("lists all types", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
 	const pageType = buildCustomType({ format: "page" });
-	await insertCustomType(customType, { repo, token, host });
-	await insertCustomType(pageType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
+	await writeLocalCustomType(project, pageType);
 
 	const { stdout, exitCode } = await prismic("type", ["list"]);
 	expect(exitCode).toBe(0);
@@ -19,9 +18,9 @@ it("lists all types", async ({ expect, prismic, repo, token, host }) => {
 	expect(stdout).toMatch(new RegExp(`${pageType.label}\\s+${pageType.id}\\s+page`));
 });
 
-it("lists types as JSON", async ({ expect, prismic, repo, token, host }) => {
+it("lists types as JSON", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", ["list", "--json"]);
 	expect(exitCode).toBe(0);

--- a/test/type-remove-tab.test.ts
+++ b/test/type-remove-tab.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["remove-tab", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type remove-tab <name> [options]");
 });
 
-it("removes a tab from a type", async ({ expect, prismic, repo, token, host }) => {
+it("removes a tab from a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ json: { Main: {}, Extra: {} } });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", [
 		"remove-tab",
@@ -20,8 +19,7 @@ it("removes a tab from a type", async ({ expect, prismic, repo, token, host }) =
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Removed tab "Extra" from "${customType.id}"`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
-	const updated = customTypes.find((ct) => ct.id === customType.id);
-	expect(updated?.json).not.toHaveProperty("Extra");
-	expect(updated?.json).toHaveProperty("Main");
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json).not.toHaveProperty("Extra");
+	expect(updated.json).toHaveProperty("Main");
 });

--- a/test/type-remove.test.ts
+++ b/test/type-remove.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { getCustomTypes, insertCustomType } from "./prismic";
+import { buildCustomType, it, readLocalCustomTypes, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["remove", "--help"]);
@@ -7,15 +6,15 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type remove <id> [options]");
 });
 
-it("removes a type", async ({ expect, prismic, repo, token, host }) => {
+it("removes a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", ["remove", customType.id]);
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Type removed: ${customType.id}`);
 
-	const customTypes = await getCustomTypes({ repo, token, host });
+	const customTypes = await readLocalCustomTypes(project);
 	const removed = customTypes.find((ct) => ct.id === customType.id);
 	expect(removed).toBeUndefined();
 });

--- a/test/type-view.test.ts
+++ b/test/type-view.test.ts
@@ -1,5 +1,4 @@
-import { buildCustomType, it } from "./it";
-import { insertCustomType } from "./prismic";
+import { buildCustomType, it, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("type", ["view", "--help"]);
@@ -7,9 +6,9 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic type view <id> [options]");
 });
 
-it("views a type", async ({ expect, prismic, repo, token, host }) => {
+it("views a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
 	expect(exitCode).toBe(0);
@@ -20,7 +19,7 @@ it("views a type", async ({ expect, prismic, repo, token, host }) => {
 	expect(stdout).toContain("Main:");
 });
 
-it("shows fields per tab", async ({ expect, prismic, repo, token, host }) => {
+it("shows fields per tab", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({
 		json: {
 			Main: {
@@ -32,7 +31,7 @@ it("shows fields per tab", async ({ expect, prismic, repo, token, host }) => {
 			},
 		},
 	});
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
 	expect(exitCode).toBe(0);
@@ -43,9 +42,9 @@ it("shows fields per tab", async ({ expect, prismic, repo, token, host }) => {
 	expect(stdout).toMatch(/meta_title\s+Text\s+Meta Title/);
 });
 
-it("views a type as JSON", async ({ expect, prismic, repo, token, host }) => {
+it("views a type as JSON", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
-	await insertCustomType(customType, { repo, token, host });
+	await writeLocalCustomType(project, customType);
 
 	const { stdout, exitCode } = await prismic("type", ["view", customType.id, "--json"]);
 	expect(exitCode).toBe(0);


### PR DESCRIPTION
Resolves:

### Description

Removes remote API calls from field, slice, and type commands. They now read and write models exclusively through the local adapter. Push and pull (added separately) reconcile local with remote.

The `--repo` flag is dropped from these commands since they no longer touch the API.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large behavioral change: commands stop updating remote Prismic models and drop `--repo`, which may break existing workflows and error handling expectations. Risk is mitigated by broad test updates, but adapter implementations and local model consistency now become critical.
> 
> **Overview**
> **Field, slice, and type commands no longer talk to the Prismic API directly.** They now fetch and persist models via the local `Adapter` APIs, and the `--repo` option is removed across these commands.
> 
> `src/models.ts` is refactored to resolve targets and content-relationship `--field` selections from locally loaded models (including nested content relationship traversal), and save paths now simply `update*()` + regenerate types rather than doing remote update + fallback create.
> 
> E2E tests are rewritten to set up and assert against local `customtypes/*/index.json` and `slices/*/model.json` files (new helpers in `test/it.ts`), matching the new “local-only” behavior; screenshot upload remains the only code path still requiring `repo/token/host` when used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92237a85205273356584ce2994495ab64e4a7aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->