### PR TITLE
feat: configure preview and simulator URL on init

### DIFF
--- a/src/adapters/nextjs.ts
+++ b/src/adapters/nextjs.ts
@@ -6,11 +6,13 @@ import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Adapter } from ".";
+import { getHost, getToken } from "../auth";
+import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
 import { addDependencies, findPackageJson, getNpmPackageVersion } from "../lib/packageJson";
 import { dedent } from "../lib/string";
 import { appendTrailingSlash } from "../lib/url";
-import { buildRoutePath } from "../project";
+import { buildRoutePath, getRepositoryName } from "../project";
 import { checkIsTypeScriptProject, findProjectRoot } from "../project";
 import {
 	pageTemplate,
@@ -38,7 +40,24 @@ export class NextJsAdapter extends Adapter {
 		await createRevalidateRoute();
 	}
 
-	onProjectInitialized(): void {}
+	async onProjectInitialized(): Promise<void> {
+		const repo = await getRepositoryName();
+		const token = await getToken();
+		const host = await getHost();
+
+		const simulatorUrl = await getSimulatorUrl({ repo, token, host });
+		if (!simulatorUrl) {
+			await setSimulatorUrl("http://localhost:3000/slice-simulator", { repo, token, host });
+		}
+
+		const previews = await getPreviews({ repo, token, host });
+		if (previews.length === 0) {
+			await addPreview(
+				{ name: "Development", websiteURL: "http://localhost:3000", resolverPath: "/api/preview" },
+				{ repo, token, host },
+			);
+		}
+	}
 
 	async onSliceCreated(model: SharedSlice, library: URL): Promise<void> {
 		const sliceDirectoryName = pascalCase(model.name);
@@ -102,7 +121,7 @@ export class NextJsAdapter extends Adapter {
 
 	async getDefaultCustomTypeLibrary(): Promise<URL> {
 		const projectRoot = await findProjectRoot();
-		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot)
+		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot);
 		return defaultCustomTypeLibrary;
 	}
 }

--- a/src/adapters/nuxt.ts
+++ b/src/adapters/nuxt.ts
@@ -7,11 +7,13 @@ import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Adapter } from ".";
+import { getHost, getToken } from "../auth";
+import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
 import { addDependencies, getNpmPackageVersion } from "../lib/packageJson";
 import { dedent } from "../lib/string";
 import { appendTrailingSlash } from "../lib/url";
-import { buildRoutePath, readConfig, updateConfig } from "../project";
+import { buildRoutePath, getRepositoryName, readConfig, updateConfig } from "../project";
 import { checkIsTypeScriptProject, findProjectRoot } from "../project";
 import { pageTemplate, sliceSimulatorPageTemplate, sliceTemplate } from "./nuxt.templates";
 
@@ -31,7 +33,24 @@ export class NuxtAdapter extends Adapter {
 		await modifySliceLibraryPath(this);
 	}
 
-	onProjectInitialized(): void {}
+	async onProjectInitialized(): Promise<void> {
+		const repo = await getRepositoryName();
+		const token = await getToken();
+		const host = await getHost();
+
+		const simulatorUrl = await getSimulatorUrl({ repo, token, host });
+		if (!simulatorUrl) {
+			await setSimulatorUrl("http://localhost:3000/slice-simulator", { repo, token, host });
+		}
+
+		const previews = await getPreviews({ repo, token, host });
+		if (previews.length === 0) {
+			await addPreview(
+				{ name: "Development", websiteURL: "http://localhost:3000", resolverPath: "/preview" },
+				{ repo, token, host },
+			);
+		}
+	}
 
 	async onSliceCreated(model: SharedSlice, library: URL): Promise<void> {
 		const sliceDirectoryName = pascalCase(model.name);
@@ -87,7 +106,7 @@ export class NuxtAdapter extends Adapter {
 
 	async getDefaultCustomTypeLibrary(): Promise<URL> {
 		const projectRoot = await findProjectRoot();
-		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot)
+		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot);
 		return defaultCustomTypeLibrary;
 	}
 }

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -8,11 +8,13 @@ import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { Adapter } from ".";
+import { getHost, getToken } from "../auth";
+import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
 import { addDependencies, findPackageJson, getNpmPackageVersion } from "../lib/packageJson";
 import { dedent } from "../lib/string";
 import { appendTrailingSlash } from "../lib/url";
