### PR TITLE
refactor: PR 199

### DIFF
--- a/test/it.ts
+++ b/test/it.ts
@@ -197,21 +197,15 @@ export async function readLocalCustomTypes(project: URL): Promise<CustomType[]> 
 	return result;
 }
 
-export async function getSliceLibraryPaths(project: URL): Promise<string[]> {
-	const configPath = new URL("prismic.config.json", project);
-	try {
-		const config: { libraries?: string[] } = JSON.parse(await readFile(configPath, "utf8"));
-		const libraries = config.libraries;
-		if (libraries && libraries.length >= 1) {
-			return libraries.map((library) => library.replace(/\\/g, "").replace(/^\.\//, ""));
-		}
-	} catch {}
-	return ["slices"];
+export async function getSliceLibraries(project: URL): Promise<URL[]> {
+	const { libraries = [] } = await getConfig(project);
+	if (libraries.length < 1) return [new URL("slices/", project)];
+	return libraries.map((library) => new URL(library.replace(/^\//, "") + "/", project));
 }
 
 export async function writeLocalSlice(project: URL, model: SharedSlice): Promise<void> {
-	const [library] = await getSliceLibraryPaths(project);
-	const path = new URL(`${library}/${pascalCase(model.name)}/model.json`, project);
+	const [library] = await getSliceLibraries(project);
+	const path = new URL(`${pascalCase(model.name)}/model.json`, library);
 	await mkdir(new URL(".", path), { recursive: true });
 	await writeFile(path, JSON.stringify(model, null, 2));
 }
@@ -222,18 +216,21 @@ export async function readLocalSlice(project: URL, id: string): Promise<SharedSl
 }
 
 export async function readLocalSlices(project: URL): Promise<SharedSlice[]> {
-	const libraries = await getSliceLibraryPaths(project);
+	const libraries = await getSliceLibraries(project);
 	const result: SharedSlice[] = [];
-
 	for (const library of libraries) {
-		const dir = new URL(`${library}/`, project);
-		const entries = await readdir(dir).catch(() => [] as string[]);
+		const entries = await readdir(library).catch(() => []);
 		for (const name of entries) {
 			try {
-				result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, dir), "utf8")));
+				result.push(JSON.parse(await readFile(new URL(`${name}/model.json`, library), "utf8")));
 			} catch {}
 		}
 	}
-
 	return result;
+}
+
+async function getConfig(project: URL): Promise<{ libraries?: string[] }> {
+	const path = new URL("prismic.config.json", project);
+	const raw = await readFile(path, "utf8");
+	return JSON.parse(raw);
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,10 +1,11 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
-import { pascalCase } from "change-case";
-import { access, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { glob } from "tinyglobby";
 import { expect } from "vitest";
 
-import { getSliceLibraryPaths } from "./it";
+import { getSliceLibraries } from "./it";
 
 declare module "vitest" {
 	// oxlint-disable-next-line no-explicit-any
@@ -41,51 +42,46 @@ expect.extend({
 
 	async toContainSlice(project, slice) {
 		const problems: string[] = [];
-		const libraries = await getSliceLibraryPaths(project);
-		const sliceDirectoryName = pascalCase(slice.name);
-		let sliceLibrary: string | undefined;
 
+		const libraries = await getSliceLibraries(project);
+		let sliceDirectory;
 		for (const library of libraries) {
-			const sliceDirectory = new URL(`${library}/${sliceDirectoryName}/`, project);
+			const sliceModelPaths = Array.from(
+				await glob("*/model.json", { absolute: true, cwd: library }),
+				(path) => pathToFileURL(path),
+			);
+			for (const sliceModelPath of sliceModelPaths) {
+				const model: SharedSlice = JSON.parse(await readFile(sliceModelPath, "utf8"));
+				if (model.id === slice.id) {
+					sliceDirectory = new URL(".", sliceModelPath);
+				}
+			}
+		}
+
+		if (!sliceDirectory) {
+			problems.push(`slice model file does not exist`);
+		} else {
+			const sliceIndexPath = new URL("../index.js", sliceDirectory);
 			try {
-				await access(sliceDirectory);
-				sliceLibrary = library;
-				break;
-			} catch {}
-		}
-
-		const library = sliceLibrary ?? libraries[0]!;
-
-		const sliceIndexPath = new URL(`${library}/index.js`, project);
-		try {
-			const sliceIndex = await readFile(sliceIndexPath, "utf8");
-			if (!new RegExp(`\\b${slice.id}: `).test(sliceIndex)) {
-				problems.push(
-					`slice "${slice.id}" not found in slice library index (${sliceIndexPath.href})`,
-				);
+				const sliceIndex = await readFile(sliceIndexPath, "utf8");
+				if (!new RegExp(`\\b${slice.id}: `).test(sliceIndex)) {
+					problems.push(
+						`slice "${slice.id}" not found in slice library index (${sliceIndexPath.href})`,
+					);
+				}
+			} catch {
+				problems.push(`slice library index (${sliceIndexPath.href}) does not exist`);
 			}
-		} catch {
-			problems.push(`slice library index (${sliceIndexPath.href}) does not exist`);
-		}
 
-		const modelPath = new URL(`${library}/${sliceDirectoryName}/model.json`, project);
-		try {
-			const model: SharedSlice = JSON.parse(await readFile(modelPath, "utf8"));
-			if (model.id !== slice.id) {
-				problems.push(`slice model file (${modelPath.href}) has wrong ID`);
+			const componentPath = new URL("index.jsx", sliceDirectory);
+			try {
+				const componentFile = await readFile(componentPath, "utf-8");
+				if (!componentFile.includes(slice.name)) {
+					problems.push(`slice component file (${componentPath.href}) does not contain slice name`);
+				}
+			} catch {
+				problems.push(`slice component file (${componentPath.href}) does not exist`);
 			}
-		} catch {
-			problems.push(`slice model file (${modelPath.href}) does not exist`);
-		}
-
-		const componentPath = new URL(`${library}/${sliceDirectoryName}/index.jsx`, project);
-		try {
-			const componentFile = await readFile(componentPath, "utf-8");
-			if (!componentFile.includes(slice.name)) {
-				problems.push(`slice component file (${componentPath.href}) does not contain slice name`);
-			}
-		} catch {
-			problems.push(`slice component file (${componentPath.href}) does not exist`);
 		}
 
 		return {


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: <!-- GitHub or Linear issue (e.g. #123, DT-123) -->

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

Refactors #199 to follow code practices from the rest of the project, like preferring `URL`s over string paths.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to integration-test utilities and matchers; the only behavioral shift is stricter config reads and slice discovery by id, which may surface mis-located slices more accurately in tests.
> 
> **Overview**
> Test helpers now resolve slice library locations as **`URL`s** via **`getSliceLibraries`** (replacing string-based **`getSliceLibraryPaths`**), with library paths read from **`prismic.config.json`** through a shared **`getConfig`** helper and defaulting to **`slices/`** when none are configured.
> 
> **`writeLocalSlice`** / **`readLocalSlices`** build paths relative to each library **`URL`** instead of joining string segments under the project root.
> 
> The **`toContainSlice`** matcher locates slices by globbing **`*/model.json`** across libraries and matching **`model.id`**, then checks the parent library’s **`index.js`** and **`index.jsx`** next to that model—rather than assuming a PascalCase folder name and a single **`{library}/index.js`** path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac7ff7c5eff3fe33d83a0b3fee80958abe721378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->