### PR TITLE
feat: support PRISMIC_TOKEN env var to override stored token

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -23,6 +23,7 @@ const CredentialsSchema = z.looseObject({
 type Credentials = z.infer<typeof CredentialsSchema>;
 
 export async function getToken(): Promise<string | undefined> {
+	if (env.PRISMIC_TOKEN) return env.PRISMIC_TOKEN;
 	const credentials = await readCredentials();
 	return credentials?.token;
 }
@@ -34,6 +35,7 @@ export async function getHost(): Promise<string> {
 }
 
 export async function refreshToken(): Promise<string | undefined> {
+	if (env.PRISMIC_TOKEN) return env.PRISMIC_TOKEN;
 	const token = await getToken();
 	if (!token) return;
 	const host = await getHost();

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -35,7 +35,7 @@ export async function getHost(): Promise<string> {
 }
 
 export async function refreshToken(): Promise<string | undefined> {
-	if (env.PRISMIC_TOKEN) return env.PRISMIC_TOKEN;
+	if (env.PRISMIC_TOKEN) return;
 	const token = await getToken();
 	if (!token) return;
 	const host = await getHost();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,7 +4,7 @@ import { getAdapter } from "../adapters";
 import { createLoginSession, getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { getProfile } from "../clients/user";
-import { DEFAULT_PRISMIC_HOST } from "../env";
+import { DEFAULT_PRISMIC_HOST, env } from "../env";
 import { openBrowser } from "../lib/browser";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
@@ -76,6 +76,11 @@ export default createCommand(config, async ({ values }) => {
 		profile = await getProfile({ token, host });
 	} catch (error) {
 		if (error instanceof UnauthorizedRequestError || error instanceof ForbiddenRequestError) {
+			if (env.PRISMIC_TOKEN) {
+				throw new CommandError(
+					"PRISMIC_TOKEN is invalid or expired. Unset it to log in with a browser, or replace it with a valid token.",
+				);
+			}
 			console.info("Not logged in. Starting login...");
 			const { email } = await createLoginSession({
 				onReady: (url) => {

--- a/src/env.ts
+++ b/src/env.ts
@@ -15,6 +15,7 @@ const Env = z.object({
 	PRISMIC_SENTRY_ENVIRONMENT: z.optional(z.string()),
 	PRISMIC_SENTRY_ENABLED: z.optional(z.stringbool()),
 	PRISMIC_HOST: z.optional(z.string()),
+	PRISMIC_TOKEN: z.optional(z.string()),
 	PRISMIC_DOCS_HOST: z.optional(z.string()),
 	PRISMIC_CONFIG_DIR: z.optional(z.string()),
 	PRISMIC_TYPE_BUILDER_ENABLED: z.optional(z.stringbool()),

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -18,3 +18,13 @@ it("fails when not logged in", async ({ expect, prismic, logout }) => {
 	const { exitCode } = await prismic("whoami");
 	expect(exitCode).not.toBe(0);
 });
+
+it("uses PRISMIC_TOKEN env var when set", async ({ expect, prismic, login, logout, token }) => {
+	const { email } = await login();
+	await logout();
+	const { stdout, exitCode } = await prismic("whoami", [], {
+		nodeOptions: { env: { PRISMIC_TOKEN: token } },
+	});
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(email);
+});


### PR DESCRIPTION
Resolves:

### Description

Adds a `PRISMIC_TOKEN` environment variable that takes priority over the token stored in the credentials file. Useful for CI, scripted use, and ephemeral environments where persisting a token to disk is undesirable.

The env value is kept in memory only — `refreshToken()` early-returns when `PRISMIC_TOKEN` is set so the value is never written to the credentials file.

Mirrors the existing `PRISMIC_HOST` pattern in `src/auth.ts`.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA

1. `node --run build`
2. With no credentials file, run `PRISMIC_TOKEN=<valid-token> ./dist/index.mjs whoami` — should print the email associated with that token.
3. With `PRISMIC_TOKEN` set, run any authenticated command and confirm the credentials file's `token` field is unchanged afterward.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/prismicio/codesmith/cli/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783031368&installation_id=125473232&pr_number=191&repository=prismicio%2Fcli&return_to=https%3A%2F%2Fgithub.com%2Fprismicio%2Fcli%2Fpull%2F191&signature=fabff33d79b3ea1fa7412649bed9f60eeed8e6073b3a39377994e7511ec76614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all authenticated commands resolve tokens and refresh behavior; mistakes could affect CI/scripts or leave users stuck on bad env tokens, but scope is small and mirrors PRISMIC_HOST.
> 
> **Overview**
> Adds optional **`PRISMIC_TOKEN`** env support so authentication can use an in-memory token instead of the on-disk credentials file—aligned with the existing **`PRISMIC_HOST`** override pattern.
> 
> **`getToken()`** returns the env value when set; **`refreshToken()`** no-ops in that case so refreshed tokens are never persisted to the credentials file. **`prismic init`** surfaces a clear error when **`PRISMIC_TOKEN`** is set but invalid, instead of falling through to browser login. Coverage includes a **`whoami`** test that runs with **`PRISMIC_TOKEN`** after logout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8920ef13d4bedfd0dd56bdadc34aadf0890d9ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->