### PR TITLE
feat: add default UID field to new repeatable types

### DIFF
--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -86,7 +86,12 @@ export default createCommand(config, async ({ positionals, values }) => {
 				}
 			: { Main: {} };
 
-	if (!single) json.Main.uid = { type: "UID", config: { label: "UID" } };
+	if (!single) {
+		json.Main = {
+			uid: { type: "UID", config: { label: "UID" } },
+			...json.Main,
+		};
+	}
 
 	const model: CustomType = {
 		id,

--- a/src/commands/type-create.ts
+++ b/src/commands/type-create.ts
@@ -86,6 +86,8 @@ export default createCommand(config, async ({ positionals, values }) => {
 				}
 			: { Main: {} };
 
+	if (!single) json.Main.uid = { type: "UID", config: { label: "UID" } };
+
 	const model: CustomType = {
 		id,
 		label: name,

--- a/test/type-create.test.ts
+++ b/test/type-create.test.ts
@@ -18,6 +18,7 @@ it("creates a custom type", async ({ expect, prismic, project }) => {
 	const id = snakeCase(label!);
 	const created = await readLocalCustomType(project, id);
 	expect(created).toMatchObject({ label, format: "custom", repeatable: true });
+	expect(created.json.Main.uid).toEqual({ type: "UID", config: { label: "UID" } });
 });
 
 it("creates a page type with --format page", async ({ expect, prismic, project }) => {
@@ -32,6 +33,7 @@ it("creates a page type with --format page", async ({ expect, prismic, project }
 	expect(created).toMatchObject({ format: "page", repeatable: true });
 	expect(created.json).toHaveProperty("SEO & Metadata");
 	expect(created.json.Main).toHaveProperty("slices");
+	expect(created.json.Main.uid).toEqual({ type: "UID", config: { label: "UID" } });
 });
 
 it("creates a single custom type", async ({ expect, prismic, project }) => {
@@ -43,6 +45,7 @@ it("creates a single custom type", async ({ expect, prismic, project }) => {
 	const id = snakeCase(label!);
 	const created = await readLocalCustomType(project, id);
 	expect(created).toMatchObject({ format: "custom", repeatable: false });
+	expect(created.json.Main).not.toHaveProperty("uid");
 });
 
 it("creates a custom type with a custom id", async ({ expect, prismic, project }) => {


### PR DESCRIPTION
Resolves:

### Description

`prismic type create` now seeds repeatable types with a default UID field in the Main tab. Singletons are unchanged.

This behavior matches the Type Builder and Slice Machine.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

1. `prismic type create "Blog Post" --format page`
2. Inspect `customtypes/blog_post/index.json` and confirm `Main.uid` exists.
3. `prismic type create Settings --single` and confirm `Main.uid` is absent.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to `prismic type create` JSON scaffolding plus test updates; only affects newly created repeatable types and should not impact existing custom type models.
> 
> **Overview**
> `prismic type create` now auto-adds a `Main.uid` field (`type: "UID"`) when creating **repeatable** types (both `custom` and `page` formats); singleton (`--single`) types remain unchanged.
> 
> Tests are updated to assert the presence of the default UID field for repeatable types and its absence for singletons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9929bcb864762d01a355e520bb235bb03acb94e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->