### PR TITLE
feat: direct users to `prismic pull` after init

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,7 +27,7 @@ const config = {
 	description: `
 		Initialize a new Prismic project by creating a repository and
 		prismic.config.json file. Detects the project framework, installs
-		dependencies, and syncs models from Prismic.
+		dependencies, and pulls models from Prismic.
 
 		Use --repo to connect to an existing repository instead. If a
 		slicemachine.config.json exists, its repository and settings will be
@@ -200,5 +200,7 @@ export default createCommand(config, async ({ values }) => {
 
 	console.info(`\nInitialized Prismic for repository "${repo}".`);
 	console.info("Run `prismic type create <name>` to create a content type.");
-	console.info("Run `prismic sync` to sync models from Prismic.");
+	if (explicitRepo) {
+		console.info("Run `prismic pull` to pull models from Prismic.");
+	}
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -200,7 +200,5 @@ export default createCommand(config, async ({ values }) => {
 
 	console.info(`\nInitialized Prismic for repository "${repo}".`);
 	console.info("Run `prismic type create <name>` to create a content type.");
-	if (explicitRepo) {
-		console.info("Run `prismic pull` to pull models from Prismic.");
-	}
+	console.info("Run `prismic pull` to pull models from Prismic.");
 });


### PR DESCRIPTION
Resolves:

### Description

The `prismic sync` command was always just a `prismic pull` with a `--watch` flag. That doesn't fit the Type Builder workflow, so we now direct everyone to `prismic pull` after making changes (in line with prismicio/editor#2348).

- Post-init guidance now points to `prismic pull` instead of `prismic sync`.
- The `init` help text now says it "pulls models from Prismic".

The `sync` command itself is unchanged and stays available.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA

- Run `prismic init` and confirm the final output suggests "Run `prismic pull` to pull models from Prismic."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and console messaging only; no logic or command behavior changes.
> 
> **Overview**
> Aligns **Type Builder** onboarding with the editor workflow by replacing references to **`prismic sync`** with **`prismic pull`** in the `init` command.
> 
> The command description now says init **pulls** models from Prismic (instead of "syncs"). After a successful init, the suggested next step is **`Run \`prismic pull\` to pull models from Prismic.`** instead of the old `sync` line. No behavior of init itself or the `sync` command is changed in this diff—only user-facing copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c50648d313ee73b01873d70eaebb0a068afa91f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->