### PR TITLE
fix: ignore cosmetic key-order drift in model comparisons

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -6,6 +6,7 @@ import { CommandError, createCommand, type CommandConfig } from "../lib/command"
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { isDescendant, relativePathname } from "../lib/url";
+import { canonicalizeModel } from "../models";
 import { findProjectRoot, getRepositoryName } from "../project";
 
 const config = {
@@ -76,13 +77,13 @@ export default createCommand(config, async ({ values }) => {
 		getSlices({ repo, token, host }),
 	]);
 	const customTypeOps = diffArrays(
-		remoteCustomTypes,
-		localCustomTypes.map((customType) => customType.model),
+		remoteCustomTypes.map(canonicalizeModel),
+		localCustomTypes.map((customType) => canonicalizeModel(customType.model)),
 		{ getKey: (model) => model.id },
 	);
 	const sliceOps = diffArrays(
-		remoteSlices,
-		localSlices.map((slice) => slice.model),
+		remoteSlices.map(canonicalizeModel),
+		localSlices.map((slice) => canonicalizeModel(slice.model)),
 		{ getKey: (model) => model.id },
 	);
 

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -77,14 +77,22 @@ export default createCommand(config, async ({ values }) => {
 		getSlices({ repo, token, host }),
 	]);
 	const customTypeOps = diffArrays(
-		remoteCustomTypes.map(canonicalizeModel),
-		localCustomTypes.map((customType) => canonicalizeModel(customType.model)),
-		{ getKey: (model) => model.id },
+		remoteCustomTypes,
+		localCustomTypes.map((customType) => customType.model),
+		{
+			getKey: (model) => model.id,
+			equals: (a, b) =>
+				JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+		},
 	);
 	const sliceOps = diffArrays(
-		remoteSlices.map(canonicalizeModel),
-		localSlices.map((slice) => canonicalizeModel(slice.model)),
-		{ getKey: (model) => model.id },
+		remoteSlices,
+		localSlices.map((slice) => slice.model),
+		{
+			getKey: (model) => model.id,
+			equals: (a, b) =>
+				JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+		},
 	);
 
 	if (!force && !gitRoot) {

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -17,6 +17,7 @@ import { CommandError, createCommand, type CommandConfig } from "../lib/command"
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { appendTrailingSlash, isDescendant, relativePathname } from "../lib/url";
+import { canonicalizeModel } from "../models";
 import { findProjectRoot, getRepositoryName } from "../project";
 
 const config = {
@@ -84,13 +85,13 @@ export default createCommand(config, async ({ values }) => {
 		getSlices({ repo, token, host }),
 	]);
 	const customTypeOps = diffArrays(
-		localCustomTypes.map((customType) => customType.model),
-		remoteCustomTypes,
+		localCustomTypes.map((customType) => canonicalizeModel(customType.model)),
+		remoteCustomTypes.map(canonicalizeModel),
 		{ getKey: (model) => model.id },
 	);
 	const sliceOps = diffArrays(
-		localSlices.map((slice) => slice.model),
-		remoteSlices,
+		localSlices.map((slice) => canonicalizeModel(slice.model)),
+		remoteSlices.map(canonicalizeModel),
 		{ getKey: (model) => model.id },
 	);
 

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -85,14 +85,22 @@ export default createCommand(config, async ({ values }) => {
 		getSlices({ repo, token, host }),
 	]);
 	const customTypeOps = diffArrays(
-		localCustomTypes.map((customType) => canonicalizeModel(customType.model)),
-		remoteCustomTypes.map(canonicalizeModel),
-		{ getKey: (model) => model.id },
+		localCustomTypes.map((customType) => customType.model),
+		remoteCustomTypes,
+		{
+			getKey: (model) => model.id,
+			equals: (a, b) =>
+				JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+		},
 	);
 	const sliceOps = diffArrays(
-		localSlices.map((slice) => canonicalizeModel(slice.model)),
-		remoteSlices.map(canonicalizeModel),
-		{ getKey: (model) => model.id },
+		localSlices.map((slice) => slice.model),
+		remoteSlices,
+		{
+			getKey: (model) => model.id,
+			equals: (a, b) =>
+				JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+		},
 	);
 
 	if (!force) {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -10,6 +10,7 @@ import { diffArrays, type ArrayDiff } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { dedent } from "../lib/string";
 import { isDescendant, relativePathname } from "../lib/url";
+import { canonicalizeModel } from "../models";
 import { findProjectRoot, getRepositoryName } from "../project";
 
 const config = {
@@ -58,13 +59,13 @@ export default createCommand(config, async ({ values }) => {
 		]);
 		userEmail = profile.email;
 		customTypeOps = diffArrays(
-			localCustomTypesMeta.map((ct) => ct.model),
-			remoteCustomTypes,
+			localCustomTypesMeta.map((ct) => canonicalizeModel(ct.model)),
+			remoteCustomTypes.map(canonicalizeModel),
 			{ getKey: (m) => m.id },
 		);
 		sliceOps = diffArrays(
-			localSlicesMeta.map((s) => s.model),
-			remoteSlices,
+			localSlicesMeta.map((s) => canonicalizeModel(s.model)),
+			remoteSlices.map(canonicalizeModel),
 			{ getKey: (m) => m.id },
 		);
 	}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -59,14 +59,22 @@ export default createCommand(config, async ({ values }) => {
 		]);
 		userEmail = profile.email;
 		customTypeOps = diffArrays(
-			localCustomTypesMeta.map((ct) => canonicalizeModel(ct.model)),
-			remoteCustomTypes.map(canonicalizeModel),
-			{ getKey: (m) => m.id },
+			localCustomTypesMeta.map((ct) => ct.model),
+			remoteCustomTypes,
+			{
+				getKey: (m) => m.id,
+				equals: (a, b) =>
+					JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+			},
 		);
 		sliceOps = diffArrays(
-			localSlicesMeta.map((s) => canonicalizeModel(s.model)),
-			remoteSlices.map(canonicalizeModel),
-			{ getKey: (m) => m.id },
+			localSlicesMeta.map((s) => s.model),
+			remoteSlices,
+			{
+				getKey: (m) => m.id,
+				equals: (a, b) =>
+					JSON.stringify(canonicalizeModel(a)) === JSON.stringify(canonicalizeModel(b)),
+			},
 		);
 	}
 

--- a/src/lib/diff.ts
+++ b/src/lib/diff.ts
@@ -3,15 +3,18 @@ export type ArrayDiff<T> = { insert: T[]; update: T[]; delete: T[] };
 export function diffArrays<T>(
 	source: T[],
 	target: T[],
-	options: { getKey: (item: T) => string },
+	options: {
+		getKey: (item: T) => string;
+		equals?: (a: T, b: T) => boolean;
+	},
 ): ArrayDiff<T> {
-	const { getKey } = options;
+	const { getKey, equals = (a, b) => JSON.stringify(a) === JSON.stringify(b) } = options;
 	const diff: ArrayDiff<T> = { insert: [], update: [], delete: [] };
 	for (const sourceItem of source) {
 		const targetItem = target.find((item) => getKey(item) === getKey(sourceItem));
 		if (!targetItem) {
 			diff.insert.push(sourceItem);
-		} else if (JSON.stringify(sourceItem) !== JSON.stringify(targetItem)) {
+		} else if (!equals(sourceItem, targetItem)) {
 			diff.update.push(sourceItem);
 		}
 	}

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,6 +6,43 @@ import type { CommandConfig } from "./lib/command";
 import { getAdapter } from "./adapters";
 import { CommandError } from "./lib/command";
 
+// Returns a deep copy of `model` with all object keys sorted alphabetically,
+// except inside containers where insertion order carries meaning (tab order
+// and field order in the editor). Used only for comparing local vs. remote
+// models — the API returns metadata keys in a different order than we wrote
+// them, which would otherwise show as cosmetic drift.
+//
+// Ordered containers:
+//   - `json`: direct children are tab names (order matters), and each tab's
+//     direct children are field IDs (order matters) — depth 2.
+//   - `primary`, `items`, `fields`: direct children are field IDs — depth 1.
+export function canonicalizeModel<T>(model: T): T {
+	return canonicalize(model, 0) as T;
+}
+
+function canonicalize(value: unknown, orderedDepth: number): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => canonicalize(item, 0));
+	}
+	if (value && typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>);
+		if (orderedDepth === 0) {
+			entries.sort(([a], [b]) => a.localeCompare(b));
+		}
+		const result: Record<string, unknown> = {};
+		for (const [key, child] of entries) {
+			let childOrderedDepth = Math.max(0, orderedDepth - 1);
+			if (key === "json") childOrderedDepth = 2;
+			else if (key === "primary" || key === "items" || key === "fields") {
+				childOrderedDepth = 1;
+			}
+			result[key] = canonicalize(child, childOrderedDepth);
+		}
+		return result;
+	}
+	return value;
+}
+
 type Field = DynamicWidget;
 type Fields = Record<string, Field>;
 type ModelKind = "slice" | "customType";

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,4 +1,9 @@
-import type { DynamicWidget, Link } from "@prismicio/types-internal/lib/customtypes";
+import type {
+	CustomType,
+	DynamicWidget,
+	Link,
+	SharedSlice,
+} from "@prismicio/types-internal/lib/customtypes";
 
 import type { Adapter } from "./adapters";
 import type { CommandConfig } from "./lib/command";
