### PR TITLE
fix: include untracked model files in dirty tree check

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -4,7 +4,7 @@ import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
-import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
+import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { isDescendant, relativePathname } from "../lib/url";
 import { findProjectRoot, getRepositoryName } from "../project";
 
@@ -42,8 +42,8 @@ export default createCommand(config, async ({ values }) => {
 	]);
 
 	if (!force && gitRoot) {
-		const dirtyTrackedPaths = await getDirtyTrackedPaths(gitRoot);
-		const dirtyFiles = dirtyTrackedPaths
+		const dirtyPaths = await getDirtyPaths(gitRoot);
+		const dirtyFiles = dirtyPaths
 			.filter(
 				(path) =>
 					(path.pathname.endsWith("/model.json") &&

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -15,7 +15,7 @@ import {
 import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
-import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
+import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { appendTrailingSlash, isDescendant, relativePathname } from "../lib/url";
 import { findProjectRoot, getRepositoryName } from "../project";
 
@@ -53,8 +53,8 @@ export default createCommand(config, async ({ values }) => {
 	]);
 
 	if (!force && gitRoot) {
-		const dirtyTrackedPaths = await getDirtyTrackedPaths(gitRoot);
-		const dirtyFiles = dirtyTrackedPaths
+		const dirtyPaths = await getDirtyPaths(gitRoot);
+		const dirtyFiles = dirtyPaths
 			.filter(
 				(path) =>
 					(path.pathname.endsWith("/model.json") &&

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,7 +7,7 @@ import { getProfile } from "../clients/user";
 import { resolveEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays, type ArrayDiff } from "../lib/diff";
-import { getDirtyTrackedPaths, getGitRoot } from "../lib/git";
+import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { dedent } from "../lib/string";
 import { isDescendant, relativePathname } from "../lib/url";
 import { findProjectRoot, getRepositoryName } from "../project";
@@ -71,8 +71,8 @@ export default createCommand(config, async ({ values }) => {
 
 	let dirtyModelFiles: string[] = [];
 	if (gitRoot) {
-		const dirtyTrackedPaths = await getDirtyTrackedPaths(gitRoot);
-		dirtyModelFiles = dirtyTrackedPaths
+		const dirtyPaths = await getDirtyPaths(gitRoot);
+		dirtyModelFiles = dirtyPaths
 			.filter(
 				(path) =>
 					(path.pathname.endsWith("/model.json") &&

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -16,9 +16,9 @@ export async function getGitRoot(start: URL): Promise<URL | undefined> {
 	}
 }
 
-export async function getDirtyTrackedPaths(gitRoot: URL): Promise<URL[]> {
+export async function getDirtyPaths(gitRoot: URL): Promise<URL[]> {
 	try {
-		const { stdout } = await x("git", ["status", "--porcelain", "--untracked-files=no"], {
+		const { stdout } = await x("git", ["status", "--porcelain"], {
 			nodeOptions: { cwd: fileURLToPath(gitRoot) },
 			throwOnError: true,
 		});

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -18,7 +18,7 @@ export async function getGitRoot(start: URL): Promise<URL | undefined> {
 
 export async function getDirtyPaths(gitRoot: URL): Promise<URL[]> {
 	try {
-		const { stdout } = await x("git", ["status", "--porcelain"], {
+		const { stdout } = await x("git", ["status", "--porcelain", "--untracked-files=all"], {
 			nodeOptions: { cwd: fileURLToPath(gitRoot) },
 			throwOnError: true,
 		});


### PR DESCRIPTION
Resolves:

### Description

The dirty tree check used by `push`, `pull`, and `status` ran `git status --porcelain --untracked-files=no`, so a freshly created slice or custom type (untracked `model.json` / `index.json`) bypassed the safety check. `push` would silently send it without a committed snapshot to recover from, and `pull` could overwrite local changes unnoticed.

Switches to `--untracked-files=all` so individual files inside untracked directories are listed (a new slice directory would otherwise show as a single `?? slices/MyNewSlice/` entry that the filter wouldn't match). Renames `getDirtyTrackedPaths` to `getDirtyPaths` to match.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

1. In a Prismic project, create a new slice via `prismic slice create` (or hand-create a `model.json` under the slices directory) without staging it.
2. Run `prismic push` — it should now refuse and list the untracked model file. Same for `prismic pull` and `prismic status`.
3. `git add` and commit the file, then `prismic push` should proceed.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.