### PR TITLE
feat(token): add --name and --json options to token create

### DIFF
--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -7,6 +7,7 @@ import {
 } from "../clients/wroom";
 import { resolveEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
 
@@ -26,6 +27,12 @@ const config = {
 			type: "boolean",
 			description: "Allow access to releases (read tokens only)",
 		},
+		name: {
+			type: "string",
+			short: "n",
+			description: `Name to identify the token (default: "${CLI_APP_NAME}")`,
+		},
+		json: { type: "boolean", description: "Output as JSON" },
 		repo: { type: "string", short: "r", description: "Repository domain" },
 		env: { type: "string", short: "e", description: "Environment domain" },
 	},
@@ -37,6 +44,8 @@ export default createCommand(config, async ({ values }) => {
 		env,
 		write,
 		"allow-releases": allowReleases,
+		name = CLI_APP_NAME,
+		json,
 	} = values;
 
 	if (write && allowReleases) {
@@ -48,17 +57,18 @@ export default createCommand(config, async ({ values }) => {
 	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let createdToken: string;
+	let scope: string | undefined;
 	try {
 		if (write) {
-			const writeToken = await createWriteToken(CLI_APP_NAME, { repo, token, host });
+			const writeToken = await createWriteToken(name, { repo, token, host });
 			createdToken = writeToken.token;
 		} else {
-			const scope = allowReleases ? "master+releases" : "master";
+			scope = allowReleases ? "master+releases" : "master";
 
-			// Find or create the CLI OAuth app.
+			// Find or create the OAuth app.
 			const apps = await getOAuthApps({ repo, token, host });
-			let app = apps.find((a) => a.name === CLI_APP_NAME);
-			if (!app) app = await createOAuthApp(CLI_APP_NAME, { repo, token, host });
+			let app = apps.find((a) => a.name === name);
+			if (!app) app = await createOAuthApp(name, { repo, token, host });
 
 			const accessToken = await createOAuthAuthorization(app.id, scope, { repo, token, host });
 			createdToken = accessToken.token;
@@ -71,7 +81,18 @@ export default createCommand(config, async ({ values }) => {
 		throw error;
 	}
 
+	if (json) {
+		console.info(
+			stringify({
+				token: createdToken,
+				type: write ? "write" : "access",
+				name,
+				repository: repo,
+				...(scope ? { scope } : {}),
+			}),
+		);
+		return;
+	}
+
 	console.info(`Token created: ${createdToken}`);
-	const envVar = write ? "PRISMIC_WRITE_TOKEN" : "PRISMIC_ACCESS_TOKEN";
-	console.info(`Add it to your .env file: ${envVar}=${createdToken}`);
 });

--- a/test/token-create.test.ts
+++ b/test/token-create.test.ts
@@ -57,6 +57,50 @@ it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
 	expect(found).toBeDefined();
 });
 
+it("creates a write token with a custom --name", async ({ expect, prismic, repo, token, host }) => {
+	const { stdout, exitCode } = await prismic("token", [
+		"create",
+		"--write",
+		"--name",
+		"My Seed Token",
+	]);
+	expect(exitCode).toBe(0);
+
+	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
+	expect(createdToken).toBeDefined();
+
+	const writeTokensInfo = await getWriteTokens({ repo, token, host });
+	const found = writeTokensInfo.tokens.find((t) => t.token === createdToken);
+	expect(found).toBeDefined();
+	expect(found!.app_name).toBe("My Seed Token");
+});
+
+it("outputs a write token as JSON with --json", async ({ expect, prismic, repo, token, host }) => {
+	const { stdout, exitCode } = await prismic("token", ["create", "--write", "--json"]);
+	expect(exitCode).toBe(0);
+
+	const result = JSON.parse(stdout);
+	expect(result.type).toBe("write");
+	expect(result.name).toBe("Prismic CLI");
+	expect(result.repository).toBe(repo);
+	expect(result.token).toBeDefined();
+
+	const writeTokensInfo = await getWriteTokens({ repo, token, host });
+	const found = writeTokensInfo.tokens.find((t) => t.token === result.token);
+	expect(found).toBeDefined();
+});
+
+it("outputs an access token as JSON with --json", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("token", ["create", "--json"]);
+	expect(exitCode).toBe(0);
+
+	const result = JSON.parse(stdout);
+	expect(result.type).toBe("access");
+	expect(result.scope).toBe("master");
+	expect(result.repository).toBe(repo);
+	expect(result.token).toBeDefined();
+});
+
 it("errors when combining --write and --allow-releases", async ({ expect, prismic }) => {
 	const { stderr, exitCode } = await prismic("token", ["create", "--write", "--allow-releases"]);
 	expect(exitCode).toBe(1);


### PR DESCRIPTION
Resolves:

### Description

Adds two options to `prismic token create`:

- `--name, -n` — labels the created token (defaults to `"Prismic CLI"`). Makes tokens identifiable in `token list` and easy to clean up.
- `--json` — prints the created token as machine-readable JSON, so scripts can parse it instead of scraping the human-readable output.

Together these let a script mint a write token from the user's CLI session, use it (e.g. a Migration API import), and revoke it — without the user manually creating a token. Also drops the `.env` hint line from the human-readable output.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA

1. `prismic token create --write --name "My token" --json` → prints `{ "token": "…", "type": "write", "name": "My token", "repository": "…" }`.
2. `prismic token list` shows the write token labeled `My token`.
3. `prismic token create --json` → JSON with `"type": "access"` and `"scope": "master"`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only output and labeling changes with tests; default name behavior matches the previous hardcoded label.
> 
> **Overview**
> **`prismic token create`** gains **`--name` / `-n`** (default `"Prismic CLI"`) so write tokens and OAuth apps are labeled with a chosen name instead of always using the fixed CLI app name, and **`--json`** so automation gets structured output (`token`, `type`, `name`, `repository`, and `scope` for access tokens).
> 
> Human output is trimmed to a single **`Token created: …`** line; the previous **`.env` variable hint** is removed. Integration tests cover custom names and JSON for write and access tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb16e478637c2911b7868de52cf2c6b8483b2609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->