@@ -6,29 +11,18 @@ import type { CommandConfig } from "./lib/command";
 import { getAdapter } from "./adapters";
 import { CommandError } from "./lib/command";
 
-// Returns a copy of `model` with top-level keys sorted alphabetically, and
-// each variation's top-level keys sorted alphabetically. Used only for
-// comparing local vs. remote — the Prismic API returns these metadata keys
-// in a different order than we wrote them, which would otherwise show as
-// cosmetic drift. Field order inside `json`/`primary`/`items` is preserved
-// because it carries meaning in the editor.
-export function canonicalizeModel<T>(model: T): T {
-	if (!isPlainObject(model)) return model;
-	const sorted = sortKeys(model);
-	if (Array.isArray(sorted.variations)) {
-		sorted.variations = sorted.variations.map((variation) =>
-			isPlainObject(variation) ? sortKeys(variation) : variation,
+export function canonicalizeModel<T extends CustomType | SharedSlice>(model: T): T {
+	const canonicalizedModel = sortKeys(model);
+	if ("variations" in canonicalizedModel) {
+		canonicalizedModel.variations = canonicalizedModel.variations.map((variation) =>
+			sortKeys(variation),
 		);
 	}
-	return sorted as T;
+	return canonicalizedModel;
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-	return value !== null && typeof value === "object" && !Array.isArray(value);
-}
-
-function sortKeys(obj: Record<string, unknown>): Record<string, unknown> {
-	return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)));
+function sortKeys<T extends Record<string, unknown>>(obj: T): T {
+	return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b))) as T;
 }
 
 type Field = DynamicWidget;