-import { buildRoutePath } from "../project";
+import { buildRoutePath, getRepositoryName } from "../project";
 import { checkIsTypeScriptProject, findProjectRoot } from "../project";
 import {
 	pageServerTemplate,
@@ -42,7 +44,24 @@ export class SvelteKitAdapter extends Adapter {
 		await modifyViteConfig();
 	}
 
-	onProjectInitialized(): void {}
+	async onProjectInitialized(): Promise<void> {
+		const repo = await getRepositoryName();
+		const token = await getToken();
+		const host = await getHost();
+
+		const simulatorUrl = await getSimulatorUrl({ repo, token, host });
+		if (!simulatorUrl) {
+			await setSimulatorUrl("http://localhost:5173/slice-simulator", { repo, token, host });
+		}
+
+		const previews = await getPreviews({ repo, token, host });
+		if (previews.length === 0) {
+			await addPreview(
+				{ name: "Development", websiteURL: "http://localhost:5173", resolverPath: "/api/preview" },
+				{ repo, token, host },
+			);
+		}
+	}
 
 	async onSliceCreated(model: SharedSlice, library: URL): Promise<void> {
 		const sliceDirectoryName = pascalCase(model.name);
@@ -103,7 +122,7 @@ export class SvelteKitAdapter extends Adapter {
 
 	async getDefaultCustomTypeLibrary(): Promise<URL> {
 		const projectRoot = await findProjectRoot();
-		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot)
+		const defaultCustomTypeLibrary = new URL("customtypes/", projectRoot);
 		return defaultCustomTypeLibrary;
 	}
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -96,7 +96,7 @@ export default createCommand(config, async ({ values }) => {
 		}
 	}
 
-	let repo = explicitRepo ?? legacySliceMachineConfig?.repositoryName;
+	let repo = (explicitRepo ?? legacySliceMachineConfig?.repositoryName)?.toLowerCase();
 	if (repo) {
 		const hasRepoAccess = profile.repositories.some((repository) => repository.domain === repo);
 		if (!hasRepoAccess) {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,10 +1,11 @@
 import { access, readFile, rm, writeFile } from "node:fs/promises";
+import { onTestFinished } from "vitest";
 
 import { captureOutput, it } from "./it";
 import {
 	addPreview,
-	cleanupRepository,
 	createRepository,
+	deleteRepository,
 	getPreviews,
 	getRepository,
 	setSimulatorUrl,
@@ -26,9 +27,17 @@ it("creates a repo if --repo is not provided and no legacy config exists", async
 	expect,
 	project,
 	prismic,
+	token,
+	host,
+	password,
 }) => {
 	await rm(new URL("prismic.config.json", project));
 	const { exitCode, stdout } = await prismic("init");
+	const createdRepositoryMatch = stdout.match(/^Created repository: ([a-z0-9-]+)$/m);
+	const name = createdRepositoryMatch?.[1];
+	if (!name) throw new Error(`Could not find created repository name in output:\n${stdout}`);
+	onTestFinished(() => deleteRepository(name, { token, password, host }));
+
 	expect(exitCode).toBe(0);
 	expect(stdout).toContain("Created repository:");
 	expect(stdout).toContain("Initialized Prismic for repository");
@@ -55,7 +64,7 @@ it("preserves existing preview config", async ({
 }) => {
 	const rawName = `CLI-Test-${crypto.randomUUID().slice(0, 8)}`;
 	const name = rawName.toLowerCase();
-	onTestFinished(() => cleanupRepository(name, { token, password, host }));
+	onTestFinished(() => deleteRepository(name, { token, password, host }));
 	await createRepository(name, { token, host });
 
 	const presetSimulator = "https://staging.example.com/slice-simulator";

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -3,7 +3,14 @@ import { access, readFile, rm, writeFile } from "node:fs/promises";
 import { onTestFinished } from "vitest";
 
 import { captureOutput, it } from "./it";
-import { cleanupRepository } from "./prismic";
+import {
+	addPreview,
+	cleanupRepository,
+	createRepository,
+	getPreviews,
+	getRepository,
+	setSimulatorUrl,
+} from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("init", ["--help"]);
@@ -38,6 +45,45 @@ it("creates a repo when --repo doesn't exist yet", async ({
 	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
 	const config = JSON.parse(configRaw);
 	expect(config.repositoryName).toBe(name);
+
+	const repository = await getRepository({ repo: name, token, host });
+	expect(repository.simulatorUrl).toBe("http://localhost:3000/slice-simulator");
+
+	const previews = await getPreviews({ repo: name, token, host });
+	const dev = previews.find((p) => p.url === "http://localhost:3000/api/preview");
+	expect(dev?.label).toBe("Development");
+}, 60_000);
+
+it("preserves existing preview config", async ({
+	expect,
+	project,
+	prismic,
+	token,
+	password,
+	host,
+}) => {
+	const rawName = `CLI-Test-${crypto.randomUUID().slice(0, 8)}`;
+	const name = rawName.toLowerCase();
+	onTestFinished(() => cleanupRepository(name, { token, password, host }));
+	await createRepository(name, { token, host });
+
+	const presetSimulator = "https://staging.example.com/slice-simulator";
+	await setSimulatorUrl(presetSimulator, { repo: name, token, host });
+	await addPreview("https://staging.example.com/api/preview", "Staging", {
+		repo: name,
+		token,
+		host,
+	});
+
+	await rm(new URL("prismic.config.json", project));
+	const { exitCode } = await prismic("init", ["--repo", rawName]);
+	expect(exitCode).toBe(0);
+
+	const repository = await getRepository({ repo: name, token, host });
+	expect(repository.simulatorUrl).toBe(presetSimulator);
+
+	const previews = await getPreviews({ repo: name, token, host });
+	expect(previews.map((p) => p.label)).toEqual(["Staging"]);
 }, 60_000);
 
 it("fails when --repo is not provided", async ({ expect, project, prismic }) => {

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -361,6 +361,20 @@ export async function deleteWriteToken(tokenValue: string, config: RepoConfig): 
 		throw new Error(`Failed to delete write token: ${res.status} ${await res.text()}`);
 }
 
+export async function setSimulatorUrl(simulatorUrl: string, config: RepoConfig): Promise<void> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("core/repository", `https://${config.repo}.${host}/`);
+	const res = await fetch(url, {
+		method: "PATCH",
+		headers: {
+			"Content-Type": "application/json",
+			Cookie: `prismic-auth=${config.token}`,
+		},
+		body: JSON.stringify({ simulator_url: simulatorUrl }),
+	});
+	if (!res.ok) throw new Error(`Failed to set simulator URL: ${res.status} ${await res.text()}`);
+}
+
 export async function getRepository(
 	config: RepoConfig,
 ): Promise<{ name: string; framework: string; simulatorUrl?: string }> {


### PR DESCRIPTION
Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

When initializing a Prismic project, set a default slice simulator URL and a "Development" preview entry pointing at localhost, but only if the repository doesn't already have them configured. This applies to the Next.js, Nuxt, and SvelteKit adapters.

Without this change, developers need to manually configure previews in the repository. We already generate the necessary preview files in the project.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automatic repository configuration (simulator URL and preview configs) during `init`, which introduces new network-side effects and could fail due to auth/permissions or overwrite expectations if the presence checks are wrong.
> 
> **Overview**
> Configures Prismic repository settings during `init` for `next`, `nuxt`, and `sveltekit`: on `onProjectInitialized`, it now **sets a default Slice Simulator URL** and **creates a "Development" preview** pointing at localhost *only if* the repository has no existing simulator URL or preview configs.
> 
> Normalizes `--repo`/legacy repository names to lowercase in `init`, and extends integration tests to assert simulator/preview configuration is created for new repos and preserved for repos with pre-existing preview/simulator settings (including adding a test-only `setSimulatorUrl` helper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9d84795fbd0140bf7f5c1ea493ac6f37f97335c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->