### PR TITLE
refactor: improve error message for unknown --env value

### DIFF
--- a/src/clients/core.ts
+++ b/src/clients/core.ts
@@ -89,11 +89,6 @@ const EnvironmentSchema = z.object({
 	domain: z.string(),
 	users: z.array(z.object({ id: z.string() })),
 });
-
-const GetEnvironmentsResponseSchema = z.object({
-	results: z.array(EnvironmentSchema),
-});
-
 export type Environment = z.infer<typeof EnvironmentSchema>;
 
 export async function getEnvironments(config: {
@@ -106,7 +101,7 @@ export async function getEnvironments(config: {
 	try {
 		const response = await request(url, {
 			credentials: { "prismic-auth": token },
-			schema: GetEnvironmentsResponseSchema,
+			schema: z.object({ results: z.array(EnvironmentSchema) }),
 		});
 		return response.results;
 	} catch (error) {

--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -30,7 +30,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await upsertLocale({ id: code, isMaster: master, customName: name }, { repo, token, host });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await removeLocale(code, { repo, token, host });

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -40,7 +40,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await addPreview({ name: displayName, websiteURL, resolverPath }, { repo, token, host });

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	let simulatorUrl;

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	try {

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -46,7 +46,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await setSimulatorUrl(simulatorUrl, { repo, token, host });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -31,13 +31,9 @@ export default createCommand(config, async ({ values }) => {
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
-	if (env) {
-		console.info(`Pulling from repository: ${parentRepo} (env: ${env})`);
-	} else {
-		console.info(`Pulling from repository: ${repo}`);
-	}
+	console.info(`Pulling from repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -42,13 +42,9 @@ export default createCommand(config, async ({ values }) => {
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
-	if (env) {
-		console.info(`Pushing to repository: ${parentRepo} (env: ${env})`);
-	} else {
-		console.info(`Pushing to repository: ${repo}`);
-	}
+	console.info(`Pushing to repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -49,7 +49,7 @@ export default createCommand(config, async ({ values }) => {
 	let sliceOps: ArrayDiff<SharedSlice> | undefined;
 	if (token) {
 		if (env) {
-			repo = await resolveEnvironment({ env, repo: parentRepo, token, host });
+			repo = await resolveEnvironment(env, { repo: parentRepo, token, host });
 		}
 		const [profile, remoteCustomTypes, remoteSlices] = await Promise.all([
 			getProfile({ token, host }),

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -41,7 +41,7 @@ export default createCommand(config, async ({ values }) => {
 	const adapter = await getAdapter();
 
 	const repo = envFlag
-		? await resolveEnvironment({ env: envFlag, repo: parentRepo, token, host })
+		? await resolveEnvironment(envFlag, { repo: parentRepo, token, host })
 		: parentRepo;
 
 	segmentTrackStart("sync", { watch: true });
@@ -51,15 +51,9 @@ export default createCommand(config, async ({ values }) => {
 		process.exit(0);
 	});
 
-	if (envFlag) {
-		console.info(
-			`Watching repository: ${parentRepo} (env: ${envFlag}, polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
-		);
-	} else {
-		console.info(
-			`Watching repository: ${repo} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
-		);
-	}
+	console.info(
+		`Watching repository: ${parentRepo}${envFlag ? ` (env: ${envFlag})` : ""} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
+	);
 
 	let lastHash = "";
 	let consecutiveErrors = 0;

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -45,7 +45,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let createdToken: string;
 	try {

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -33,7 +33,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -67,7 +67,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	const defaultValue = trigger.length > 0 ? false : true;
 

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -27,7 +27,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -54,7 +54,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -28,7 +28,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment({ env, repo: parentRepo, token, host }) : parentRepo;
+	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,34 +1,37 @@
-import { getEnvironments } from "./clients/core";
+import { type Environment, getEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
-import { CommandError } from "./lib/command";
 
-export async function resolveEnvironment(args: {
-	env: string;
-	repo: string;
-	token: string | undefined;
-	host: string;
-}): Promise<string> {
-	const { env, repo, token, host } = args;
+export async function resolveEnvironment(
+	env: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<string> {
+	const { repo, token, host } = config;
 
 	const [profile, environments] = await Promise.all([
 		getProfile({ token, host }),
 		getEnvironments({ repo, token, host }),
 	]);
 
-	const available = environments.filter(
+	const availableEnvironments = environments.filter(
 		(environment) =>
-			environment.kind !== "dev" && environment.users.some((user) => user.id === profile.shortId),
+			(environment.kind === "prod" || environment.kind === "stage") &&
+			environment.users.some((user) => user.id === profile.shortId),
 	);
-
-	const match = available.find((environment) => environment.domain === env);
+	const match = availableEnvironments.find((environment) => environment.domain === env);
 	if (match) return match.domain;
 
-	if (available.length === 0) {
-		throw new CommandError(`No environments available on repository "${repo}".`);
-	}
+	throw new InvalidEnvironmentError(env, availableEnvironments, repo);
+}
 
-	const list = available.map((environment) => `  ${environment.domain}`).join("\n");
-	throw new CommandError(
-		`Environment "${env}" not found on repository "${repo}".\n\nAvailable environments:\n${list}`,
-	);
+export class InvalidEnvironmentError extends Error {
+	name = "InvalidEnvironmentError";
+	repo: string;
+	env: string;
+	availableEnvironments: Environment[];
+	constructor(env: string, availableEnvironments: Environment[], repo: string) {
+		super();
+		this.repo = repo;
+		this.env = env;
+		this.availableEnvironments = availableEnvironments;
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,20 +250,6 @@ async function main(): Promise<void> {
 			return;
 		}
 
-		if (error instanceof InvalidEnvironmentError) {
-			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
-			}
-			const list = error.availableEnvironments.map((environment) => environment.domain).join("\n");
-			console.error(`
-				Environment "${error.env}" not found on repository "${error.repo}".
-
-				Available environments:
-				  ${list}
-			`);
-			return;
-		}
-
 		if (error instanceof UnauthorizedRequestError || error instanceof ForbiddenRequestError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
 				segmentTrackEnd(command, { error });

--- a/src/index.ts
+++ b/src/index.ts
@@ -240,13 +240,22 @@ async function main(): Promise<void> {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
 				segmentTrackEnd(command);
 			}
-			const list = error.availableEnvironments.map((environment) => environment.domain).join("\n");
-			console.error(dedent`
-				Environment "${error.env}" not found on repository "${error.repo}".
+			if (
+				error.availableEnvironments.length === 1 &&
+				error.repo === error.availableEnvironments[0].domain
+			) {
+				console.error(`No environments available on repository "${error.repo}".`);
+			} else {
+				const list = error.availableEnvironments
+					.map((environment) => environment.domain)
+					.join("\n");
+				console.error(dedent`
+					Environment "${error.env}" not found on repository "${error.repo}".
 
-				Available environments:
-				  ${list}
-			`);
+					Available environments:
+					  ${list}
+				`);
+			}
 			return;
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ async function main(): Promise<void> {
 				segmentTrackEnd(command);
 			}
 			const list = error.availableEnvironments.map((environment) => environment.domain).join("\n");
-			console.error(`
+			console.error(dedent`
 				Environment "${error.env}" not found on repository "${error.repo}".
 
 				Available environments:

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import type_ from "./commands/type";
 import webhook from "./commands/webhook";
 import whoami from "./commands/whoami";
 import { UPDATE_NOTIFIER_STATE_PATH } from "./config";
+import { InvalidEnvironmentError } from "./environments";
 import { CommandError, createCommandRouter } from "./lib/command";
 import { decodePayload } from "./lib/jwt";
 import {
@@ -232,6 +233,34 @@ async function main(): Promise<void> {
 				segmentTrackEnd(command, { error });
 			}
 			console.error(error.message);
+			return;
+		}
+
+		if (error instanceof InvalidEnvironmentError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
+			const list = error.availableEnvironments.map((environment) => environment.domain).join("\n");
+			console.error(`
+				Environment "${error.env}" not found on repository "${error.repo}".
+
+				Available environments:
+				  ${list}
+			`);
+			return;
+		}
+
+		if (error instanceof InvalidEnvironmentError) {
+			if (!UNTRACKED_COMMANDS.includes(command)) {
+				segmentTrackEnd(command);
+			}
+			const list = error.availableEnvironments.map((environment) => environment.domain).join("\n");
+			console.error(`
+				Environment "${error.env}" not found on repository "${error.repo}".
+
+				Available environments:
+				  ${list}
+			`);
 			return;
 		}
 

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -21,7 +21,7 @@ it.sequential("supports --help", async ({ expect, prismic }) => {
 it.sequential("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("pull", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
 });
 
 it.sequential("pulls slices and custom types from remote", async ({

--- a/test/push.serial.test.ts
+++ b/test/push.serial.test.ts
@@ -10,7 +10,7 @@ it("supports --help", async ({ expect, prismic }) => {
 it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("push", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
 });
 
 it("pushes a new local custom type to remote", async ({

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -60,7 +60,7 @@ it("reports remote-only models when added remotely but not pulled", async ({
 it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 	const { stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "does-not-exist"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`Environment "does-not-exist" not found on repository "${repo}".`);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
 });
 
 it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {


### PR DESCRIPTION
Resolves: 

### Description

Improves the error shown when `--env` is passed an unknown environment. The message is now formatted consistently with the CLI's other errors and lists the available environments (or notes when none exist).

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->