### PR TITLE
feat: add --env flag

### DIFF
--- a/src/clients/core.ts
+++ b/src/clients/core.ts
@@ -83,6 +83,40 @@ export async function removePreview(
 	}
 }
 
+const EnvironmentSchema = z.object({
+	kind: z.enum(["prod", "stage", "dev"]),
+	name: z.string(),
+	domain: z.string(),
+	users: z.array(z.object({ id: z.string() })),
+});
+
+const GetEnvironmentsResponseSchema = z.object({
+	results: z.array(EnvironmentSchema),
+});
+
+export type Environment = z.infer<typeof EnvironmentSchema>;
+
+export async function getEnvironments(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<Environment[]> {
+	const { repo, token, host } = config;
+	const url = new URL("core/environments", getCoreBaseUrl(repo, host));
+	try {
+		const response = await request(url, {
+			credentials: { "prismic-auth": token },
+			schema: GetEnvironmentsResponseSchema,
+		});
+		return response.results;
+	} catch (error) {
+		if (error instanceof NotFoundRequestError) {
+			error.message = `Repository not found: ${repo}`;
+		}
+		throw error;
+	}
+}
+
 const RepositoryResponseSchema = z.object({
 	simulator_url: z.optional(z.string()),
 });

--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { upsertLocale } from "../clients/locale";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -19,15 +20,17 @@ const config = {
 		master: { type: "boolean", description: "Set as the master locale" },
 		name: { type: "string", short: "n", description: "Custom display name (for custom locales)" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo = await getRepositoryName(), master = false, name } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, master = false, name } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await upsertLocale({ id: code, isMaster: master, customName: name }, { repo, token, host });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales } from "../clients/locale";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,14 +18,16 @@ const config = {
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName(), json } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { removeLocale } from "../clients/locale";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await removeLocale(code, { repo, token, host });

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales, upsertLocale } from "../clients/locale";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { addPreview } from "../clients/core";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,12 +19,13 @@ const config = {
 	options: {
 		name: { type: "string", short: "n", description: "Display name (defaults to hostname)" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo = await getRepositoryName(), name } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, name } = values;
 
 	let parsed: URL;
 	try {
@@ -38,6 +40,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await addPreview({ name: displayName, websiteURL, resolverPath }, { repo, token, host });

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, getSimulatorUrl } from "../clients/core";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,14 +18,16 @@ const config = {
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName(), json } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	let simulatorUrl;

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, removePreview } from "../clients/core";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	try {

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { setSimulatorUrl } from "../clients/core";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -23,12 +24,13 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [urlArg] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	let parsed: URL;
 	try {
@@ -44,6 +46,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await setSimulatorUrl(simulatorUrl, { repo, token, host });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,6 +1,7 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
@@ -18,18 +19,25 @@ const config = {
 	options: {
 		force: { type: "boolean", short: "f", description: "Overwrite local changes" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo = await getRepositoryName() } = values;
+	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	console.info(`Pulling from repository: ${repo}`);
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+
+	if (env) {
+		console.info(`Pulling from repository: ${parentRepo} (env: ${env})`);
+	} else {
+		console.info(`Pulling from repository: ${repo}`);
+	}
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -12,6 +12,7 @@ import {
 	updateCustomType,
 	updateSlice,
 } from "../clients/custom-types";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
@@ -29,18 +30,25 @@ const config = {
 	options: {
 		force: { type: "boolean", short: "f", description: "Skip safety checks" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo = await getRepositoryName() } = values;
+	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	console.info(`Pushing to repository: ${repo}`);
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+
+	if (env) {
+		console.info(`Pushing to repository: ${parentRepo} (env: ${env})`);
+	} else {
+		console.info(`Pushing to repository: ${repo}`);
+	}
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -91,9 +91,6 @@ export default createCommand(config, async ({ values }) => {
 		console.info(`Authenticated as: ${userEmail}`);
 	} else {
 		console.info("Not logged in — log in with `prismic login` to compare with remote.");
-		if (env) {
-			console.info("Environment flag ignored — log in to use --env.");
-		}
 	}
 
 	const inSync =

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,6 +4,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { getProfile } from "../clients/user";
+import { resolveEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays, type ArrayDiff } from "../lib/diff";
 import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
@@ -21,11 +22,12 @@ const config = {
 	`,
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
@@ -41,10 +43,14 @@ export default createCommand(config, async ({ values }) => {
 			adapter.getSlices(),
 		]);
 
+	let repo = parentRepo;
 	let userEmail: string | undefined;
 	let customTypeOps: ArrayDiff<CustomType> | undefined;
 	let sliceOps: ArrayDiff<SharedSlice> | undefined;
 	if (token) {
+		if (env) {
+			repo = await resolveEnvironment({ env, repo: parentRepo, token, host });
+		}
 		const [profile, remoteCustomTypes, remoteSlices] = await Promise.all([
 			getProfile({ token, host }),
 			getCustomTypes({ repo, token, host }),
@@ -77,11 +83,17 @@ export default createCommand(config, async ({ values }) => {
 			.map((path) => relativePathname(projectRoot, path));
 	}
 
-	console.info(`Repository: ${repo}`);
+	console.info(`Repository: ${parentRepo}`);
+	if (env) {
+		console.info(`Environment: ${env}`);
+	}
 	if (userEmail) {
 		console.info(`Authenticated as: ${userEmail}`);
 	} else {
 		console.info("Not logged in — log in with `prismic login` to compare with remote.");
+		if (env) {
+			console.info("Environment flag ignored — log in to use --env.");
+		}
 	}
 
 	const inSync =

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -5,6 +5,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { env } from "../env";
+import { resolveEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { segmentTrackEnd, segmentTrackStart } from "../lib/segment";
@@ -28,15 +29,20 @@ const config = {
 			required: true,
 		},
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env: envFlag } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
+
+	const repo = envFlag
+		? await resolveEnvironment({ env: envFlag, repo: parentRepo, token, host })
+		: parentRepo;
 
 	segmentTrackStart("sync", { watch: true });
 	process.on("SIGINT", () => {
@@ -45,9 +51,15 @@ export default createCommand(config, async ({ values }) => {
 		process.exit(0);
 	});
 
-	console.info(
-		`Watching repository: ${repo} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
-	);
+	if (envFlag) {
+		console.info(
+			`Watching repository: ${parentRepo} (env: ${envFlag}, polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
+		);
+	} else {
+		console.info(
+			`Watching repository: ${repo} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
+		);
+	}
 
 	let lastHash = "";
 	let consecutiveErrors = 0;

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -5,6 +5,7 @@ import {
 	createWriteToken,
 	getOAuthApps,
 } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -26,11 +27,17 @@ const config = {
 			description: "Allow access to releases (read tokens only)",
 		},
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName(), write, "allow-releases": allowReleases } = values;
+	const {
+		repo: parentRepo = await getRepositoryName(),
+		env,
+		write,
+		"allow-releases": allowReleases,
+	} = values;
 
 	if (write && allowReleases) {
 		throw new CommandError("--allow-releases is only valid for access tokens (not with --write)");
@@ -38,6 +45,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let createdToken: string;
 	try {

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -5,6 +5,7 @@ import {
 	getOAuthApps,
 	getWriteTokens,
 } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -22,15 +23,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [tokenValue] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getOAuthApps, getWriteTokens } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,14 +18,16 @@ const config = {
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName(), json } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { createWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -25,6 +26,7 @@ const config = {
 			description: "Trigger events (can be repeated)",
 		},
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -52,7 +54,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName(), name, secret, trigger = [] } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, name, secret, trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -65,6 +67,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 
 	const defaultValue = trigger.length > 0 ? false : true;
 

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,14 +18,16 @@ const config = {
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo = await getRepositoryName(), json } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { deleteWebhook, getWebhooks } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -24,6 +25,7 @@ const config = {
 			required: true,
 		},
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -39,7 +41,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName(), trigger = [] } = values;
+	const { repo: parentRepo = await getRepositoryName(), env, trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -52,6 +54,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, WEBHOOK_TRIGGERS } from "../clients/wroom";
+import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,15 +18,17 @@ const config = {
 	},
 	options: {
 		repo: { type: "string", short: "r", description: "Repository domain" },
+		env: { type: "string", short: "e", description: "Environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo: parentRepo = await getRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();
+	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,0 +1,34 @@
+import { getEnvironments } from "./clients/core";
+import { getProfile } from "./clients/user";
+import { CommandError } from "./lib/command";
+
+export async function resolveEnvironment(args: {
+	env: string;
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<string> {
+	const { env, repo, token, host } = args;
+
+	const [profile, environments] = await Promise.all([
+		getProfile({ token, host }),
+		getEnvironments({ repo, token, host }),
+	]);
+
+	const available = environments.filter(
+		(environment) =>
+			environment.kind !== "dev" && environment.users.some((user) => user.id === profile.shortId),
+	);
+
+	const match = available.find((environment) => environment.domain === env);
+	if (match) return match.domain;
+
+	if (available.length === 0) {
+		throw new CommandError(`No environments available on repository "${repo}".`);
+	}
+
+	const list = available.map((environment) => `  ${environment.domain}`).join("\n");
+	throw new CommandError(
+		`Environment "${env}" not found on repository "${repo}".\n\nAvailable environments:\n${list}`,
+	);
+}

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -18,14 +18,10 @@ it.sequential("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic pull [options]");
 });
 
-it.sequential("rejects --env when no environments are available", async ({
-	expect,
-	prismic,
-	repo,
-}) => {
+it.sequential("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("pull", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
 });
 
 it.sequential("pulls slices and custom types from remote", async ({

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -18,6 +18,16 @@ it.sequential("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic pull [options]");
 });
 
+it.sequential("rejects --env when no environments are available", async ({
+	expect,
+	prismic,
+	repo,
+}) => {
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo, "--env", "does-not-exist"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+});
+
 it.sequential("pulls slices and custom types from remote", async ({
 	expect,
 	project,

--- a/test/push.serial.test.ts
+++ b/test/push.serial.test.ts
@@ -7,6 +7,12 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic push [options]");
 });
 
+it("rejects --env when no environments are available", async ({ expect, prismic, repo }) => {
+	const { stderr, exitCode } = await prismic("push", ["--repo", repo, "--env", "does-not-exist"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+});
+
 it("pushes a new local custom type to remote", async ({
 	expect,
 	project,

--- a/test/push.serial.test.ts
+++ b/test/push.serial.test.ts
@@ -7,10 +7,10 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic push [options]");
 });
 
-it("rejects --env when no environments are available", async ({ expect, prismic, repo }) => {
+it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("push", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
 });
 
 it("pushes a new local custom type to remote", async ({

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -57,6 +57,21 @@ it("reports remote-only models when added remotely but not pulled", async ({
 	expect(stdout).toContain("prismic pull");
 });
 
+it("rejects --env when no environments are available", async ({ expect, prismic, repo }) => {
+	const { stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "does-not-exist"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+});
+
+it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {
+	await logout();
+	const { stdout, exitCode } = await prismic("status", ["--repo", repo, "--env", "anything"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Repository: ${repo}`);
+	expect(stdout).toContain("Environment: anything");
+	expect(stdout).toContain("Environment flag ignored");
+});
+
 it("reports differing models when local and remote disagree", async ({
 	expect,
 	project,

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -57,10 +57,10 @@ it("reports remote-only models when added remotely but not pulled", async ({
 	expect(stdout).toContain("prismic pull");
 });
 
-it("rejects --env when no environments are available", async ({ expect, prismic, repo }) => {
+it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
 });
 
 it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -69,7 +69,6 @@ it("warns and skips --env when not logged in", async ({ expect, prismic, logout,
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain(`Repository: ${repo}`);
 	expect(stdout).toContain("Environment: anything");
-	expect(stdout).toContain("Environment flag ignored");
 });
 
 it("reports differing models when local and remote disagree", async ({


### PR DESCRIPTION
Resolves:

### Description

Adds an `--env <domain>` flag to commands that target a repository:

- `push`, `pull`, `status`, `sync`
- `locale` (add, list, remove, set-master)
- `preview` (add, list, remove, set-simulator)
- `token` (create, delete, list)
- `webhook` (create, disable, enable, list, remove, set-triggers, view)

It takes priority over the repo, whether from `prismic.config.json` or `--repo`. The base repo is still used to look up environments, then the env's domain replaces the repo for the actual API calls.

The env must exist on the repo and the user must have access to the env.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

`status` shows the parent repo and the selected environment:

```
$ prismic status --env <env-domain>
Repository: <repo>
Environment: <env-domain>
Authenticated as: <user-email>
...
```

`pull` and `push` print a header with both:

```
$ prismic pull --env <env-domain>
Pulling from repository: <repo> (env: <env-domain>)
...

$ prismic push --env <env-domain> --force
Pushing to repository: <repo> (env: <env-domain>)
...
```

An unknown env lists the ones available to the user:

```
$ prismic status --env <unknown>
Environment "<unknown>" not found on repository "<repo>".

Available environments:
  <env-domain-1>
  <env-domain-2>
```

### How to QA

Against a repo where you have access to a non-dev environment (e.g. staging):

```sh
prismic status --env <env-domain>
prismic pull   --env <env-domain>
prismic push   --env <env-domain> --force
prismic locale list --env <env-domain>
prismic webhook list --env <env-domain>
```

Negative path:

```sh
prismic status --env does-not-exist  # CommandError, lists valid envs
```