### PR TITLE
fix: create new slices in the first configured library

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -106,7 +106,7 @@ export abstract class Adapter {
 	}
 
 	async createSlice(model: SharedSlice, library?: URL): Promise<void> {
-		library ??= await this.getDefaultSliceLibrary();
+		library ??= (await this.getSliceLibraries())[0];
 		const sliceDirectoryName = pascalCase(model.name);
 		const sliceDirectory = new URL(sliceDirectoryName, appendTrailingSlash(library));
 		const modelPath = new URL("model.json", appendTrailingSlash(sliceDirectory));

--- a/test/it.ts
+++ b/test/it.ts
@@ -197,8 +197,21 @@ export async function readLocalCustomTypes(project: URL): Promise<CustomType[]> 
 	return result;
 }
 
+export async function getSliceLibraryPaths(project: URL): Promise<string[]> {
+	const configPath = new URL("prismic.config.json", project);
+	try {
+		const config: { libraries?: string[] } = JSON.parse(await readFile(configPath, "utf8"));
+		const libraries = config.libraries;
+		if (libraries && libraries.length >= 1) {
+			return libraries.map((library) => library.replace(/\\/g, "").replace(/^\.\//, ""));
+		}
+	} catch {}
+	return ["slices"];
+}
+
 export async function writeLocalSlice(project: URL, model: SharedSlice): Promise<void> {
-	const path = new URL(`slices/${pascalCase(model.name)}/model.json`, project);
+	const [library] = await getSliceLibraryPaths(project);
+	const path = new URL(`${library}/${pascalCase(model.name)}/model.json`, project);
 	await mkdir(new URL(".", path), { recursive: true });
 	await writeFile(path, JSON.stringify(model, null, 2));
 }
@@ -209,13 +222,18 @@ export async function readLocalSlice(project: URL, id: string): Promise<SharedSl
 }
 
 export async function readLocalSlices(project: URL): Promise<SharedSlice[]> {
-	const dir = new URL("slices/", project);
-	const entries = await readdir(dir).catch(() => [] as string[]);
+	const libraries = await getSliceLibraryPaths(project);
 	const result: SharedSlice[] = [];
-	for (const name of entries) {
-		try {
-			result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, dir), "utf8")));
-		} catch {}
+
+	for (const library of libraries) {
+		const dir = new URL(`${library}/`, project);
+		const entries = await readdir(dir).catch(() => [] as string[]);
+		for (const name of entries) {
+			try {
+				result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, dir), "utf8")));
+			} catch {}
+		}
 	}
+
 	return result;
 }

--- a/test/it.ts
+++ b/test/it.ts
@@ -197,21 +197,15 @@ export async function readLocalCustomTypes(project: URL): Promise<CustomType[]> 
 	return result;
 }
 
-export async function getSliceLibraryPaths(project: URL): Promise<string[]> {
-	const configPath = new URL("prismic.config.json", project);
-	try {
-		const config: { libraries?: string[] } = JSON.parse(await readFile(configPath, "utf8"));
-		const libraries = config.libraries;
-		if (libraries && libraries.length >= 1) {
-			return libraries.map((library) => library.replace(/\\/g, "").replace(/^\.\//, ""));
-		}
-	} catch {}
-	return ["slices"];
+export async function getSliceLibraries(project: URL): Promise<URL[]> {
+	const { libraries = [] } = await getConfig(project);
+	if (libraries.length < 1) return [new URL("slices/", project)];
+	return libraries.map((library) => new URL(library.replace(/^\//, "") + "/", project));
 }
 
 export async function writeLocalSlice(project: URL, model: SharedSlice): Promise<void> {
-	const [library] = await getSliceLibraryPaths(project);
-	const path = new URL(`${library}/${pascalCase(model.name)}/model.json`, project);
+	const [library] = await getSliceLibraries(project);
+	const path = new URL(`${pascalCase(model.name)}/model.json`, library);
 	await mkdir(new URL(".", path), { recursive: true });
 	await writeFile(path, JSON.stringify(model, null, 2));
 }
@@ -222,18 +216,21 @@ export async function readLocalSlice(project: URL, id: string): Promise<SharedSl
 }
 
 export async function readLocalSlices(project: URL): Promise<SharedSlice[]> {
-	const libraries = await getSliceLibraryPaths(project);
+	const libraries = await getSliceLibraries(project);
 	const result: SharedSlice[] = [];
-
 	for (const library of libraries) {
-		const dir = new URL(`${library}/`, project);
-		const entries = await readdir(dir).catch(() => [] as string[]);
+		const entries = await readdir(library).catch(() => []);
 		for (const name of entries) {
 			try {
-				result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, dir), "utf8")));
+				result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, library), "utf8")));
 			} catch {}
 		}
 	}
-
 	return result;
+}
+
+async function getConfig(project: URL): Promise<{ libraries?: string[] }> {
+	const path = new URL("prismic.config.json", project);
+	const raw = await readFile(path, "utf8");
+	return JSON.parse(raw);
 }

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -1,6 +1,7 @@
 import { writeFile, mkdir } from "node:fs/promises";
 import { sep } from "node:path";
 import { fileURLToPath } from "node:url";
