### PR TITLE
refactor: split tracking domain logic from segment client

### DIFF
--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -8,8 +8,8 @@ import { env } from "../env";
 import { resolveEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
-import { segmentTrackEnd, segmentTrackStart } from "../lib/segment";
 import { getRepositoryName } from "../project";
+import { trackCommandStart, trackCommandEnd } from "../tracking";
 
 const POLL_INTERVAL_MS = env.TEST ? 500 : 5000;
 const MAX_CONSECUTIVE_ERRORS = 5;
@@ -44,10 +44,10 @@ export default createCommand(config, async ({ values }) => {
 		? await resolveEnvironment(envFlag, { repo: parentRepo, token, host })
 		: parentRepo;
 
-	segmentTrackStart("sync", { watch: true });
+	trackCommandStart("sync", { watch: true });
 	process.on("SIGINT", () => {
 		console.info("\nWatch stopped. Goodbye!");
-		segmentTrackEnd("sync", { watch: true });
+		trackCommandEnd("sync", { watch: true });
 		process.exit(0);
 	});
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,13 +34,6 @@ import {
 	UnauthorizedRequestError,
 } from "./lib/request";
 import {
-	initSegment,
-	segmentIdentify,
-	segmentSetRepository,
-	segmentTrackEnd,
-	segmentTrackStart,
-} from "./lib/segment";
-import {
 	sentryCaptureError,
 	sentrySetContext,
 	sentrySetTag,
@@ -51,6 +44,13 @@ import { dedent } from "./lib/string";
 import { initUpdateNotifier } from "./lib/update-notifier";
 import { InvalidPrismicConfigError, MissingPrismicConfigError } from "./project";
 import { safeGetRepositoryName, TypeBuilderRequiredError } from "./project";
+import {
+	initTracking,
+	setTrackedRepository,
+	trackCommandEnd,
+	trackCommandStart,
+	trackUser,
+} from "./tracking";
 
 const UNTRACKED_COMMANDS = ["login", "logout", "whoami", "sync", "docs", "status"];
 
@@ -170,11 +170,13 @@ async function main(): Promise<void> {
 	if (typeof repo !== "string") repo = "";
 
 	if (!help) {
+		const host = await getHost();
+
 		setupSentry();
-		await initSegment();
+		await initTracking({ host });
 
 		if (repo) {
-			segmentSetRepository(repo);
+			setTrackedRepository(repo);
 			sentrySetTag("repository", repo);
 			sentrySetContext("Repository Data", { name: repo });
 		}
@@ -188,7 +190,6 @@ async function main(): Promise<void> {
 
 		const token = await getToken();
 		if (token) {
-			const host = await getHost();
 			const exp = decodePayload(token)?.exp;
 			const now = Date.now() / 1000;
 
@@ -199,7 +200,7 @@ async function main(): Promise<void> {
 			if (!exp || exp > now) {
 				getProfile({ token, host })
 					.then((profile) => {
-						segmentIdentify({ shortId: profile.shortId, intercomHash: profile.intercomHash });
+						trackUser(profile);
 						sentrySetUser({ id: profile.shortId });
 					})
 					.catch(() => {});
@@ -207,7 +208,7 @@ async function main(): Promise<void> {
 		}
 
 		if (command && !UNTRACKED_COMMANDS.includes(command)) {
-			segmentTrackStart(command);
+			trackCommandStart(command);
 		}
 	}
 
@@ -215,14 +216,14 @@ async function main(): Promise<void> {
 		await router();
 
 		if (command && !UNTRACKED_COMMANDS.includes(command)) {
-			segmentTrackEnd(command);
+			trackCommandEnd(command);
 		}
 	} catch (error) {
 		process.exitCode = 1;
 
 		if (error instanceof CommandError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			console.error(dedent(error.message));
 			return;
@@ -230,7 +231,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof NoSupportedFrameworkError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command, { error });
+				trackCommandEnd(command, { error });
 			}
 			console.error(error.message);
 			return;
@@ -238,7 +239,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof InvalidEnvironmentError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			if (
 				error.availableEnvironments.length === 1 &&
@@ -261,7 +262,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof UnauthorizedRequestError || error instanceof ForbiddenRequestError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command, { error });
+				trackCommandEnd(command, { error });
 			}
 			console.error("Not logged in. Run `prismic login` first.");
 			return;
@@ -269,7 +270,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof NotFoundRequestError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			console.error(
 				error.message || "Not found. Verify the repository and any specified identifiers exist.",
@@ -279,7 +280,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof InvalidPrismicConfigError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			console.error(`${error.message} Run \`prismic init\` to re-create a config.`);
 			return;
@@ -287,7 +288,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof MissingPrismicConfigError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			console.error(`${error.message} Run \`prismic init\` to create a config.`);
 			return;
@@ -295,7 +296,7 @@ async function main(): Promise<void> {
 
 		if (error instanceof TypeBuilderRequiredError) {
 			if (!UNTRACKED_COMMANDS.includes(command)) {
-				segmentTrackEnd(command);
+				trackCommandEnd(command);
 			}
 			console.error(dedent`
 				This command requires the Type Builder in your repository.
@@ -310,7 +311,7 @@ async function main(): Promise<void> {
 		}
 
 		if (!UNTRACKED_COMMANDS.includes(command)) {
-			segmentTrackEnd(command, { error });
+			trackCommandEnd(command, { error });
 		}
 		await sentryCaptureError(error);
 		throw error;

--- a/src/lib/segment.ts
+++ b/src/lib/segment.ts
@@ -84,7 +84,10 @@ function flushEvents(config: { writeKey: string }): void {
 	try {
 		const payload = Buffer.from(
 			JSON.stringify({
-				trackEvents,
+				trackEvents: trackEvents.map((event) => ({
+					...event,
+					userId: event.userId || userId,
+				})),
 				identifyEvents,
 				writeKey,
 			}),

--- a/src/lib/segment.ts
+++ b/src/lib/segment.ts
@@ -1,151 +1,96 @@
 import { spawn } from "node:child_process";
-import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import packageJson from "../../package.json" with { type: "json" };
-import { env } from "../env";
-
-const SEGMENT_WRITE_KEY =
-	process.env.PRISMIC_ENV && process.env.PRISMIC_ENV !== "production"
-		? "Ng5oKJHCGpSWplZ9ymB7Pu7rm0sTDeiG"
-		: "cGjidifKefYb6EPaGaqpt8rQXkv5TD6P";
+import { name as packageName, version as packageVersion } from "../../package.json";
 
 const SEGMENT_TRACK_URL = "https://api.segment.io/v1/track";
 const SEGMENT_IDENTIFY_URL = "https://api.segment.io/v1/identify";
 
-let enabled = false;
-let anonymousId = "";
+const trackEvents: TrackedEvent[] = [];
+const identifyEvents: TrackedIdentity[] = [];
+const anonymousId = crypto.randomUUID();
 let userId: string | undefined;
-let globalRepository: string | undefined;
-const appContext = { app: { name: packageJson.name, version: packageJson.version } };
-const trackQueue: Array<{
+
+type TrackedEvent = {
 	event: string;
 	properties: Record<string, unknown>;
-	context: Record<string, unknown>;
-}> = [];
-const identifyQueue: Array<Record<string, unknown>> = [];
-
-export async function initSegment(): Promise<void> {
-	try {
-		if (env.TEST) {
-			return;
-		}
-		enabled = await isTelemetryEnabled();
-		if (!enabled) {
-			return;
-		}
-
-		anonymousId = randomUUID();
-		process.on("exit", flushTelemetry);
-	} catch {
-		enabled = false;
-	}
-}
-
-export type TrackContext = { repository?: string; watch?: boolean };
-
-export function segmentTrackStart(command: string, context: TrackContext = {}): void {
-	if (!enabled) return;
-
-	const { repository = globalRepository, watch } = context;
-
-	const properties: Record<string, unknown> = {
-		commandType: command,
-		fullCommand: process.argv.join(" "),
+	context: {
+		app: { name: string; version: string };
+		groupId?: Record<string, string>;
 	};
-	if (repository) properties.repository = repository;
-	if (watch !== undefined) properties.watch = watch;
+	userId?: string;
+	anonymousId: string;
+	timestamp: string;
+};
 
-	trackQueue.push({
-		event: "Prismic CLI Start",
-		properties,
-		context: buildContext(repository),
-	});
+type TrackedIdentity = {
+	userId: string;
+	anonymousId: string;
+	integrations: { Intercom: { user_hash: string } };
+	context: { app: { name: string; version: string } };
+	timestamp: string;
+};
+
+export async function initSegment(config: { writeKey: string }): Promise<void> {
+	const { writeKey } = config;
+	process.on("exit", () => flushEvents({ writeKey }));
 }
 
-export function segmentTrackEnd(
-	command: string,
-	context: TrackContext & { success?: boolean; error?: unknown } = {},
-): void {
-	if (!enabled) return;
-
-	const { success = !process.exitCode, error, repository = globalRepository, watch } = context;
-
-	const properties: Record<string, unknown> = {
-		commandType: command,
-		fullCommand: process.argv.join(" "),
-		success,
-	};
-	if (repository) properties.repository = repository;
-	if (watch !== undefined) properties.watch = watch;
-	if (error !== undefined) {
-		const message = error instanceof Error ? error.message : String(error);
-		properties.error = message.slice(0, 512);
-	}
-
-	trackQueue.push({
-		event: "Prismic CLI End",
-		properties,
-		context: buildContext(repository),
-	});
-}
-
-export function segmentIdentify(profile: { shortId: string; intercomHash: string }): void {
-	if (!enabled) {
-		return;
-	}
-
-	userId = profile.shortId;
-
-	identifyQueue.push({
-		userId,
+export function trackIdentity(identity: { userId: string; intercomHash: string }): void {
+	userId = identity.userId;
+	identifyEvents.push({
+		userId: identity.userId,
 		anonymousId,
-		integrations: { Intercom: { user_hash: profile.intercomHash } },
-		context: appContext,
+		integrations: { Intercom: { user_hash: identity.intercomHash } },
+		context: {
+			app: {
+				name: packageName,
+				version: packageVersion,
+			},
+		},
 		timestamp: new Date().toISOString(),
 	});
 }
 
-export function segmentSetRepository(repo: string): void {
-	globalRepository = repo;
+export function trackEvent(
+	event: string,
+	config: { properties?: Record<string, unknown>; groupId?: Record<string, string> } = {},
+): void {
+	const { properties, groupId } = config;
+	trackEvents.push({
+		event,
+		properties: {
+			nodeVersion: process.versions.node,
+			...properties,
+		},
+		context: {
+			app: {
+				name: packageName,
+				version: packageVersion,
+			},
+			groupId,
+		},
+		userId,
+		anonymousId,
+		timestamp: new Date().toISOString(),
+	});
 }
 
-function buildContext(repository: string | undefined): Record<string, unknown> {
-	const context: Record<string, unknown> = { ...appContext };
-	if (repository) context.groupId = { Repository: repository };
-	return context;
-}
+function flushEvents(config: { writeKey: string }): void {
+	const { writeKey } = config;
 
-/**
- * Spawns a detached subprocess to send queued telemetry events.
- * The main process exits immediately; the subprocess handles HTTP delivery.
- */
-function flushTelemetry(): void {
-	if (trackQueue.length === 0 && identifyQueue.length === 0) {
-		return;
-	}
+	if (trackEvents.length === 0 && identifyEvents.length === 0) return;
 
 	try {
 		const payload = Buffer.from(
 			JSON.stringify({
-				trackEvents: trackQueue.map((e) => ({
-					...(userId ? { userId } : {}),
-					anonymousId,
-					event: e.event,
-					properties: { nodeVersion: process.versions.node, ...e.properties },
-					context: e.context,
-					timestamp: new Date().toISOString(),
-				})),
-				identifyEvents: identifyQueue,
+				trackEvents,
+				identifyEvents,
+				writeKey,
 			}),
 		).toString("base64");
 
-		const script = fileURLToPath(
-			new URL("./subprocesses/sendSegmentEvents.mjs", import.meta.url),
-		);
+		const script = fileURLToPath(new URL("./subprocesses/sendSegmentEvents.mjs", import.meta.url));
 		const child = spawn(process.execPath, [script, payload], {
 			detached: true,
 			stdio: "ignore",
@@ -155,17 +100,18 @@ function flushTelemetry(): void {
 		// Silent failure — never breaks the CLI
 	}
 
-	trackQueue.length = 0;
-	identifyQueue.length = 0;
+	trackEvents.length = 0;
+	identifyEvents.length = 0;
 }
 
 export async function sendSegmentEvents(
 	trackEvents: unknown[],
 	identifyEvents: unknown[],
+	writeKey: string,
 ): Promise<void> {
 	const headers = {
 		"Content-Type": "application/json",
-		Authorization: `Basic ${btoa(SEGMENT_WRITE_KEY + ":")}`,
+		Authorization: `Basic ${btoa(writeKey + ":")}`,
 	};
 
 	await Promise.allSettled([
@@ -180,33 +126,4 @@ export async function sendSegmentEvents(
 			),
 		),
 	]);
-}
-
-async function isTelemetryEnabled(): Promise<boolean> {
-	try {
-		// Check user-level .prismicrc
-		const userRc = await readJsonFile(join(homedir(), ".prismicrc"));
-		if (userRc?.telemetry === false) {
-			return false;
-		}
-
-		// Check project-level .prismicrc
-		const projectRc = await readJsonFile(join(process.cwd(), ".prismicrc"));
-		if (projectRc?.telemetry === false) {
-			return false;
-		}
-
-		return true;
-	} catch {
-		return true;
-	}
-}
-
-async function readJsonFile(path: string): Promise<Record<string, unknown> | undefined> {
-	try {
-		const contents = await readFile(path, "utf8");
-		return JSON.parse(contents);
-	} catch {
-		return undefined;
-	}
 }

--- a/src/subprocesses/sendSegmentEvents.ts
+++ b/src/subprocesses/sendSegmentEvents.ts
@@ -1,9 +1,9 @@
 import { sendSegmentEvents } from "../lib/segment";
 
-const { trackEvents, identifyEvents } = JSON.parse(
+const { trackEvents, identifyEvents, writeKey } = JSON.parse(
 	Buffer.from(process.argv[2], "base64").toString(),
 );
 
 try {
-	await sendSegmentEvents(trackEvents, identifyEvents);
+	await sendSegmentEvents(trackEvents, identifyEvents, writeKey);
 } catch {}

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -1,0 +1,89 @@
+import { homedir } from "node:os";
+import { pathToFileURL } from "node:url";
+import * as z from "zod/mini";
+
+import type { Profile } from "./clients/user";
+
+import { DEFAULT_PRISMIC_HOST, env } from "./env";
+import { readJsonFile } from "./lib/file";
+import { initSegment, trackEvent, trackIdentity } from "./lib/segment";
+import { appendTrailingSlash } from "./lib/url";
+
+const PROD_WRITE_KEY = "cGjidifKefYb6EPaGaqpt8rQXkv5TD6P";
+const STAGING_WRITE_KEY = "Ng5oKJHCGpSWplZ9ymB7Pu7rm0sTDeiG";
+
+let repository: string | undefined;
+
+export async function initTracking(config: { host: string }): Promise<void> {
+	if (env.TEST) return;
+	const { host } = config;
+	const enabled = await isTelemetryEnabled();
+	if (!enabled) return;
+	const writeKey = host === DEFAULT_PRISMIC_HOST ? PROD_WRITE_KEY : STAGING_WRITE_KEY;
+	await initSegment({ writeKey });
+}
+
+export function setTrackedRepository(repo: string): void {
+	repository = repo;
+}
+
+export function trackUser(profile: Profile): void {
+	trackIdentity({ userId: profile.shortId, intercomHash: profile.intercomHash });
+}
+
+export function trackCommandStart(command: string, config: { watch?: boolean } = {}): void {
+	const { watch } = config;
+	trackEvent("Prismic CLI Start", {
+		properties: {
+			commandType: command,
+			fullCommand: process.argv.join(" "),
+			repository,
+			watch,
+		},
+	});
+}
+
+export function trackCommandEnd(
+	command: string,
+	config: { watch?: boolean; success?: boolean; error?: unknown } = {},
+): void {
+	const { watch, success = !process.exitCode, error } = config;
+	const errorMessage = error ? (error instanceof Error ? error.message : String(error)) : undefined;
+	trackEvent("Prismic CLI End", {
+		properties: {
+			commandType: command,
+			fullCommand: process.argv.join(" "),
+			success,
+			repository,
+			watch,
+			error: errorMessage?.slice(0, 512),
+		},
+		groupId: repository ? { Repository: repository } : undefined,
+	});
+}
+
+const PrismicRcSchema = z.object({
+	telemetry: z.boolean(),
+});
+
+async function isTelemetryEnabled(): Promise<boolean> {
+	try {
+		// Check user-level .prismicrc
+		const userRc = await readJsonFile(
+			new URL(".prismicrc", appendTrailingSlash(pathToFileURL(homedir()))),
+			{ schema: PrismicRcSchema },
+		);
+		if (userRc.telemetry === false) return false;
+
+		// Check project-level .prismicrc
+		const projectRc = await readJsonFile(
+			new URL(".prismicrc", appendTrailingSlash(pathToFileURL(process.cwd()))),
+			{ schema: PrismicRcSchema },
+		);
+		if (projectRc.telemetry === false) return false;
+
+		return true;
+	} catch {
+		return true;
+	}
+}

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -40,6 +40,7 @@ export function trackCommandStart(command: string, config: { watch?: boolean } =
 			repository,
 			watch,
 		},
+		groupId: repository ? { Repository: repository } : undefined,
 	});
 }
 
@@ -72,14 +73,14 @@ async function isTelemetryEnabled(): Promise<boolean> {
 		const userRc = await readJsonFile(
 			new URL(".prismicrc", appendTrailingSlash(pathToFileURL(homedir()))),
 			{ schema: PrismicRcSchema },
-		);
+		).catch(() => ({ telemetry: true }));
 		if (userRc.telemetry === false) return false;
 
 		// Check project-level .prismicrc
 		const projectRc = await readJsonFile(
 			new URL(".prismicrc", appendTrailingSlash(pathToFileURL(process.cwd()))),
 			{ schema: PrismicRcSchema },
-		);
+		).catch(() => ({ telemetry: true }));
 		if (projectRc.telemetry === false) return false;
 
 		return true;


### PR DESCRIPTION
Resolves:

### Description

Moves Prismic-specific tracking logic out of `src/lib/segment.ts` into a new `src/tracking.ts` module, keeping `lib/segment.ts` domain-agnostic. The Segment write key is now derived from the Prismic host rather than `PRISMIC_ENV`.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CLI telemetry is initialized and how the Segment write key is selected (now based on `host` and `.prismicrc`), which could impact event delivery/opt-out behavior. Runtime risk is mostly limited to analytics but touches the CLI entrypoint and exit-flush flow.
> 
> **Overview**
> **Telemetry refactor:** Moves Prismic-specific tracking concerns (telemetry opt-out via `.prismicrc`, repository grouping, command start/end properties, and user identity) into a new `src/tracking.ts`, leaving `src/lib/segment.ts` as a domain-agnostic event queue + sender.
> 
> **Initialization changes:** CLI startup (`src/index.ts`) and `sync` now call `initTracking`/`trackCommandStart`/`trackCommandEnd`/`trackUser` instead of `lib/segment` helpers, and the Segment write key is determined from the resolved Prismic `host` (prod vs non-prod) and passed through the subprocess payload to `sendSegmentEvents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23fc6514ed0d00e558135d84bb93515f7b21cf4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->