--- a/src/models.ts
+++ b/src/models.ts
@@ -7,36 +7,43 @@ import { getAdapter } from "./adapters";
 import { CommandError } from "./lib/command";
 
 // Returns a deep copy of `model` with all object keys sorted alphabetically,
-// except inside containers where insertion order carries meaning (tab order
-// and field order in the editor). Used only for comparing local vs. remote
-// models — the API returns metadata keys in a different order than we wrote
-// them, which would otherwise show as cosmetic drift.
+// except inside containers where insertion order carries meaning in the
+// editor. Used only for comparing local vs. remote models — the API returns
+// metadata keys in a different order than we wrote them, which would
+// otherwise show as cosmetic drift.
 //
-// Ordered containers:
-//   - `json`: direct children are tab names (order matters), and each tab's
-//     direct children are field IDs (order matters) — depth 2.
-//   - `primary`, `items`, `fields`: direct children are field IDs — depth 1.
+// Order is preserved in:
+//   - `json`: a tab map. Its keys are tab names.
+//   - Each tab object inside `json`: a field map. Its keys are field IDs.
+//   - `primary`, `items`, `fields`: field maps. Their keys are field IDs.
 export function canonicalizeModel<T>(model: T): T {
-	return canonicalize(model, 0) as T;
+	return canonicalize(model, undefined, undefined) as T;
 }
 
