### PR TITLE
feat: add `prismic init --no-setup` to skip framework scaffolding

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -58,12 +58,12 @@ export abstract class Adapter {
 	abstract getDefaultSliceLibrary(): Promise<URL>;
 	abstract getDefaultCustomTypeLibrary(): Promise<URL>;
 
-	async initProject(): Promise<void> {
+	async initProject({ setup = true }: { setup?: boolean } = {}): Promise<void> {
 		const libraries = await this.getSliceLibraries();
 		for (const library of libraries) {
 			await this.createSliceIndexFile(library);
 		}
-		await this.setupProject();
+		if (setup) await this.setupProject();
 		await this.onProjectInitialized();
 	}
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -39,11 +39,15 @@ const config = {
 			type: "boolean",
 			description: "Skip opening the browser automatically during login",
 		},
+		"no-setup": {
+			type: "boolean",
+			description: "Skip framework scaffolding (dependencies and framework files)",
+		},
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: explicitRepo, "no-browser": noBrowser } = values;
+	const { repo: explicitRepo, "no-browser": noBrowser, "no-setup": noSetup } = values;
 
 	// Check for existing prismic.config.json
 	try {
@@ -161,16 +165,18 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	// Install dependencies and create framework files
-	await adapter.initProject();
+	await adapter.initProject({ setup: !noSetup });
 
 	// Run package manager install
-	try {
-		console.info("Installing dependencies...");
-		await installDependencies();
-	} catch {
-		console.warn(
-			"Could not install dependencies automatically. Please install them manually (i.e. `npm install`).",
-		);
+	if (!noSetup) {
+		try {
+			console.info("Installing dependencies...");
+			await installDependencies();
+		} catch {
+			console.warn(
+				"Could not install dependencies automatically. Please install them manually (i.e. `npm install`).",
+			);
+		}
 	}
 
 	// Sync models from remote and generate types

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -103,6 +103,22 @@ it("initializes a project with --repo when logged in", async ({
 	expect(config.repositoryName).toBe(repo);
 }, 60_000);
 
+it("skips framework scaffolding with --no-setup", async ({ expect, project, prismic, repo }) => {
+	await rm(new URL("prismic.config.json", project));
+
+	const { exitCode } = await prismic("init", ["--repo", repo, "--no-setup"]);
+	expect(exitCode).toBe(0);
+
+	// The config file is still written.
+	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
+	expect(JSON.parse(configRaw).repositoryName).toBe(repo);
+
+	// No @prismicio/* packages are added and no install is run.
+	const packageJson = JSON.parse(await readFile(new URL("package.json", project), "utf-8"));
+	expect(packageJson.dependencies).not.toHaveProperty("@prismicio/client");
+	await expect(access(new URL("package-lock.json", project))).rejects.toThrow();
+}, 60_000);
+
 it("triggers login flow when not logged in", async ({ expect, project, prismic, logout, repo }) => {
 	await rm(new URL("prismic.config.json", project));
 	await logout();


### PR DESCRIPTION
Resolves: #202

### Description

Adds a `--no-setup` flag to `prismic init` that runs the full init flow but skips the framework scaffolding step, so it does not add the `@prismicio/*` packages or generate the framework files. This is for projects that write the Prismic client, pages, and route handlers by hand.

`--no-setup` skips exactly what `prismic gen setup` does: `Adapter.setupProject()` and dependency installation. Everything else still runs — creating or connecting the repository, writing `prismic.config.json`, migrating a legacy `slicemachine.config.json`, syncing models, and generating types.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic init --no-setup` in a project. It should create the repository and `prismic.config.json`, sync models, and generate types, without adding `@prismicio/*` packages or creating framework files.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in CLI flag with default init behavior unchanged; only skips scaffolding and install when explicitly requested.
> 
> **Overview**
> Adds **`prismic init --no-setup`** for hand-rolled Prismic integrations: init still connects or creates the repo, writes **`prismic.config.json`**, migrates legacy Slice Machine config when present, syncs models, and generates types, but skips framework scaffolding and **`npm install`**.
> 
> **`Adapter.initProject`** now accepts **`{ setup?: boolean }`** (default **`true`**). When **`setup`** is false, **`setupProject()`** is not called; slice index creation and **`onProjectInitialized()`** still run.
> 
> An integration test asserts **`--no-setup`** leaves **`prismic.config.json`** in place and does not add **`@prismicio/client`** or run install (no **`package-lock.json`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3677d2dd35bf1b1e47279972e4eac05b6dca860f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->