### PR TITLE
feat: allow `prismic init` migration on all Slice Machine repositories

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -4,9 +4,7 @@ import { readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as z from "zod/mini";
 
-import { getVariantData } from "./clients/amplitude";
 import { getRepository } from "./clients/repository";
-import { getProfile } from "./clients/user";
 import { env } from "./env";
 import { exists, findUpward } from "./lib/file";
 import { stringify } from "./lib/json";
@@ -253,16 +251,8 @@ export async function checkIsTypeBuilderEnabled(
 	if (env.PRISMIC_TYPE_BUILDER_ENABLED !== undefined) return env.PRISMIC_TYPE_BUILDER_ENABLED;
 
 	const { token, host } = config;
-	const profile = await getProfile({ token, host });
-	const [variantData, repository] = await Promise.all([
-		getVariantData(profile.shortId, {
-			groups: { Repository: [repo] },
-			host,
-		}),
-		getRepository({ repo, token, host }),
-	]);
-	const flagEnabled = variantData["dev-tools-types-builder-cloud"]?.value === "on";
-	return flagEnabled && repository.quotas?.sliceMachineEnabled === true;
+	const repository = await getRepository({ repo, token, host });
+	return repository.quotas?.sliceMachineEnabled === true;
 }
 
 export class TypeBuilderRequiredError extends Error {


### PR DESCRIPTION
Resolves: https://app.notion.com/p/prismic/Good-bye-Slice-Machine-3343bee0866980a2b112c9e05c606145?source=copy_link

### Description

Allow migration from Slice Machine to Type Builder/CLI via `prismic init`. This was allowed before, but only to repositories that had the feature flag enabled. Now, all repos can perform the migration.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic init` in a Slice Machine project whose repository has the Slice Machine quota enabled but is not in the `dev-tools-types-builder-cloud` flag rollout. It should now proceed with the migration instead of failing with the "requires the Type Builder" error.

[^1]:
    Please use these labels when submitting a review:
    :question: #ask:&ensp;Ask a question.
    :bulb: #idea:&ensp;Suggest an idea.
    :warning: #issue:&ensp;Strongly suggest a change.
    :tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows the gate to repository quota only and removes two API calls; behavior for non-quota repos is unchanged and there is no auth or data-model change.
> 
> **Overview**
> **Type Builder enablement** no longer depends on the Amplitude `dev-tools-types-builder-cloud` flag or a user profile lookup. `checkIsTypeBuilderEnabled` now only honors `PRISMIC_TYPE_BUILDER_ENABLED` when set, otherwise it fetches the repository and returns whether `quotas.sliceMachineEnabled` is true.
> 
> For **`prismic init`** with `--repo` (or a legacy Slice Machine config), repos with the Slice Machine quota can migrate to Type Builder/CLI even when they were outside the old flag rollout; repos without that quota still hit `TypeBuilderRequiredError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be2582ab3af4a30c5d7e09fa9aa116db7b8257e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->