### PR TITLE
feat: persist the active environment in .env.local

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -44,6 +44,7 @@ export class NoSupportedFrameworkError extends Error {
 
 export abstract class Adapter {
 	abstract readonly id: string;
+	abstract readonly repositoryEnvVar: string;
 
 	abstract onProjectInitialized(): Promise<void> | void;
 	abstract onSliceCreated(model: SharedSlice, library: URL): Promise<void> | void;

--- a/src/adapters/nextjs.templates.ts
+++ b/src/adapters/nextjs.templates.ts
@@ -357,7 +357,8 @@ export function prismicIOFileTemplate(args: {
 			/**
 			 * The project's Prismic repository name.
 			 */
-			export const repositoryName = prismicConfig.repositoryName;
+			export const repositoryName =
+				process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 			${createClientContents}
 		`;
@@ -369,7 +370,8 @@ export function prismicIOFileTemplate(args: {
 		/**
 		 * The project's Prismic repository name.
 		 */
-		export const repositoryName = prismicConfig.repositoryName;
+		export const repositoryName =
+			process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 		${createClientContents}
 	`;

--- a/src/adapters/nextjs.ts
+++ b/src/adapters/nextjs.ts
@@ -26,6 +26,7 @@ import {
 
 export class NextJsAdapter extends Adapter {
 	readonly id = "next";
+	readonly repositoryEnvVar = "NEXT_PUBLIC_PRISMIC_ENVIRONMENT";
 
 	async setupProject(): Promise<void> {
 		await addDependencies({

--- a/src/adapters/nuxt.ts
+++ b/src/adapters/nuxt.ts
@@ -21,6 +21,7 @@ const NUXT_PRISMIC = "@nuxtjs/prismic";
 
 export class NuxtAdapter extends Adapter {
 	readonly id = "nuxt";
+	readonly repositoryEnvVar = "NUXT_PUBLIC_PRISMIC_ENVIRONMENT";
 
 	async setupProject(): Promise<void> {
 		await addDependencies({

--- a/src/adapters/sveltekit.templates.ts
+++ b/src/adapters/sveltekit.templates.ts
@@ -16,7 +16,8 @@ export function prismicIOFileTemplate(args: { typescript: boolean }): string {
 			/**
 			 * The project's Prismic repository name.
 			 */
-			export const repositoryName = prismicConfig.repositoryName;
+			export const repositoryName =
+				import.meta.env.VITE_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 			/**
 			 * Creates a Prismic client for the project's repository. The client is used to
@@ -45,7 +46,8 @@ export function prismicIOFileTemplate(args: { typescript: boolean }): string {
 		/**
 		 * The project's Prismic repository name.
 		 */
-		export const repositoryName = prismicConfig.repositoryName;
+		export const repositoryName =
+			import.meta.env.VITE_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 		/**
 		 * Creates a Prismic client for the project's repository. The client is used to

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -28,6 +28,7 @@ import {
 
 export class SvelteKitAdapter extends Adapter {
 	readonly id = "sveltekit";
+	readonly repositoryEnvVar = "VITE_PRISMIC_ENVIRONMENT";
 
 	async setupProject(): Promise<void> {
 		await addDependencies({

--- a/src/commands/env-active.ts
+++ b/src/commands/env-active.ts
@@ -1,0 +1,19 @@
+import { getActiveRepositoryName } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env active",
+	description: `
+		Print the active environment, or production if none is set.
+	`,
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const active = await getActiveRepositoryName();
+	if (active) {
+		console.info(active);
+		return;
+	}
+	console.info(`${await getRepositoryName()} (production)`);
+});

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -1,0 +1,32 @@
+import { getHost, getToken } from "../auth";
+import { getActiveRepositoryName, getAvailableEnvironments } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { formatTable } from "../lib/string";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env list",
+	description: `
+		List environments available on a Prismic repository, including production.
+	`,
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { repo = await getRepositoryName() } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+
+	const environments = await getAvailableEnvironments({ repo, token, host });
+	const active = (await getActiveRepositoryName()) ?? repo;
+
+	const rows = environments.map((environment) => {
+		const label = environment.kind === "prod" ? "production" : environment.name;
+		const marker = environment.domain === active ? " (active)" : "";
+		return [environment.domain, `${label}${marker}`];
+	});
+	console.info(formatTable(rows, { headers: ["DOMAIN", "NAME"] }));
+});

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -1,0 +1,43 @@
+import { getAdapter } from "../adapters";
+import { getHost, getToken } from "../auth";
+import { resolveEnvironment } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { removeEnvVar, setEnvVar } from "../lib/env-file";
+import { findProjectRoot, getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env set",
+	description: `
+		Set the active environment for local development.
+
+		Writes the environment to .env.local. The website and CLI read it as the
+		active repository. Setting production removes it.
+	`,
+	positionals: {
+		environment: { description: "Environment domain", required: true },
+	},
+	options: {
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals, values }) => {
+	const [environment] = positionals;
+	const { repo = await getRepositoryName() } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+
+	const domain = await resolveEnvironment(environment, { repo, token, host });
+	const adapter = await getAdapter();
+	const path = new URL(".env.local", await findProjectRoot());
+
+	if (domain === repo) {
+		await removeEnvVar(path, adapter.repositoryEnvVar);
+		console.info(`Active environment set to production: ${domain}`);
+		return;
+	}
+
+	await setEnvVar(path, adapter.repositoryEnvVar, domain);
+	console.info(`Active environment set: ${domain}`);
+});

--- a/src/commands/env-unset.ts
+++ b/src/commands/env-unset.ts
@@ -1,0 +1,18 @@
+import { getAdapter } from "../adapters";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { removeEnvVar } from "../lib/env-file";
+import { findProjectRoot } from "../project";
+
+const config = {
+	name: "prismic env unset",
+	description: `
+		Revert to production by removing the active environment from .env.local.
+	`,
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const adapter = await getAdapter();
+	const projectRoot = await findProjectRoot();
+	await removeEnvVar(new URL(".env.local", projectRoot), adapter.repositoryEnvVar);
+	console.info("Active environment reverted to production.");
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,28 @@
+import { createCommandRouter } from "../lib/command";
+import envActive from "./env-active";
+import envList from "./env-list";
+import envSet from "./env-set";
+import envUnset from "./env-unset";
+
+export default createCommandRouter({
+	name: "prismic env",
+	description: "Manage the active Prismic environment.",
+	commands: {
+		list: {
+			handler: envList,
+			description: "List environments",
+		},
+		set: {
+			handler: envSet,
+			description: "Set the active environment",
+		},
+		unset: {
+			handler: envUnset,
+			description: "Revert to production",
+		},
+		active: {
+			handler: envActive,
+			description: "Print the active environment",
+		},
+	},
+});

--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic locale add",
@@ -26,7 +25,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, master = false, name } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, master = false, name } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -1,11 +1,10 @@
 import { getHost, getToken } from "../auth";
 import { getLocales } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic locale list",
@@ -23,7 +22,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { removeLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic locale remove",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getLocales, upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic locale set-master",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { addPreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic preview add",
@@ -25,7 +24,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, name } = values;
 
 	let parsed: URL;
 	try {

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -1,11 +1,10 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, getSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic preview list",
@@ -23,7 +22,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, removePreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic preview remove",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { setSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic preview set-simulator",
@@ -30,7 +29,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [urlArg] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	let parsed: URL;
 	try {

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -2,13 +2,13 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { isDescendant, relativePathname } from "../lib/url";
 import { canonicalizeModel } from "../models";
-import { findProjectRoot, getRepositoryName } from "../project";
+import { findProjectRoot } from "../project";
 
 const config = {
 	name: "prismic pull",
@@ -26,7 +26,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { force = false, repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -21,14 +21,14 @@ import {
 	type OnboardingStep,
 } from "../clients/repository";
 import { getWorkingDocumentsUrlForCustomType, getCustomTypeListUrl } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { BadRequestError } from "../lib/request";
 import { appendTrailingSlash, isDescendant, relativePathname } from "../lib/url";
 import { canonicalizeModel } from "../models";
-import { findProjectRoot, getRepositoryName } from "../project";
+import { findProjectRoot } from "../project";
 
 const config = {
 	name: "prismic push",
@@ -46,7 +46,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { force = false, repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,14 +4,14 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { getProfile } from "../clients/user";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays, type ArrayDiff } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
 import { dedent } from "../lib/string";
 import { isDescendant, relativePathname } from "../lib/url";
 import { canonicalizeModel } from "../models";
-import { findProjectRoot, getRepositoryName } from "../project";
+import { findProjectRoot } from "../project";
 
 const config = {
 	name: "prismic status",
@@ -28,7 +28,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,10 +6,9 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
 import { env } from "../env";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
-import { getRepositoryName } from "../project";
 import { trackCommandStart, trackCommandEnd } from "../tracking";
 
 const POLL_INTERVAL_MS = env.TEST ? 500 : 5000;
@@ -35,7 +34,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env: envFlag } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env: envFlag } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -5,11 +5,10 @@ import {
 	createWriteToken,
 	getOAuthApps,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const CLI_APP_NAME = "Prismic CLI";
 
@@ -40,7 +39,7 @@ const config = {
 
 export default createCommand(config, async ({ values }) => {
 	const {
-		repo: parentRepo = await getRepositoryName(),
+		repo: parentRepo = await resolveRepositoryName(),
 		env,
 		write,
 		"allow-releases": allowReleases,

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -5,10 +5,9 @@ import {
 	getOAuthApps,
 	getWriteTokens,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic token delete",
@@ -29,7 +28,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [tokenValue] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -1,11 +1,10 @@
 import { getHost, getToken } from "../auth";
 import { getOAuthApps, getWriteTokens } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic token list",
@@ -23,7 +22,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { createWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook create",
@@ -54,7 +53,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name, secret, trigger = [] } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, name, secret, trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook disable",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook enable",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -1,11 +1,10 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
 import { formatTable } from "../lib/string";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook list",
@@ -23,7 +22,7 @@ const config = {
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, json } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { deleteWebhook, getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook remove",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook set-triggers",
@@ -41,7 +40,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, trigger = [] } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env, trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -1,9 +1,8 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { resolveEnvironment, resolveRepositoryName } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
-import { getRepositoryName } from "../project";
 
 const config = {
 	name: "prismic webhook view",
@@ -24,7 +23,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { repo: parentRepo = await resolveRepositoryName(), env } = values;
 
 	const token = await getToken();
 	const host = await getHost();

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,10 +1,14 @@
+import { getAdapter } from "./adapters";
 import { type Environment, getEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
+import { readEnvFile } from "./lib/env-file";
+import { findProjectRoot, getRepositoryName } from "./project";
 
-export async function resolveEnvironment(
-	env: string,
-	config: { repo: string; token: string | undefined; host: string },
-): Promise<string> {
+export async function getAvailableEnvironments(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<Environment[]> {
 	const { repo, token, host } = config;
 
 	const [profile, environments] = await Promise.all([
@@ -12,15 +16,47 @@ export async function resolveEnvironment(
 		getEnvironments({ repo, token, host }),
 	]);
 
-	const availableEnvironments = environments.filter(
+	return environments.filter(
 		(environment) =>
 			(environment.kind === "prod" || environment.kind === "stage") &&
 			environment.users.some((user) => user.id === profile.shortId),
 	);
+}
+
+export async function resolveEnvironment(
+	env: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<string> {
+	const availableEnvironments = await getAvailableEnvironments(config);
 	const match = availableEnvironments.find((environment) => environment.domain === env);
 	if (match) return match.domain;
 
-	throw new InvalidEnvironmentError(env, availableEnvironments, repo);
+	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
+}
+
+/**
+ * The repository name persisted as the active environment, read from
+ * `process.env` then `.env.local`. Returns `undefined` when none is set.
+ */
+export async function getActiveRepositoryName(): Promise<string | undefined> {
+	let key: string;
+	try {
+		const adapter = await getAdapter();
+		key = adapter.repositoryEnvVar;
+	} catch {
+		return undefined;
+	}
+
+	const fromProcess = process.env[key];
+	if (fromProcess) return fromProcess;
+
+	const localEnv = await readEnvFile(new URL(".env.local", await findProjectRoot()));
+	return localEnv[key];
+}
+
+/** The repository name to target by default, honoring the active environment. */
+export async function resolveRepositoryName(): Promise<string> {
+	return (await getActiveRepositoryName()) ?? (await getRepositoryName());
 }
 
 export class InvalidEnvironmentError extends Error {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getAdapter, NoSupportedFrameworkError } from "./adapters";
 import { cleanupLegacyAuthFile, getHost, getToken, spawnTokenRefresh } from "./auth";
 import { getProfile } from "./clients/user";
 import docs from "./commands/docs";
+import environment from "./commands/env";
 import field from "./commands/field";
 import gen from "./commands/gen";
 import init from "./commands/init";
@@ -101,6 +102,10 @@ const router = createCommandRouter({
 		repo: {
 			handler: repo,
 			description: "Manage repositories",
+		},
+		env: {
+			handler: environment,
+			description: "Manage the active environment",
 		},
 		type: {
 			handler: type_,

--- a/src/lib/env-file.ts
+++ b/src/lib/env-file.ts
@@ -1,0 +1,38 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { parseEnv } from "node:util";
+
+export async function readEnvFile(path: URL): Promise<Record<string, string | undefined>> {
+	try {
+		return parseEnv(await readFile(path, "utf8"));
+	} catch {
+		return {};
+	}
+}
+
+export async function setEnvVar(path: URL, key: string, value: string): Promise<void> {
+	let contents = "";
+	try {
+		contents = await readFile(path, "utf8");
+	} catch {}
+
+	const line = `${key}=${value}`;
+	const pattern = new RegExp(`^${key}=.*$`, "m");
+	if (pattern.test(contents)) {
+		contents = contents.replace(pattern, line);
+	} else {
+		if (contents && !contents.endsWith("\n")) contents += "\n";
+		contents += `${line}\n`;
+	}
+
+	await writeFile(path, contents);
+}
+
+export async function removeEnvVar(path: URL, key: string): Promise<void> {
+	let contents: string;
+	try {
+		contents = await readFile(path, "utf8");
+	} catch {
+		return;
+	}
+	await writeFile(path, contents.replace(new RegExp(`^${key}=.*\\n?`, "m"), ""));
+}

--- a/test/env-active.test.ts
+++ b/test/env-active.test.ts
@@ -1,0 +1,26 @@
+import { writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["active", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env active [options]");
+});
+
+it("prints production when no environment is active", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["active"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`${repo} (production)`);
+});
+
+it("reads the active environment from .env.local", async ({ expect, prismic, project }) => {
+	await writeFile(
+		new URL(".env.local", project),
+		"NEXT_PUBLIC_PRISMIC_ENVIRONMENT=my-repo-staging\n",
+	);
+
+	const { stdout, exitCode } = await prismic("env", ["active"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("my-repo-staging");
+});

--- a/test/env-list.test.ts
+++ b/test/env-list.test.ts
@@ -1,0 +1,14 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["list", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env list [options]");
+});
+
+it("lists environments including production", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["list"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+	expect(stdout).toContain("production");
+});

--- a/test/env-set.test.ts
+++ b/test/env-set.test.ts
@@ -1,0 +1,29 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["set", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env set <environment> [options]");
+});
+
+// TODO: Test setting a non-production environment once the e2e setup can create
+// one. It should write the environment's domain to .env.local as the active
+// repository. The test repository only has production, so it can't be covered yet.
+
+it("setting production clears the active environment", async ({ expect, prismic, project, repo }) => {
+	const path = new URL(".env.local", project);
+	await writeFile(path, "NEXT_PUBLIC_PRISMIC_ENVIRONMENT=my-repo-staging\n");
+
+	const { stdout, exitCode } = await prismic("env", ["set", repo]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("production");
+	expect(await readFile(path, "utf8")).not.toContain("my-repo-staging");
+});
+
+it("rejects an unknown environment", async ({ expect, prismic }) => {
+	const { stderr, exitCode } = await prismic("env", ["set", "does-not-exist"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain("No environments available");
+});

--- a/test/env-unset.test.ts
+++ b/test/env-unset.test.ts
@@ -1,0 +1,18 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["unset", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env unset [options]");
+});
+
+it("unsets the active environment", async ({ expect, prismic, project }) => {
+	const path = new URL(".env.local", project);
+	await writeFile(path, "NEXT_PUBLIC_PRISMIC_ENVIRONMENT=my-repo-staging\n");
+
+	const { exitCode } = await prismic("env", ["unset"]);
+	expect(exitCode).toBe(0);
+	expect(await readFile(path, "utf8")).not.toContain("my-repo-staging");
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});


### PR DESCRIPTION
Resolves: #209

### Description

Environments only had low-level controls: `--env` worked per command but nothing persisted it, so a dev had to remember which environment they were in and repeat the flag. This adds a persisted, shared active environment.

- `prismic env list` — list environments, including production, marking the active one
- `prismic env set <name>` — set the active environment (writes it to `.env.local`)
- `prismic env unset` — revert to production (removes it from `.env.local`)
- `prismic env active` — print the active environment

The active environment is stored as one framework-specific variable in `.env.local`, resolved by the adapter (`NEXT_PUBLIC_PRISMIC_ENVIRONMENT`, `NUXT_PUBLIC_PRISMIC_ENVIRONMENT`, `VITE_PRISMIC_ENVIRONMENT`). The CLI reads it as the default repository (after `--env` and `--repo`, before the `prismic.config.json` default). Generated Next.js and SvelteKit projects read the same variable natively; Nuxt reads it through `@nuxtjs/prismic`. The names match Slice Machine, so existing `.env.local` files stay compatible.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

In a Next.js or SvelteKit project with environments:

1. `prismic env list` — production is marked active.
2. `prismic env set <environment>` — writes the variable to `.env.local`; `prismic env active` reflects it, and content commands target it.
3. Run the dev server — the site reads the active environment.
4. `prismic env unset` — reverts to production.

<!-- Your favorite emoji is welcome to close your PR! -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default repository resolution now affects many API commands (push/pull/sync, tokens, webhooks), so a stale `.env.local` could target the wrong environment; changes are local-dev focused and `--repo`/`--env` still override.
> 
> **Overview**
> Adds a **`prismic env`** command group so local dev can keep a shared active environment instead of passing **`--env`** on every command.
> 
> **`env list`**, **`env set`**, **`env unset`**, and **`env active`** read and write a framework-specific variable in **`.env.local`** (`NEXT_PUBLIC_PRISMIC_ENVIRONMENT`, `NUXT_PUBLIC_PRISMIC_ENVIRONMENT`, or `VITE_PRISMIC_ENVIRONMENT`). Setting production removes the variable. Adapters expose **`repositoryEnvVar`**; new **`lib/env-file`** helpers update the file.
> 
> **`resolveRepositoryName()`** (active env from **`process.env`** / **`.env.local`**, else **`prismic.config.json`**) replaces **`getRepositoryName()`** as the default target for push/pull/sync/status and locale, preview, token, and webhook commands. **`--env`** / **`--repo`** still override per invocation.
> 
> Scaffolded Next.js and SvelteKit **`prismicio`** templates prefer the same env var for **`repositoryName`**, aligning the dev server with CLI and Slice Machine naming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a511c65fa08579c42cbaff0c9af37044e502167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->