### PR TITLE
feat(tracking): identify CLI and detect AI agent harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ coverage
 !.vscode/tasks.json
 !.vscode/launch.json
 *.code-workspace
+
+.claude

--- a/src/clients/wroom.ts
+++ b/src/clients/wroom.ts
@@ -320,11 +320,14 @@ export async function createRepository(config: {
 	domain: string;
 	name: string;
 	framework: string;
+	agent: string | undefined;
 	token: string | undefined;
 	host: string;
 }): Promise<void> {
-	const { domain, name, framework, token, host } = config;
+	const { domain, name, framework, agent, token, host } = config;
 	const url = new URL("app/dashboard/repositories", getDashboardUrl(host));
+	url.searchParams.set("app", "cli");
+	if (agent) url.searchParams.set("agent", agent);
 	await request(url, {
 		method: "POST",
 		body: { domain, name, framework, plan: "personal" },

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -1,6 +1,7 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { checkIsDomainAvailable, createRepository } from "../clients/wroom";
+import { detectAgent } from "../lib/ai";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 
@@ -39,9 +40,10 @@ export async function createRepo(config: {
 
 	const adapter = await getAdapter().catch(() => undefined);
 	const framework = adapter?.id ?? "other";
+	const agent = await detectAgent();
 
 	try {
-		await createRepository({ domain, name: name ?? domain, framework, token, host });
+		await createRepository({ domain, name: name ?? domain, framework, agent, token, host });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -3,13 +3,16 @@ import { exists } from "./file";
 export async function detectAgent(): Promise<string | undefined> {
 	if (process.env.AI_AGENT) return process.env.AI_AGENT.toLowerCase();
 
-	if (process.env.CLAUDE_CODE_IS_COWORK === "1" || process.env.CLAUDE_CODE_IS_COWORK === "true")
+	if (process.env.CLAUDE_CODE_IS_COWORK === "1" || process.env.CLAUDE_CODE_IS_COWORK === "true") {
 		return "claude-cowork";
+	}
 	if (process.env.CLAUDECODE === "1" || process.env.CLAUDE_CODE) return "claude-code";
-	if (process.env.CODEX_CI === "1" || process.env.CODEX_SANDBOX || process.env.CODEX_THREAD_ID)
+	if (process.env.CODEX_CI === "1" || process.env.CODEX_SANDBOX || process.env.CODEX_THREAD_ID) {
 		return "codex";
-	if (process.env.CURSOR_AGENT === "1" || process.env.CURSOR_EXTENSION_HOST_ROLE === "agent-exec")
+	}
+	if (process.env.CURSOR_AGENT === "1" || process.env.CURSOR_EXTENSION_HOST_ROLE === "agent-exec") {
 		return "cursor";
+	}
 	if (process.env.CLINE_ACTIVE === "true") return "cline";
 	if (process.env.ANTIGRAVITY_AGENT) return "antigravity";
 	if (process.env.AUGMENT_AGENT === "1") return "augment";
@@ -21,8 +24,9 @@ export async function detectAgent(): Promise<string | undefined> {
 		process.env.COPILOT_MODEL ||
 		process.env.COPILOT_ALLOW_ALL ||
 		process.env.COPILOT_GITHUB_TOKEN
-	)
+	) {
 		return "github-copilot";
+	}
 
 	const agent = process.env.AGENT?.toLowerCase();
 	if (agent === "goose" || agent === "amp") return agent;

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,0 +1,36 @@
+import { exists } from "./file";
+
+export async function detectAgent(): Promise<string | undefined> {
+	if (process.env.AI_AGENT) return process.env.AI_AGENT.toLowerCase();
+
+	if (process.env.CLAUDE_CODE_IS_COWORK === "1" || process.env.CLAUDE_CODE_IS_COWORK === "true")
+		return "claude-cowork";
+	if (process.env.CLAUDECODE === "1" || process.env.CLAUDE_CODE) return "claude-code";
+	if (process.env.CODEX_CI === "1" || process.env.CODEX_SANDBOX || process.env.CODEX_THREAD_ID)
+		return "codex";
+	if (process.env.CURSOR_AGENT === "1" || process.env.CURSOR_EXTENSION_HOST_ROLE === "agent-exec")
+		return "cursor";
+	if (process.env.CLINE_ACTIVE === "true") return "cline";
+	if (process.env.ANTIGRAVITY_AGENT) return "antigravity";
+	if (process.env.AUGMENT_AGENT === "1") return "augment";
+	if (process.env.OPENCODE_CLIENT === "1") return "opencode";
+	if (process.env.GEMINI_CLI === "1") return "gemini-cli";
+	if (process.env.TRAE_AI_SHELL_ID) return "trae";
+	if (process.env.REPL_ID) return "replit";
+	if (
+		process.env.COPILOT_MODEL ||
+		process.env.COPILOT_ALLOW_ALL ||
+		process.env.COPILOT_GITHUB_TOKEN
+	)
+		return "github-copilot";
+
+	const agent = process.env.AGENT?.toLowerCase();
+	if (agent === "goose" || agent === "amp") return agent;
+
+	if (process.platform === "linux") {
+		const isDevin = await exists(new URL("file:///opt/.devin"));
+		if (isDevin) return "devin";
+	}
+
+	if (process.env.IS_SANDBOX === "yes") return "unknown-sandbox";
+}

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -5,6 +5,7 @@ import * as z from "zod/mini";
 import type { Profile } from "./clients/user";
 
 import { DEFAULT_PRISMIC_HOST, env } from "./env";
+import { detectAgent } from "./lib/ai";
 import { readJsonFile } from "./lib/file";
 import { initSegment, trackEvent, trackIdentity } from "./lib/segment";
 import { appendTrailingSlash } from "./lib/url";
@@ -13,6 +14,7 @@ const PROD_WRITE_KEY = "cGjidifKefYb6EPaGaqpt8rQXkv5TD6P";
 const STAGING_WRITE_KEY = "Ng5oKJHCGpSWplZ9ymB7Pu7rm0sTDeiG";
 
 let repository: string | undefined;
+let agent: string | undefined;
 
 export async function initTracking(config: { host: string }): Promise<void> {
 	if (env.TEST) return;
@@ -20,6 +22,7 @@ export async function initTracking(config: { host: string }): Promise<void> {
 	const enabled = await isTelemetryEnabled();
 	if (!enabled) return;
 	const writeKey = host === DEFAULT_PRISMIC_HOST ? PROD_WRITE_KEY : STAGING_WRITE_KEY;
+	agent = await detectAgent();
 	await initSegment({ writeKey });
 }
 
@@ -39,6 +42,7 @@ export function trackCommandStart(command: string, config: { watch?: boolean } =
 			fullCommand: process.argv.join(" "),
 			repository,
 			watch,
+			agent,
 		},
 		groupId: repository ? { Repository: repository } : undefined,
 	});
@@ -58,6 +62,7 @@ export function trackCommandEnd(
 			repository,
 			watch,
 			error: errorMessage?.slice(0, 512),
+			agent,
 		},
 		groupId: repository ? { Repository: repository } : undefined,
 	});


### PR DESCRIPTION
### Description

- Adds a `detectAgent` helper that identifies the AI coding agent (Claude Code, Codex, Cursor, Cline, Copilot, etc.) invoking the CLI based on environment variables. Groundwork for harness-aware tracking.
- `createRepository` now sends `?app=cli` (and `&agent=<harness>` when detected) on `POST /app/dashboard/repositories`. On the API side (paired PR: prismicio/wroom#3189), `app=cli` maps to a new `ExternalApp.CLI` case so the `Repository Created` Segment event reports `source=cli`, and the `agent` query param is propagated as an `agent` trait on the same event.
- `Prismic CLI Start` and `Prismic CLI End` events now carry an `agent` property as well, so harness usage can be analyzed across the full CLI lifecycle, not only repo creation.

### How to QA [^1]

Deployed to [dev-tools](https://dev-tools-wroom.com/dashboard)
- Use an agent to create a new repository with the CLI, initialize, etc:
  - `PRISMIC_HOST=dev-tools-wroom.com npx prismic@pr-175 repo create -n my-repo`
  - `PRISMIC_HOST=dev-tools-wroom.com npx prismic@pr-175 init -r my-repo`
- Check Segment live debugger to see the new `source` and `agent` properties

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new standalone helper that only reads environment variables (and optionally checks a Linux file path) without changing existing execution paths.
> 
> **Overview**
> Introduces `src/lib/ai.ts` with a new async `detectAgent()` helper that identifies the active AI agent by checking a prioritized set of environment variables (Claude Code/Cowork, Codex, Cursor, Cline, Copilot, etc.).
> 
> On Linux it additionally probes for a Devin marker at `file:///opt/.devin`, and it returns `unknown-sandbox` when `IS_SANDBOX=yes`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2983c7afd192395dc8cfe3ff5efa135bba835f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->