### PR TITLE
fix: resolve escaped </script> in generated framework files

### DIFF
--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,6 +1,19 @@
 import baseDedent from "dedent";
 
-export const dedent = baseDedent.withOptions({ alignValues: true });
+const baseDedentWithOptions = baseDedent.withOptions({ alignValues: true });
+
+export function dedent(strings: TemplateStringsArray | string, ...values: unknown[]): string {
+	if (typeof strings === "string") {
+		return baseDedentWithOptions(strings);
+	}
+
+	// dedent reads `strings.raw` by default, which keeps escapes the bundler adds
+	// to string literals (e.g. `</script>` becomes `<\/script>`). Point `raw` at
+	// the regular string segments instead, where escapes are already resolved, so
+	// they don't leak into generated files.
+	const resolved = Array.from(strings);
+	return baseDedentWithOptions(Object.assign(resolved, { raw: resolved }), ...values);
+}
 
 export function formatTable(
 	rows: string[][],

--- a/test/gen-setup.test.ts
+++ b/test/gen-setup.test.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 
 import { it } from "./it";
 
@@ -33,6 +33,32 @@ it("skips existing files", { timeout: 30_000 }, async ({ expect, project, prismi
 	expect(exitCode).toBe(0);
 
 	await expect(project).toHaveFile("prismicio.js", { contains: "// custom client file" });
+});
+
+it("generates valid script tags for SvelteKit", { timeout: 30_000 }, async ({
+	expect,
+	project,
+	prismic,
+}) => {
+	// Reconfigure the fixture as a SvelteKit project so a file with a <script>
+	// block is generated (the simulator page).
+	await writeFile(
+		new URL("package.json", project),
+		JSON.stringify({ dependencies: { "@sveltejs/kit": "latest", svelte: "latest" } }),
+	);
+	await mkdir(new URL("node_modules/svelte/", project), { recursive: true });
+	await writeFile(
+		new URL("node_modules/svelte/package.json", project),
+		JSON.stringify({ version: "5.0.0" }),
+	);
+
+	const { exitCode } = await prismic("gen", ["setup", "--no-install"]);
+	expect(exitCode).toBe(0);
+
+	// The closing tag must be "</script>", not the bundler-escaped "<\/script>".
+	await expect(project).toHaveFile("src/routes/slice-simulator/+page.svelte", {
+		contains: "</script>",
+	});
 });
 
 it("skips installation with --no-install", async ({ expect, project, prismic }) => {


### PR DESCRIPTION
Resolves: #193

### Description

`prismic gen setup` and `prismic init` generated Nuxt and SvelteKit files whose closing `<script>` tag was written as `<\/script>` (with a stray backslash), producing invalid SFC syntax.

The bundler escapes `</script>` to `<\/script>` in string literals, and our `dedent` wrapper reads the raw template strings, so the backslash leaked into the output. This points `dedent` at the resolved string segments instead, where the escape is already gone.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA

1. In a Nuxt or SvelteKit project, delete the slice simulator file.
2. Run `prismic gen setup`.
3. Open the regenerated simulator file and confirm the closing tag is `</script>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to the shared `dedent` helper plus a new test; behavior for non-`</script>` templates should match prior dedenting while fixing escape leakage.
> 
> **Overview**
> Fixes invalid closing tags like `<\/script>` in files emitted by **`prismic gen setup`** and **`prismic init`** (Nuxt/SvelteKit simulator pages and similar).
> 
> **`dedent`** is no longer a thin re-export of `dedent.withOptions`. It now builds template output from **resolved** string segments and sets `raw` to those same segments so bundler escapes on literals (e.g. `</script>` → `<\/script>`) are not written into generated source.
> 
> Adds a **`gen setup`** integration test that treats the fixture as SvelteKit and asserts `src/routes/slice-simulator/+page.svelte` contains a literal `</script>` closing tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f16cfe7611b53dea4bd57aab51c9d7e01f05345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->