### PR TITLE
feat: set a master locale when creating a repository

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -35,6 +35,11 @@ const config = {
 	`,
 	options: {
 		repo: { type: "string", short: "r", description: "Repository name" },
+		lang: {
+			type: "string",
+			short: "l",
+			description: "Master locale for a new repository (default: en-us)",
+		},
 		"no-browser": {
 			type: "boolean",
 			description: "Skip opening the browser automatically during login",
@@ -43,7 +48,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: explicitRepo, "no-browser": noBrowser } = values;
+	const { repo: explicitRepo, lang, "no-browser": noBrowser } = values;
 
 	// Check for existing prismic.config.json
 	try {
@@ -119,7 +124,7 @@ export default createCommand(config, async ({ values }) => {
 	const adapter = await getAdapter();
 
 	if (!repo) {
-		repo = await createRepo({ token, host });
+		repo = await createRepo({ lang, token, host });
 		console.info(`Created repository: ${repo}`);
 	}
 

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -1,5 +1,6 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
+import { upsertLocale } from "../clients/locale";
 import { completeOnboardingStepsSilently } from "../clients/repository";
 import { checkIsDomainAvailable, createRepository } from "../clients/wroom";
 import { detectAgent } from "../lib/ai";
@@ -13,15 +14,20 @@ const config = {
 	description: "Create a new Prismic repository.",
 	options: {
 		name: { type: "string", short: "n", description: "Display name for the repository" },
+		lang: {
+			type: "string",
+			short: "l",
+			description: "Master locale for the new repository (default: en-us)",
+		},
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { name } = values;
+	const { name, lang } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const domain = await createRepo({ name, token, host });
+	const domain = await createRepo({ name, lang, token, host });
 
 	console.info(`Repository created: ${domain}`);
 	console.info(`URL: https://${domain}.${host}/`);
@@ -29,10 +35,11 @@ export default createCommand(config, async ({ values }) => {
 
 export async function createRepo(config: {
 	name?: string;
+	lang?: string;
 	token: string | undefined;
 	host: string;
 }): Promise<string> {
-	const { name, token, host } = config;
+	const { name, lang = "en-us", token, host } = config;
 
 	const domain = await findAvailableDomain({ token, host });
 	if (!domain) {
@@ -49,6 +56,17 @@ export async function createRepo(config: {
 		if (error instanceof UnknownRequestError) {
 			const message = await error.text();
 			throw new CommandError(`Failed to create repository: ${message}`);
+		}
+		throw error;
+	}
+
+	// A new repository has no locale, so set the master locale to make it usable.
+	try {
+		await upsertLocale({ id: lang, isMaster: true }, { repo: domain, token, host });
+	} catch (error) {
+		if (error instanceof UnknownRequestError) {
+			const message = await error.text();
+			throw new CommandError(`Failed to set master locale: ${message}`);
 		}
 		throw error;
 	}

--- a/test/repo-create.test.ts
+++ b/test/repo-create.test.ts
@@ -1,7 +1,7 @@
 import { onTestFinished } from "vitest";
 
 import { it } from "./it";
-import { deleteRepository, getRepository } from "./prismic";
+import { deleteRepository, getLocales, getRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("repo", ["create", "--help"]);
@@ -36,4 +36,18 @@ it("creates a repository with a name", async ({ expect, prismic, token, host, pa
 
 	const repository = await getRepository({ repo: domain!, token, host });
 	expect(repository.name).toBe(name);
+});
+
+it("sets the master locale with --lang", async ({ expect, prismic, token, host, password }) => {
+	const { stdout, exitCode } = await prismic("repo", ["create", "--lang", "fr-fr"]);
+	expect(exitCode).toBe(0);
+
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	onTestFinished(() => deleteRepository(domain!, { token, password, host }));
+
+	const locales = await getLocales({ repo: domain!, token, host });
+	const master = locales.find((locale) => locale.isMaster);
+	expect(master?.id).toBe("fr-fr");
 });


### PR DESCRIPTION
Resolves: #207

### Description

`prismic init` and `prismic repo create` create a repository with no locale, so you can't add content until you manually run `prismic locale add en-us --master` (and the Migration API fails without one).

This adds a `--lang` option (defaulting to `en-us`) to both commands that sets the new repository's master locale on creation, making a freshly created repository usable out of the box.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic repo create` (or `prismic repo create --lang fr-fr`) and confirm the new repository has a master locale set. The same applies to `prismic init` when it creates a repository.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches repository provisioning and locale API calls; a failed upsert leaves a repo without a master locale, though errors are surfaced explicitly.
> 
> **Overview**
> New repositories were created without a master locale, blocking content and Migration API use until someone ran `prismic locale add` manually.
> 
> **`prismic repo create`** and **`prismic init`** (when it creates a repo) now accept **`--lang` / `-l`**, default **`en-us`**. Shared **`createRepo`** calls **`upsertLocale`** with `isMaster: true` right after **`createRepository`**, with clear errors if locale setup fails.
> 
> An integration test asserts **`--lang fr-fr`** sets the master locale on the new repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ff2f1d92b2e084a3647e2738a3bcbe37ed3098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->