### PR TITLE
fix: map non-prod hosts to staging Amplitude

### DIFF
--- a/src/clients/amplitude.ts
+++ b/src/clients/amplitude.ts
@@ -38,12 +38,10 @@ export async function getVariantData(
 
 function getAmplitudeApiKey(host: string): string {
 	if (host === DEFAULT_PRISMIC_HOST) return PROD_API_KEY;
-	if (host === WROOM_PRISMIC_HOST) return WROOM_API_KEY;
-	throw new Error(
-		`The Amplitude service is only supported in: ${DEFAULT_PRISMIC_HOST}, ${WROOM_PRISMIC_HOST}`,
-	);
+	return WROOM_API_KEY;
 }
 
 function getAmplitudeServiceUrl(host: string): URL {
-	return new URL(`https://amplitude.${host}/`);
+	if (host === DEFAULT_PRISMIC_HOST) return new URL(`https://amplitude.${DEFAULT_PRISMIC_HOST}/`);
+	return new URL(`https://amplitude.${WROOM_PRISMIC_HOST}/`);
 }


### PR DESCRIPTION
## Summary
- Development environments previously threw `The Amplitude service is only supported in: prismic.io, wroom.io` during flag lookup.
- Amplitude only has prod and staging, so route any non-`prismic.io` host to the staging endpoint/key (same pattern as Segment in `tracking.ts`).
- Also fixes the server URL — non-prod hosts no longer try to hit a non-existent `amplitude.<host>`, they hit `amplitude.wroom.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how feature-flag/variant data is resolved by altering host→key/URL mapping; misrouting could cause flags to be fetched from the wrong Amplitude environment.
> 
> **Overview**
> Adjusts Amplitude variant-data requests to **treat any non-`prismic.io` host as staging**: `getAmplitudeApiKey` no longer throws for unknown hosts and always returns the Wroom key, and `getAmplitudeServiceUrl` now maps explicitly to either `amplitude.prismic.io` (prod) or `amplitude.wroom.io` (staging) instead of constructing `amplitude.<host>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b82f15b5c76652177a517687740b5c7d133c13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->