+import { pascalCase } from "change-case";
 import { x } from "tinyexec";
 
 import { buildCustomType, buildSlice, it } from "./it";
@@ -99,6 +100,35 @@ it.sequential("adds new slice to existing library on re-pull", async ({
 	expect(second.exitCode).toBe(0);
 	await expect(project).toContainSlice(sliceA);
 	await expect(project).toContainSlice(sliceB);
+});
+
+it.sequential("pulls new slices into the first configured library", async ({
+	expect,
+	project,
+	prismic,
+	repo,
+	token,
+	host,
+}) => {
+	const slice = buildSlice();
+
+	await writeFile(
+		new URL("prismic.config.json", project),
+		JSON.stringify({
+			repositoryName: repo,
+			libraries: ["./slices/blog", "./slices/features"],
+		}),
+	);
+
+	await insertSlice(slice, { repo, token, host });
+
+	const { exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode).toBe(0);
+
+	const sliceDirectoryName = pascalCase(slice.name);
+	await expect(project).toContainSlice(slice);
+	await expect(project).toHaveFile(`slices/blog/${sliceDirectoryName}/model.json`);
+	await expect(project).not.toHaveFile(`slices/${sliceDirectoryName}/model.json`);
 });
 
 it.sequential("removes deleted slice and updates index on re-pull", async ({

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,10 +1,11 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { pascalCase } from "change-case";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { glob } from "tinyglobby";
 import { expect } from "vitest";
 
-import { getSliceLibraryPaths } from "./it";
+import { getSliceLibraries } from "./it";
 
 declare module "vitest" {
 	// oxlint-disable-next-line no-explicit-any
@@ -41,51 +42,46 @@ expect.extend({
 
 	async toContainSlice(project, slice) {
 		const problems: string[] = [];
-		const libraries = await getSliceLibraryPaths(project);
-		const sliceDirectoryName = pascalCase(slice.name);
-		let sliceLibrary: string | undefined;
 
+		const libraries = await getSliceLibraries(project);
+		let sliceDirectory;
 		for (const library of libraries) {
-			const sliceDirectory = new URL(`${library}/${sliceDirectoryName}/`, project);
+			const sliceModelPaths = Array.from(
+				await glob("*/model.json", { absolute: true, cwd: library }),
+				(path) => pathToFileURL(path),
+			);
+			for (const sliceModelPath of sliceModelPaths) {
+				const model: SharedSlice = JSON.parse(await readFile(sliceModelPath, "utf8"));
+				if (model.id === slice.id) {
+					sliceDirectory = new URL(".", sliceModelPath);
+				}
+			}
+		}
+
+		if (!sliceDirectory) {
+			problems.push(`slice model file does not exist`);
+		} else {
+			const sliceIndexPath = new URL("../index.js", sliceDirectory);
 			try {
-				await access(sliceDirectory);
-				sliceLibrary = library;
-				break;
-			} catch {}
-		}
-
-		const library = sliceLibrary ?? libraries[0]!;
-
-		const sliceIndexPath = new URL(`${library}/index.js`, project);
-		try {
-			const sliceIndex = await readFile(sliceIndexPath, "utf8");
-			if (!new RegExp(`\\b${slice.id}: `).test(sliceIndex)) {
-				problems.push(
-					`slice "${slice.id}" not found in slice library index (${sliceIndexPath.href})`,
-				);
+				const sliceIndex = await readFile(sliceIndexPath, "utf8");
+				if (!new RegExp(`\\b${slice.id}: `).test(sliceIndex)) {
+					problems.push(
+						`slice "${slice.id}" not found in slice library index (${sliceIndexPath.href})`,
+					);
+				}
+			} catch {
+				problems.push(`slice library index (${sliceIndexPath.href}) does not exist`);
 			}
-		} catch {
-			problems.push(`slice library index (${sliceIndexPath.href}) does not exist`);
-		}
 
-		const modelPath = new URL(`${library}/${sliceDirectoryName}/model.json`, project);
-		try {
-			const model: SharedSlice = JSON.parse(await readFile(modelPath, "utf8"));
-			if (model.id !== slice.id) {
-				problems.push(`slice model file (${modelPath.href}) has wrong ID`);
+			const componentPath = new URL("index.jsx", sliceDirectory);
+			try {
+				const componentFile = await readFile(componentPath, "utf-8");
+				if (!componentFile.includes(slice.name)) {
+					problems.push(`slice component file (${componentPath.href}) does not contain slice name`);
+				}
+			} catch {
+				problems.push(`slice component file (${componentPath.href}) does not exist`);
 			}
-		} catch {
-			problems.push(`slice model file (${modelPath.href}) does not exist`);
-		}
-
-		const componentPath = new URL(`${library}/${sliceDirectoryName}/index.jsx`, project);
-		try {
-			const componentFile = await readFile(componentPath, "utf-8");
-			if (!componentFile.includes(slice.name)) {
-				problems.push(`slice component file (${componentPath.href}) does not contain slice name`);
-			}
-		} catch {
-			problems.push(`slice component file (${componentPath.href}) does not exist`);
 		}
 
 		return {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,10 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { readFile } from "node:fs/promises";
+import { pascalCase } from "change-case";
+import { access, readFile } from "node:fs/promises";
 import { expect } from "vitest";
+
+import { getSliceLibraryPaths } from "./it";
 
 declare module "vitest" {
 	// oxlint-disable-next-line no-explicit-any
@@ -38,8 +41,22 @@ expect.extend({
 
 	async toContainSlice(project, slice) {
 		const problems: string[] = [];
+		const libraries = await getSliceLibraryPaths(project);
+		const sliceDirectoryName = pascalCase(slice.name);
+		let sliceLibrary: string | undefined;
 
-		const sliceIndexPath = new URL("slices/index.js", project);
+		for (const library of libraries) {
+			const sliceDirectory = new URL(`${library}/${sliceDirectoryName}/`, project);
+			try {
+				await access(sliceDirectory);
+				sliceLibrary = library;
+				break;
+			} catch {}
+		}
+
+		const library = sliceLibrary ?? libraries[0]!;
+
+		const sliceIndexPath = new URL(`${library}/index.js`, project);
 		try {
 			const sliceIndex = await readFile(sliceIndexPath, "utf8");
 			if (!new RegExp(`\\b${slice.id}: `).test(sliceIndex)) {
@@ -51,7 +68,7 @@ expect.extend({
 			problems.push(`slice library index (${sliceIndexPath.href}) does not exist`);
 		}
 
-		const modelPath = new URL(`slices/${slice.name}/model.json`, project);
+		const modelPath = new URL(`${library}/${sliceDirectoryName}/model.json`, project);
 		try {
 			const model: SharedSlice = JSON.parse(await readFile(modelPath, "utf8"));
 			if (model.id !== slice.id) {
@@ -61,7 +78,7 @@ expect.extend({
 			problems.push(`slice model file (${modelPath.href}) does not exist`);
 		}
 
-		const componentPath = new URL(`slices/${slice.name}/index.jsx`, project);
+		const componentPath = new URL(`${library}/${sliceDirectoryName}/index.jsx`, project);
 		try {
 			const componentFile = await readFile(componentPath, "utf-8");
 			if (!componentFile.includes(slice.name)) {

--- a/test/slice-create.test.ts
+++ b/test/slice-create.test.ts
@@ -1,4 +1,5 @@
 import { snakeCase } from "change-case";
+import { writeFile } from "node:fs/promises";
 
 import { buildSlice, it, readLocalSlice } from "./it";
 
@@ -31,4 +32,25 @@ it("creates a slice with a custom id", async ({ expect, prismic, project }) => {
 
 	const created = await readLocalSlice(project, id);
 	expect(created).toBeDefined();
+});
+
+it("creates a slice in the first configured library", async ({ expect, prismic, project, repo }) => {
+	await writeFile(
+		new URL("prismic.config.json", project),
+		JSON.stringify({
+			repositoryName: repo,
+			libraries: ["./slices/blog", "./slices/features"],
+		}),
+	);
+
+	const { name } = buildSlice();
+	const id = snakeCase(name);
+
+	const { exitCode } = await prismic("slice", ["create", name]);
+	expect(exitCode).toBe(0);
+
+	const created = await readLocalSlice(project, id);
+	expect(created).toBeDefined();
+	await expect(project).toHaveFile(`slices/blog/${name}/model.json`);
+	await expect(project).not.toHaveFile(`slices/${name}/model.json`);
 });


### PR DESCRIPTION
## Summary
- Use the first slice library from `prismic.config.json` when creating slices via `pull`, `sync`, and `slice create`
- Fall back to the framework default library when no libraries are configured
- Add integration tests and update test helpers/matchers for custom library paths

## Test plan
- [ ] Run `npm test -- test/pull.test.ts test/slice-create.test.ts` with E2E credentials
- [ ] Configure `libraries: ["./slices/blog"]` in a project, create a slice in Type Builder, run `prismic pull`, and confirm the slice lands under `./slices/blog/`
- [ ] Run a subsequent `prismic push` and confirm the slice is recognized

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is limited to slice creation target paths; existing multi-library read paths were already in place, with new tests covering the configured-library case.
> 
> **Overview**
> New slices from **`pull`**, **`sync`**, and **`slice create`** are written to the **first** path in `prismic.config.json` `libraries`, instead of always using the framework default (e.g. `./slices/`).
> 
> `Adapter.createSlice` now defaults `library` to `(await getSliceLibraries())[0]`, which already resolves configured libraries or falls back to the default when none are set.
> 
> Test helpers and **`toContainSlice`** were updated to scan all configured libraries (via `getSliceLibraries` / glob), and integration tests assert slices land under the first library (e.g. `./slices/blog`) and not the root `./slices/` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20bbcef8e138e6c7b49fbf5dddac92ec2ca6e572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->