-function canonicalize(value: unknown, orderedDepth: number): unknown {
+const FIELD_MAP_KEYS = new Set(["primary", "items", "fields"]);
+const TAB_MAP_KEY = "json";
+
+function canonicalize(
+	value: unknown,
+	parentKey: string | undefined,
+	grandparentKey: string | undefined,
+): unknown {
 	if (Array.isArray(value)) {
-		return value.map((item) => canonicalize(item, 0));
+		// Array elements are independent subtrees; their parent context resets.
+		return value.map((item) => canonicalize(item, undefined, undefined));
 	}
 	if (value && typeof value === "object") {
+		const isFieldMap = parentKey !== undefined && FIELD_MAP_KEYS.has(parentKey);
+		const isTabMap = parentKey === TAB_MAP_KEY;
+		const isTabObject = grandparentKey === TAB_MAP_KEY;
+		const preserveKeyOrder = isFieldMap || isTabMap || isTabObject;
+
 		const entries = Object.entries(value as Record<string, unknown>);
-		if (orderedDepth === 0) {
-			entries.sort(([a], [b]) => a.localeCompare(b));
-		}
+		if (!preserveKeyOrder) entries.sort(([a], [b]) => a.localeCompare(b));
+
 		const result: Record<string, unknown> = {};
 		for (const [key, child] of entries) {
-			let childOrderedDepth = Math.max(0, orderedDepth - 1);
-			if (key === "json") childOrderedDepth = 2;
-			else if (key === "primary" || key === "items" || key === "fields") {
-				childOrderedDepth = 1;
-			}
-			result[key] = canonicalize(child, childOrderedDepth);
+			result[key] = canonicalize(child, key, parentKey);
 		}
 		return result;
 	}

--- a/src/models.ts
+++ b/src/models.ts
@@ -6,48 +6,29 @@ import type { CommandConfig } from "./lib/command";
 import { getAdapter } from "./adapters";
 import { CommandError } from "./lib/command";
 
-// Returns a deep copy of `model` with all object keys sorted alphabetically,
-// except inside containers where insertion order carries meaning in the
-// editor. Used only for comparing local vs. remote models — the API returns
-// metadata keys in a different order than we wrote them, which would
-// otherwise show as cosmetic drift.
-//
-// Order is preserved in:
-//   - `json`: a tab map. Its keys are tab names.
-//   - Each tab object inside `json`: a field map. Its keys are field IDs.
-//   - `primary`, `items`, `fields`: field maps. Their keys are field IDs.
+// Returns a copy of `model` with top-level keys sorted alphabetically, and
+// each variation's top-level keys sorted alphabetically. Used only for
+// comparing local vs. remote — the Prismic API returns these metadata keys
+// in a different order than we wrote them, which would otherwise show as
+// cosmetic drift. Field order inside `json`/`primary`/`items` is preserved
+// because it carries meaning in the editor.
 export function canonicalizeModel<T>(model: T): T {
-	return canonicalize(model, undefined, undefined) as T;
+	if (!isPlainObject(model)) return model;
+	const sorted = sortKeys(model);
+	if (Array.isArray(sorted.variations)) {
+		sorted.variations = sorted.variations.map((variation) =>
+			isPlainObject(variation) ? sortKeys(variation) : variation,
+		);
+	}
+	return sorted as T;
 }
 
-const FIELD_MAP_KEYS = new Set(["primary", "items", "fields"]);
-const TAB_MAP_KEY = "json";
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
 
-function canonicalize(
-	value: unknown,
-	parentKey: string | undefined,
-	grandparentKey: string | undefined,
-): unknown {
-	if (Array.isArray(value)) {
-		// Array elements are independent subtrees; their parent context resets.
-		return value.map((item) => canonicalize(item, undefined, undefined));
-	}
-	if (value && typeof value === "object") {
-		const isFieldMap = parentKey !== undefined && FIELD_MAP_KEYS.has(parentKey);
-		const isTabMap = parentKey === TAB_MAP_KEY;
-		const isTabObject = grandparentKey === TAB_MAP_KEY;
-		const preserveKeyOrder = isFieldMap || isTabMap || isTabObject;
-
-		const entries = Object.entries(value as Record<string, unknown>);
-		if (!preserveKeyOrder) entries.sort(([a], [b]) => a.localeCompare(b));
-
-		const result: Record<string, unknown> = {};
-		for (const [key, child] of entries) {
-			result[key] = canonicalize(child, key, parentKey);
-		}
-		return result;
-	}
-	return value;
+function sortKeys(obj: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)));
 }
 
 type Field = DynamicWidget;


### PR DESCRIPTION
Resolves: #170

### Description

`prismic push` and `prismic pull` write model JSON in different key orders, so after a successful push, `prismic status` reports types and slices as "Differ" indefinitely — and the git-dirty safety check then blocks the next push until the user commits a cosmetic-only pull.

Root cause: `diffArrays` compares with `JSON.stringify`, which is key-order sensitive. The API returns top-level model keys, top-level slice keys, and slice variation keys in a different order than we author them, but those keys have no semantic meaning.

This change normalizes models before diffing — sort keys by default, but preserve insertion order inside containers where order is meaningful in the editor (`json` for tab order and field order within tabs, and `primary`/`items`/`fields` for field order within variations and groups). Disk content is untouched.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA

1. In a fresh project, create a type and add a few fields:
   - `prismic type create "Announcement"`
   - `prismic field add uid --to-type announcement`
   - `prismic field add text message --to-type announcement --label "Message"`
2. `git add . && git commit -m "add announcement type"`
3. `prismic push` → reports the type as pushed.
4. `prismic status` → should report "Already up to date." (previously reported "Differ").
5. `prismic pull` → should report "Already up to date." (previously rewrote the local file with reordered keys).
6. Reorder a field with `prismic field reorder` and confirm `prismic status` still detects the change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the equality logic used by `prismic push`/`pull`/`status` to decide whether models differ; an overly-aggressive canonicalization could cause real schema changes to be missed or reduce visibility of differences.
> 
> **Overview**
> **Model diffs are now key-order insensitive.** `diffArrays` gains an optional `equals` comparator, and `push`, `pull`, and `status` pass a comparator that compares `canonicalizeModel()` output rather than raw `JSON.stringify`.
> 
> Adds `canonicalizeModel()` in `models.ts` to normalize custom type and slice models (including per-variation objects) by sorting object keys before comparison, reducing cosmetic-only churn and repeated “Differ” status after successful syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99a29dcd38938df34ae528802d744332820bf3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->