### PR TITLE
Revert "feat: use --name as repository domain in repo create and init…

### DIFF
--- a/src/clients/wroom.ts
+++ b/src/clients/wroom.ts
@@ -318,7 +318,7 @@ export async function checkIsDomainAvailable(config: {
 
 export async function createRepository(config: {
 	domain: string;
-	name?: string;
+	name: string;
 	framework: string;
 	agent: string | undefined;
 	token: string | undefined;
@@ -328,15 +328,9 @@ export async function createRepository(config: {
 	const url = new URL("app/dashboard/repositories", getDashboardUrl(host));
 	url.searchParams.set("app", "cli");
 	if (agent) url.searchParams.set("agent", agent);
-
-	const body: Record<string, unknown> = { domain, framework, plan: "personal" };
-	if (name) {
-		body.name = name;
-	}
-
 	await request(url, {
 		method: "POST",
-		body,
+		body: { domain, name, framework, plan: "personal" },
 		credentials: { "prismic-auth": token },
 	});
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -20,7 +20,7 @@ import {
 	UnknownProjectRootError,
 } from "../project";
 import { checkIsTypeBuilderEnabled, TypeBuilderRequiredError } from "../project";
-import { createRepo, repositoryNameSchema } from "./repo-create";
+import { createRepo } from "./repo-create";
 
 const config = {
 	name: "prismic init",
@@ -34,7 +34,7 @@ const config = {
 		migrated.
 	`,
 	options: {
-		repo: { type: "string", short: "r", description: "Repository name (created if it doesn't exist)" },
+		repo: { type: "string", short: "r", description: "Repository name" },
 		"no-browser": {
 			type: "boolean",
 			description: "Skip opening the browser automatically during login",
@@ -96,39 +96,27 @@ export default createCommand(config, async ({ values }) => {
 		}
 	}
 
-	let repo = (explicitRepo ?? legacySliceMachineConfig?.repositoryName)?.toLowerCase();
-	if (!repo) {
-		throw new CommandError(
-			"Missing --repo. Provide the repository name to connect to (creating it if it doesn't exist yet).",
-		);
-	}
-
-	const repoExistsInAccount = profile.repositories.some((r) => r.domain === repo);
-	if (!repoExistsInAccount) {
-		const parsed = repositoryNameSchema.safeParse(repo);
-		if (!parsed.success) {
+	let repo = explicitRepo ?? legacySliceMachineConfig?.repositoryName;
+	if (repo) {
+		const hasRepoAccess = profile.repositories.some((repository) => repository.domain === repo);
+		if (!hasRepoAccess) {
 			throw new CommandError(
-				`Invalid repository name "${repo}": ${parsed.error.issues[0]?.message ?? "Invalid value"}`,
+				`Repository "${repo}" not found in your account. Check the name or request access to the repository.`,
 			);
 		}
-	} else {
+
 		const isTypeBuilderEnabled = await checkIsTypeBuilderEnabled(repo, { token, host });
 		if (!isTypeBuilderEnabled) {
 			throw new TypeBuilderRequiredError();
 		}
 	}
 
-	// getAdapter checks for a supported framework; calling it before createRepo
 	const adapter = await getAdapter();
 
-	if (!repoExistsInAccount) {
-		console.info(
-			`Repository "${repo}" was not found in your account. Creating it...`,
-		);
-		repo = await createRepo({ name: repo, token, host });
+	if (!repo) {
+		repo = await createRepo({ token, host });
 		console.info(`Created repository: ${repo}`);
 	}
-	
 
 	// Create prismic.config.json
 	try {

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -1,5 +1,3 @@
-import * as z from "zod/mini";
-
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { completeOnboardingStepsSilently } from "../clients/repository";
@@ -8,62 +6,37 @@ import { detectAgent } from "../lib/ai";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 
-export const repositoryNameSchema = z
-	.string()
-	.check(
-		z.minLength(4, "Must be at least 4 characters"),
-		z.maxLength(63, "Must be at most 63 characters"),
-		z.regex(
-			/^[a-zA-Z0-9][-a-zA-Z0-9]{2,}[a-zA-Z0-9]$/,
-			"Must contain only letters, numbers, and hyphens, and start and end with a letter or number",
-		),
-	);
+const MAX_DOMAIN_TRIES = 5;
 
 const config = {
 	name: "prismic repo create",
 	description: "Create a new Prismic repository.",
 	options: {
-		name: {
-			type: "string",
-			short: "n",
-			description: "Repository name (used as the domain)",
-			required: true,
-			schema: repositoryNameSchema,
-		},
-		"display-name": {
-			type: "string",
-			short: "d",
-			description: "Display name for the repository",
-		},
+		name: { type: "string", short: "n", description: "Display name for the repository" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { name, "display-name": displayName } = values;
+	const { name } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const domain = await createRepo({ name, displayName, token, host });
+	const domain = await createRepo({ name, token, host });
 
 	console.info(`Repository created: ${domain}`);
 	console.info(`URL: https://${domain}.${host}/`);
 });
 
 export async function createRepo(config: {
-	name: string;
-	displayName?: string;
+	name?: string;
 	token: string | undefined;
 	host: string;
 }): Promise<string> {
-	const { name, displayName, token, host } = config;
+	const { name, token, host } = config;
 
-	const domain = name.toLowerCase();
-
-	const available = await checkIsDomainAvailable({ domain, token, host });
-	if (!available) {
-		throw new CommandError(
-			`Repository name "${domain}" is already taken. Choose a different name or request access to it.`,
-		);
+	const domain = await findAvailableDomain({ token, host });
+	if (!domain) {
+		throw new CommandError("Failed to create a repository. Please try again.");
 	}
 
 	const adapter = await getAdapter().catch(() => undefined);
@@ -71,14 +44,7 @@ export async function createRepo(config: {
 	const agent = await detectAgent();
 
 	try {
-		await createRepository({
-			domain,
-			name: displayName,
-			framework,
-			agent,
-			token,
-			host,
-		});
+		await createRepository({ domain, name: name ?? domain, framework, agent, token, host });
 	} catch (error) {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
@@ -94,5 +60,22 @@ export async function createRepo(config: {
 		stepIds: ["createPrismicProject"],
 	});
 
+	return domain;
+}
+
+async function findAvailableDomain(config: {
+	token: string | undefined;
+	host: string;
+}): Promise<string | undefined> {
+	const { token, host } = config;
+	let domain;
+	for (let i = 0; i < MAX_DOMAIN_TRIES; i++) {
+		const candidate = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+		const available = await checkIsDomainAvailable({ domain: candidate, token, host });
+		if (available) {
+			domain = candidate;
+			break;
+		}
+	}
 	return domain;
 }

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -1,7 +1,5 @@
 import type { ParseArgsOptionDescriptor } from "node:util";
 
-import type * as z from "zod/mini";
-
 import { parseArgs } from "node:util";
 
 import { dedent, formatTable } from "./string";
@@ -11,14 +9,7 @@ export type CommandConfig = {
 	description: string;
 	sections?: Record<string, string>;
 	positionals?: Record<string, { description: string; required?: boolean }>;
-	options?: Record<
-		string,
-		ParseArgsOptionDescriptor & {
-			description: string;
-			required?: boolean;
-			schema?: z.ZodMiniType<unknown, unknown>;
-		}
-	>;
+	options?: Record<string, ParseArgsOptionDescriptor & { description: string; required?: boolean }>;
 };
 
 type CommandHandlerArgs<T extends CommandConfig> = ParseArgsReturnType<T> & {
@@ -72,15 +63,6 @@ export function createCommand<T extends CommandConfig>(
 		for (const [name, config] of Object.entries(options)) {
 			if (config.required && !(name in result.values)) {
 				throw new CommandError(`Missing required option: --${name}`);
-			}
-			const optionValues = result.values as Record<string, unknown>;
-			if (config.schema && name in optionValues) {
-				const parsed = config.schema.safeParse(optionValues[name]);
-				if (!parsed.success) {
-					const message = parsed.error.issues[0]?.message ?? "Invalid value";
-					throw new CommandError(`Invalid ${name}: ${message}`);
-				}
-				optionValues[name] = parsed.data;
 			}
 		}
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,9 +1,6 @@
 import { access, readFile, rm, writeFile } from "node:fs/promises";
 
-import { onTestFinished } from "vitest";
-
 import { captureOutput, it } from "./it";
-import { cleanupRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("init", ["--help"]);
@@ -17,35 +14,21 @@ it("fails if prismic.config.json already exists", async ({ expect, prismic }) =>
 	expect(stderr).toContain("already initialized");
 });
 
-it("creates a repo when --repo doesn't exist yet", async ({
+it("creates a repo if --repo is not provided and no legacy config exists", async ({
 	expect,
 	project,
 	prismic,
-	token,
-	host,
-	password,
 }) => {
 	await rm(new URL("prismic.config.json", project));
-	const rawName = `CLI-Test-${crypto.randomUUID().slice(0, 8)}`;
-	const name = rawName.toLowerCase();
-	onTestFinished(() => cleanupRepository(name, { token, password, host }));
-
-	const { exitCode, stdout } = await prismic("init", ["--repo", rawName]);
+	const { exitCode, stdout } = await prismic("init");
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Created repository: ${name}`);
-	expect(stdout).toContain(`Initialized Prismic for repository "${name}"`);
+	expect(stdout).toContain("Created repository:");
+	expect(stdout).toContain("Initialized Prismic for repository");
 
 	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
 	const config = JSON.parse(configRaw);
-	expect(config.repositoryName).toBe(name);
+	expect(config.repositoryName).toMatch(/^[a-f0-9]{8}$/);
 }, 60_000);
-
-it("fails when --repo is not provided", async ({ expect, project, prismic }) => {
-	await rm(new URL("prismic.config.json", project));
-	const { exitCode, stderr } = await prismic("init");
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain("Missing --repo");
-});
 
 it("initializes a project with --repo when logged in", async ({
 	expect,
@@ -76,14 +59,11 @@ it("triggers login flow when not logged in", async ({ expect, project, prismic, 
 	proc.kill();
 });
 
-it("fails if --repo is taken by another account", async ({ expect, project, prismic }) => {
+it("fails if repo is not in the user's account", async ({ expect, project, prismic }) => {
 	await rm(new URL("prismic.config.json", project));
-	// "prismic" is reserved/taken and will fail availability check.
-	const { exitCode, stderr } = await prismic("init", ["--repo", "prismic"]);
+	const { exitCode, stderr } = await prismic("init", ["--repo", "nonexistent-repo-xyz-12345"]);
 	expect(exitCode).toBe(1);
-	expect(stderr).toContain(
-		'Repository name "prismic" is already taken. Choose a different name or request access to it.',
-	);
+	expect(stderr).toContain("not found in your account");
 });
 
 it("migrates slicemachine.config.json", async ({ expect, project, prismic, repo }) => {

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -49,14 +49,6 @@ export async function deleteRepository(
 	}
 }
 
-export async function cleanupRepository(
-	domain: string | undefined,
-	config: AuthConfig & { password: string },
-): Promise<void> {
-	if (domain === undefined) return;
-	await deleteRepository(domain, config);
-}
-
 export async function getCustomTypes(config: RepoConfig): Promise<CustomType[]> {
 	const host = config.host ?? DEFAULT_HOST;
 	const url = new URL("customtypes", `https://customtypes.${host}/`);

--- a/test/repo-create.test.ts
+++ b/test/repo-create.test.ts
@@ -1,7 +1,7 @@
 import { onTestFinished } from "vitest";
 
 import { it } from "./it";
-import { cleanupRepository, getRepository } from "./prismic";
+import { deleteRepository, getRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("repo", ["create", "--help"]);
@@ -9,87 +9,31 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic repo create [options]");
 });
 
-it("requires --name", async ({ expect, prismic }) => {
-	const { stderr, exitCode } = await prismic("repo", ["create"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain("Missing required option: --name");
+it("creates a repository", async ({ expect, prismic, token, host, password }) => {
+	const { stdout, exitCode } = await prismic("repo", ["create"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("Repository created:");
+
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	onTestFinished(() => deleteRepository(domain!, { token, password, host }));
+
+	const repository = await getRepository({ repo: domain!, token, host });
+	expect(repository).toBeDefined();
 });
 
-it("creates a repository using --name as the domain", async ({
-	expect,
-	prismic,
-	token,
-	host,
-	password,
-}) => {
-	const name = `cli-test-${crypto.randomUUID().slice(0, 8)}`;
-	onTestFinished(() => cleanupRepository(name, { token, password, host }));
-
+it("creates a repository with a name", async ({ expect, prismic, token, host, password }) => {
+	const name = `Test ${crypto.randomUUID().slice(0, 8)}`;
 	const { stdout, exitCode } = await prismic("repo", ["create", "--name", name]);
 	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Repository created: ${name}`);
+	expect(stdout).toContain("Repository created:");
 
-	const repository = await getRepository({ repo: name, token, host });
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	onTestFinished(() => deleteRepository(domain!, { token, password, host }));
+
+	const repository = await getRepository({ repo: domain!, token, host });
 	expect(repository.name).toBe(name);
-});
-
-it("lowercases --name before submitting", async ({
-	expect,
-	prismic,
-	token,
-	host,
-	password,
-}) => {
-	const suffix = crypto.randomUUID().slice(0, 8);
-	const name = `CLI-Test-${suffix}`;
-	const expectedDomain = name.toLowerCase();
-	onTestFinished(() => cleanupRepository(expectedDomain, { token, password, host }));
-
-	const { stdout, exitCode } = await prismic("repo", ["create", "--name", name]);
-	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Repository created: ${expectedDomain}`);
-
-	const repository = await getRepository({ repo: expectedDomain, token, host });
-	expect(repository.name).toBe(expectedDomain);
-});
-
-it("rejects --name with disallowed characters", async ({ expect, prismic }) => {
-	const { stderr, exitCode } = await prismic("repo", ["create", "--name", "My Test Repo"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain("Invalid name:");
-});
-
-it("uses --display-name as the repository label", async ({
-	expect,
-	prismic,
-	token,
-	host,
-	password,
-}) => {
-	const name = `cli-test-${crypto.randomUUID().slice(0, 8)}`;
-	const displayName = "My Display Name";
-	onTestFinished(() => cleanupRepository(name, { token, password, host }));
-
-	const { stdout, exitCode } = await prismic("repo", [
-		"create",
-		"--name",
-		name,
-		"--display-name",
-		displayName,
-	]);
-	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Repository created: ${name}`);
-
-	const repository = await getRepository({ repo: name, token, host });
-	expect(repository.name).toBe(displayName);
-});
-
-it("fails with guidance when --name is invalid", async ({ expect, prismic }) => {
-	const tooShort = await prismic("repo", ["create", "--name", "!!"]);
-	expect(tooShort.exitCode).toBe(1);
-	expect(tooShort.stderr).toContain("Invalid name:");
-
-	const tooLong = await prismic("repo", ["create", "--name", `a${"x".repeat(62)}z`]);
-	expect(tooLong.exitCode).toBe(1);
-	expect(tooLong.stderr).toContain("Invalid name:");
 });


### PR DESCRIPTION
This reverts commit 1b7e4bf5e93369a34787951e424436446c0b371d.

The team agreed on keeping the random domain generation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes repository provisioning behavior in `init`/`repo create` (auto-creating random domains and removing CLI-side name validation), which could affect user workflows and error handling but doesn’t touch security-sensitive logic.
> 
> **Overview**
> Restores **random repository domain generation** for `prismic repo create` and `prismic init`, instead of using a user-supplied `--name/--repo` as the domain.
> 
> `init` now **auto-creates a repository when `--repo` isn’t provided**, and when `--repo` is provided it must already be accessible in the user’s account (no implicit creation). `repo create`’s `--name` becomes an optional **display name only**, with the domain picked via repeated availability checks.
> 
> Removes the zod-based per-option schema validation from the command framework, updates `createRepository` to require a `name`, and adjusts tests to reflect the new CLI behavior and cleanup flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c51b96aeac6895da2bc712be65c459ea1e4593d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->