### PR TITLE
feat: add `prismic env` commands and CLI-owned active environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
 		"./dist"
 	],
 	"type": "module",
+	"exports": {
+		"./env": "./dist/env.mjs",
+		"./env/register": "./dist/env/register.mjs"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/active-environment.ts
+++ b/src/active-environment.ts
@@ -1,0 +1,99 @@
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { getConfigDir } from "./lib/config-dir";
+import { stringify } from "./lib/json";
+
+// The active environment lives in the CLI, keyed by project so nothing lands in
+// the repo. Reads are synchronous so a framework config can set the environment
+// variable before the framework reads it at build time. This module is published
+// as `prismic/env`, so it stays dependency-light.
+
+const CONFIG_FILENAME = "prismic.config.json";
+
+const ENVIRONMENTS_PATH = new URL(
+	"environments.json",
+	getConfigDir("prismic", process.env.PRISMIC_CONFIG_DIR),
+);
+
+const FRAMEWORK_ENV_VARS: Record<string, string> = {
+	next: "NEXT_PUBLIC_PRISMIC_ENVIRONMENT",
+	nuxt: "NUXT_PUBLIC_PRISMIC_ENVIRONMENT",
+	"@sveltejs/kit": "VITE_PRISMIC_ENVIRONMENT",
+};
+
+export function getActiveEnvironment(): string | undefined {
+	const project = findProjectRoot();
+	if (!project) return undefined;
+	return readState()[project];
+}
+
+export function setActiveEnvironment(domain: string): void {
+	const project = findProjectRoot();
+	if (!project) return;
+	const state = readState();
+	state[project] = domain;
+	writeState(state);
+}
+
+export function unsetActiveEnvironment(): void {
+	const project = findProjectRoot();
+	if (!project) return;
+	const state = readState();
+	if (!(project in state)) return;
+	delete state[project];
+	writeState(state);
+}
+
+export function getFrameworkEnvVar(): string | undefined {
+	const packageJson = readPackageJson();
+	if (!packageJson) return undefined;
+	const dependencies = {
+		...packageJson.dependencies,
+		...packageJson.devDependencies,
+		...packageJson.peerDependencies,
+	};
+	for (const dependency in FRAMEWORK_ENV_VARS) {
+		if (dependency in dependencies) return FRAMEWORK_ENV_VARS[dependency];
+	}
+	return undefined;
+}
+
+function readState(): Record<string, string> {
+	try {
+		return JSON.parse(readFileSync(ENVIRONMENTS_PATH, "utf8"));
+	} catch {
+		return {};
+	}
+}
+
+function writeState(state: Record<string, string>): void {
+	mkdirSync(new URL(".", ENVIRONMENTS_PATH), { recursive: true });
+	writeFileSync(ENVIRONMENTS_PATH, stringify(state));
+}
+
+function findProjectRoot(): string | undefined {
+	return findUpward(CONFIG_FILENAME, (dir) => realpathSync(dir));
+}
+
+type PackageJson = {
+	dependencies?: Record<string, string>;
+	devDependencies?: Record<string, string>;
+	peerDependencies?: Record<string, string>;
+};
+
+function readPackageJson(): PackageJson | undefined {
+	return findUpward("package.json", (dir) =>
+		JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
+	);
+}
+
+function findUpward<T>(filename: string, onFound: (dir: string) => T): T | undefined {
+	let dir = process.cwd();
+	while (true) {
+		if (existsSync(join(dir, filename))) return onFound(dir);
+		const parent = dirname(dir);
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+}

--- a/src/active-environment.ts
+++ b/src/active-environment.ts
@@ -1,7 +1,8 @@
-import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { getConfigDir } from "./lib/config-dir";
+import { findUpwardSync } from "./lib/file";
 import { stringify } from "./lib/json";
 
 // The active environment lives in the CLI, keyed by project so nothing lands in
@@ -73,7 +74,9 @@ function writeState(state: Record<string, string>): void {
 }
 
 function findProjectRoot(): string | undefined {
-	return findUpward(CONFIG_FILENAME, (dir) => realpathSync(dir));
+	const configPath = findUpwardSync(CONFIG_FILENAME);
+	if (!configPath) return undefined;
+	return realpathSync(fileURLToPath(new URL(".", configPath)));
 }
 
 type PackageJson = {
@@ -83,17 +86,11 @@ type PackageJson = {
 };
 
 function readPackageJson(): PackageJson | undefined {
-	return findUpward("package.json", (dir) =>
-		JSON.parse(readFileSync(join(dir, "package.json"), "utf8")),
-	);
-}
-
-function findUpward<T>(filename: string, onFound: (dir: string) => T): T | undefined {
-	let dir = process.cwd();
-	while (true) {
-		if (existsSync(join(dir, filename))) return onFound(dir);
-		const parent = dirname(dir);
-		if (parent === dir) return undefined;
-		dir = parent;
+	const packageJsonPath = findUpwardSync("package.json");
+	if (!packageJsonPath) return undefined;
+	try {
+		return JSON.parse(readFileSync(packageJsonPath, "utf8"));
+	} catch {
+		return undefined;
 	}
 }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -44,7 +44,7 @@ export class NoSupportedFrameworkError extends Error {
 
 // Adds `import "prismic/env/register"` to the first existing framework config so
 // the active environment is applied at build time.
-export async function addRegisterImport(candidates: string[]): Promise<void> {
+export async function addEnvRegisterImport(candidates: string[]): Promise<void> {
 	const projectRoot = await findProjectRoot();
 	for (const candidate of candidates) {
 		const configUrl = new URL(candidate, projectRoot);

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -51,7 +51,7 @@ export async function addRegisterImport(candidates: string[]): Promise<void> {
 		if (!(await exists(configUrl))) continue;
 		const contents = await readFile(configUrl, "utf8");
 		if (!contents.includes("prismic/env/register")) {
-			await writeFile(configUrl, `import "prismic/env/register";\n${contents}`);
+			await writeFile(configUrl, `import "prismic/env/register";\n\n${contents}`);
 		}
 		return;
 	}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,12 +1,12 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { pascalCase } from "change-case";
-import { rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { generateTypes } from "prismic-ts-codegen";
 import { glob } from "tinyglobby";
 
-import { readJsonFile, writeFileRecursive } from "../lib/file";
+import { exists, readJsonFile, writeFileRecursive } from "../lib/file";
 import { stringify } from "../lib/json";
 import { readPackageJson } from "../lib/packageJson";
 import { appendTrailingSlash } from "../lib/url";
@@ -40,6 +40,21 @@ export class NoSupportedFrameworkError extends Error {
 	name = "NoSupportedFrameworkError";
 	message =
 		"No supported framework found. Run this command in a Next.js, Nuxt, or SvelteKit project.";
+}
+
+// Adds `import "prismic/env/register"` to the first existing framework config so
+// the active environment is applied at build time.
+export async function addRegisterImport(candidates: string[]): Promise<void> {
+	const projectRoot = await findProjectRoot();
+	for (const candidate of candidates) {
+		const configUrl = new URL(candidate, projectRoot);
+		if (!(await exists(configUrl))) continue;
+		const contents = await readFile(configUrl, "utf8");
+		if (!contents.includes("prismic/env/register")) {
+			await writeFile(configUrl, `import "prismic/env/register";\n${contents}`);
+		}
+		return;
+	}
 }
 
 export abstract class Adapter {

--- a/src/adapters/nextjs.templates.ts
+++ b/src/adapters/nextjs.templates.ts
@@ -357,7 +357,7 @@ export function prismicIOFileTemplate(args: {
 			/**
 			 * The project's Prismic repository name.
 			 */
-			export const repositoryName = prismicConfig.repositoryName;
+			export const repositoryName = process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 			${createClientContents}
 		`;
@@ -369,7 +369,7 @@ export function prismicIOFileTemplate(args: {
 		/**
 		 * The project's Prismic repository name.
 		 */
-		export const repositoryName = prismicConfig.repositoryName;
+		export const repositoryName = process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 		${createClientContents}
 	`;

--- a/src/adapters/nextjs.ts
+++ b/src/adapters/nextjs.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter, addRegisterImport } from ".";
+import { Adapter, addEnvRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -39,7 +39,7 @@ export class NextJsAdapter extends Adapter {
 		await createPreviewRoute();
 		await createExitPreviewRoute();
 		await createRevalidateRoute();
-		await addRegisterImport(["next.config.ts", "next.config.mjs", "next.config.js"]);
+		await addEnvRegisterImport(["next.config.ts", "next.config.mjs", "next.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/adapters/nextjs.ts
+++ b/src/adapters/nextjs.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter } from ".";
+import { Adapter, addRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -29,6 +29,7 @@ export class NextJsAdapter extends Adapter {
 
 	async setupProject(): Promise<void> {
 		await addDependencies({
+			prismic: `^${await getNpmPackageVersion("prismic")}`,
 			"@prismicio/client": `^${await getNpmPackageVersion("@prismicio/client")}`,
 			"@prismicio/react": `^${await getNpmPackageVersion("@prismicio/react")}`,
 			"@prismicio/next": `^${await getNpmPackageVersion("@prismicio/next")}`,
@@ -38,6 +39,7 @@ export class NextJsAdapter extends Adapter {
 		await createPreviewRoute();
 		await createExitPreviewRoute();
 		await createRevalidateRoute();
+		await addRegisterImport(["next.config.ts", "next.config.mjs", "next.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/adapters/sveltekit.templates.ts
+++ b/src/adapters/sveltekit.templates.ts
@@ -16,7 +16,7 @@ export function prismicIOFileTemplate(args: { typescript: boolean }): string {
 			/**
 			 * The project's Prismic repository name.
 			 */
-			export const repositoryName = prismicConfig.repositoryName;
+			export const repositoryName = import.meta.env.VITE_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 			/**
 			 * Creates a Prismic client for the project's repository. The client is used to
@@ -45,7 +45,7 @@ export function prismicIOFileTemplate(args: { typescript: boolean }): string {
 		/**
 		 * The project's Prismic repository name.
 		 */
-		export const repositoryName = prismicConfig.repositoryName;
+		export const repositoryName = import.meta.env.VITE_PRISMIC_ENVIRONMENT || prismicConfig.repositoryName;
 
 		/**
 		 * Creates a Prismic client for the project's repository. The client is used to

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter } from ".";
+import { Adapter, addRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -31,6 +31,7 @@ export class SvelteKitAdapter extends Adapter {
 
 	async setupProject(): Promise<void> {
 		await addDependencies({
+			prismic: `^${await getNpmPackageVersion("prismic")}`,
 			"@prismicio/client": `^${await getNpmPackageVersion("@prismicio/client")}`,
 			"@prismicio/svelte": `^${await getNpmPackageVersion("@prismicio/svelte")}`,
 		});
@@ -42,6 +43,7 @@ export class SvelteKitAdapter extends Adapter {
 		await createRootLayoutServerFile();
 		await createRootLayoutFile();
 		await modifyViteConfig();
+		await addRegisterImport(["vite.config.ts", "vite.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter, addRegisterImport } from ".";
+import { Adapter, addEnvRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -43,7 +43,7 @@ export class SvelteKitAdapter extends Adapter {
 		await createRootLayoutServerFile();
 		await createRootLayoutFile();
 		await modifyViteConfig();
-		await addRegisterImport(["vite.config.ts", "vite.config.js"]);
+		await addEnvRegisterImport(["vite.config.ts", "vite.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/commands/env-active.ts
+++ b/src/commands/env-active.ts
@@ -1,0 +1,15 @@
+import { createCommand, type CommandConfig } from "../lib/command";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env active",
+	description: `
+		Print the active environment.
+
+		Prints the production environment when no environment is active.
+	`,
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	console.info(await getRepositoryName());
+});

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -1,6 +1,6 @@
 import { getActiveEnvironment } from "../active-environment";
 import { getHost, getToken } from "../auth";
-import { getEnvironments } from "../environments";
+import { getUserEnvironments } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
@@ -23,7 +23,7 @@ export default createCommand(config, async ({ values }) => {
 	const token = await getToken();
 	const host = await getHost();
 
-	const environments = await getEnvironments({ repo: repositoryName, token, host });
+	const environments = await getUserEnvironments({ repo: repositoryName, token, host });
 	const activeDomain = getActiveEnvironment() ?? repositoryName;
 
 	if (json) {

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -1,6 +1,6 @@
 import { getActiveEnvironment } from "../active-environment";
 import { getHost, getToken } from "../auth";
-import { listAvailableEnvironments } from "../environments";
+import { getEnvironments } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { formatTable } from "../lib/string";
@@ -23,7 +23,7 @@ export default createCommand(config, async ({ values }) => {
 	const token = await getToken();
 	const host = await getHost();
 
-	const environments = await listAvailableEnvironments({ repo: repositoryName, token, host });
+	const environments = await getEnvironments({ repo: repositoryName, token, host });
 	const activeDomain = getActiveEnvironment() ?? repositoryName;
 
 	if (json) {

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -1,0 +1,50 @@
+import { getActiveEnvironment } from "../active-environment";
+import { getHost, getToken } from "../auth";
+import { listAvailableEnvironments } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
+import { readConfig } from "../project";
+
+const config = {
+	name: "prismic env list",
+	description: `
+		List the environments available for the project, marking the active one.
+	`,
+	options: {
+		json: { type: "boolean", description: "Output as JSON" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { json } = values;
+
+	const { repositoryName } = await readConfig();
+	const token = await getToken();
+	const host = await getHost();
+
+	const environments = await listAvailableEnvironments({ repo: repositoryName, token, host });
+	const activeDomain = getActiveEnvironment() ?? repositoryName;
+
+	if (json) {
+		const results = environments.map((environment) => ({
+			kind: environment.kind,
+			name: environment.name,
+			domain: environment.domain,
+			active: environment.domain === activeDomain,
+		}));
+		console.info(stringify(results));
+		return;
+	}
+
+	if (environments.length === 0) {
+		console.info("No environments found.");
+		return;
+	}
+
+	const rows = environments.map((environment) => {
+		const activeLabel = environment.domain === activeDomain ? " (active)" : "";
+		return [environment.domain, `${environment.name}${activeLabel}`];
+	});
+	console.info(formatTable(rows, { headers: ["DOMAIN", "NAME"] }));
+});

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -24,14 +24,14 @@ export default createCommand(config, async ({ values }) => {
 	const host = await getHost();
 
 	const environments = await getUserEnvironments({ repo: repositoryName, token, host });
-	const activeDomain = getActiveEnvironment() ?? repositoryName;
+	const activeEnvironment = getActiveEnvironment() ?? repositoryName;
 
 	if (json) {
 		const results = environments.map((environment) => ({
 			kind: environment.kind,
 			name: environment.name,
 			domain: environment.domain,
-			active: environment.domain === activeDomain,
+			active: environment.domain === activeEnvironment,
 		}));
 		console.info(stringify(results));
 		return;
@@ -43,7 +43,7 @@ export default createCommand(config, async ({ values }) => {
 	}
 
 	const rows = environments.map((environment) => {
-		const activeLabel = environment.domain === activeDomain ? " (active)" : "";
+		const activeLabel = environment.domain === activeEnvironment ? " (active)" : "";
 		return [environment.domain, `${environment.name}${activeLabel}`];
 	});
 	console.info(formatTable(rows, { headers: ["DOMAIN", "NAME"] }));

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -1,0 +1,38 @@
+import { setActiveEnvironment, unsetActiveEnvironment } from "../active-environment";
+import { getHost, getToken } from "../auth";
+import { resolveEnvironment } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { readConfig } from "../project";
+
+const config = {
+	name: "prismic env set",
+	description: `
+		Set the active environment for the project.
+
+		The active environment is stored by the CLI and used by every command and by
+		the project at build time. Setting the production environment is the same as
+		\`prismic env unset\`.
+	`,
+	positionals: {
+		name: { description: "Environment domain", required: true },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals }) => {
+	const [name] = positionals;
+
+	const { repositoryName } = await readConfig();
+	const token = await getToken();
+	const host = await getHost();
+
+	const domain = await resolveEnvironment(name, { repo: repositoryName, token, host });
+
+	if (domain === repositoryName) {
+		unsetActiveEnvironment();
+		console.info(`Reset to the production environment "${repositoryName}".`);
+		return;
+	}
+
+	setActiveEnvironment(domain);
+	console.info(`Set the active environment to "${domain}".`);
+});

--- a/src/commands/env-unset.ts
+++ b/src/commands/env-unset.ts
@@ -1,0 +1,18 @@
+import { unsetActiveEnvironment } from "../active-environment";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { readConfig } from "../project";
+
+const config = {
+	name: "prismic env unset",
+	description: `
+		Reset the active environment to the production environment.
+	`,
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const { repositoryName } = await readConfig();
+
+	unsetActiveEnvironment();
+
+	console.info(`Reset to the production environment "${repositoryName}".`);
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,28 @@
+import { createCommandRouter } from "../lib/command";
+import envActive from "./env-active";
+import envList from "./env-list";
+import envSet from "./env-set";
+import envUnset from "./env-unset";
+
+export default createCommandRouter({
+	name: "prismic env",
+	description: "Manage the active environment for a Prismic project.",
+	commands: {
+		set: {
+			handler: envSet,
+			description: "Set the active environment",
+		},
+		unset: {
+			handler: envUnset,
+			description: "Reset to the production environment",
+		},
+		active: {
+			handler: envActive,
+			description: "Print the active environment",
+		},
+		list: {
+			handler: envList,
+			description: "List environments",
+		},
+	},
+});

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,7 +1,7 @@
-import { type Environment, getEnvironments } from "./clients/core";
+import { type Environment, getEnvironments as getAllEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
 
-export async function listAvailableEnvironments(config: {
+export async function getEnvironments(config: {
 	repo: string;
 	token: string | undefined;
 	host: string;
@@ -10,7 +10,7 @@ export async function listAvailableEnvironments(config: {
 
 	const [profile, environments] = await Promise.all([
 		getProfile({ token, host }),
-		getEnvironments({ repo, token, host }),
+		getAllEnvironments({ repo, token, host }),
 	]);
 
 	return environments.filter(
@@ -24,12 +24,12 @@ export async function resolveEnvironment(
 	env: string,
 	config: { repo: string; token: string | undefined; host: string },
 ): Promise<string> {
-	const availableEnvironments = await listAvailableEnvironments(config);
+	const environments = await getEnvironments(config);
 
-	const match = availableEnvironments.find((environment) => environment.domain === env);
+	const match = environments.find((environment) => environment.domain === env);
 	if (match) return match.domain;
 
-	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
+	throw new InvalidEnvironmentError(env, environments, config.repo);
 }
 
 export class InvalidEnvironmentError extends Error {

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,7 +1,7 @@
-import { type Environment, getEnvironments as getAllEnvironments } from "./clients/core";
+import { type Environment, getEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
 
-export async function getEnvironments(config: {
+export async function getUserEnvironments(config: {
 	repo: string;
 	token: string | undefined;
 	host: string;
@@ -10,7 +10,7 @@ export async function getEnvironments(config: {
 
 	const [profile, environments] = await Promise.all([
 		getProfile({ token, host }),
-		getAllEnvironments({ repo, token, host }),
+		getEnvironments({ repo, token, host }),
 	]);
 
 	return environments.filter(
@@ -24,7 +24,7 @@ export async function resolveEnvironment(
 	env: string,
 	config: { repo: string; token: string | undefined; host: string },
 ): Promise<string> {
-	const environments = await getEnvironments(config);
+	const environments = await getUserEnvironments(config);
 
 	const match = environments.find((environment) => environment.domain === env);
 	if (match) return match.domain;

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,10 +1,11 @@
 import { type Environment, getEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
 
-export async function resolveEnvironment(
-	env: string,
-	config: { repo: string; token: string | undefined; host: string },
-): Promise<string> {
+export async function listAvailableEnvironments(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<Environment[]> {
 	const { repo, token, host } = config;
 
 	const [profile, environments] = await Promise.all([
@@ -12,15 +13,23 @@ export async function resolveEnvironment(
 		getEnvironments({ repo, token, host }),
 	]);
 
-	const availableEnvironments = environments.filter(
+	return environments.filter(
 		(environment) =>
 			(environment.kind === "prod" || environment.kind === "stage") &&
 			environment.users.some((user) => user.id === profile.shortId),
 	);
+}
+
+export async function resolveEnvironment(
+	env: string,
+	config: { repo: string; token: string | undefined; host: string },
+): Promise<string> {
+	const availableEnvironments = await listAvailableEnvironments(config);
+
 	const match = availableEnvironments.find((environment) => environment.domain === env);
 	if (match) return match.domain;
 
-	throw new InvalidEnvironmentError(env, availableEnvironments, repo);
+	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
 }
 
 export class InvalidEnvironmentError extends Error {

--- a/src/exports/env.ts
+++ b/src/exports/env.ts
@@ -1,0 +1,1 @@
+export { getActiveEnvironment } from "../active-environment";

--- a/src/exports/register.ts
+++ b/src/exports/register.ts
@@ -1,0 +1,11 @@
+import { getActiveEnvironment, getFrameworkEnvVar } from "../active-environment";
+
+// Side-effect import for a framework config (e.g. `import "prismic/env/register"`).
+// Sets the framework's environment variable to the active environment, leaving an
+// existing value (e.g. from CI) untouched.
+
+const variable = getFrameworkEnvVar();
+const active = getActiveEnvironment();
+if (variable && active && process.env[variable] == null) {
+	process.env[variable] = active;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getAdapter, NoSupportedFrameworkError } from "./adapters";
 import { cleanupLegacyAuthFile, getHost, getToken, spawnTokenRefresh } from "./auth";
 import { getProfile } from "./clients/user";
 import docs from "./commands/docs";
+import envCommand from "./commands/env";
 import field from "./commands/field";
 import gen from "./commands/gen";
 import init from "./commands/init";
@@ -93,6 +94,10 @@ const router = createCommandRouter({
 		status: {
 			handler: status,
 			description: "Show local vs remote model differences",
+		},
+		env: {
+			handler: envCommand,
+			description: "Manage the active environment",
 		},
 		locale: {
 			handler: locale,

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import * as z from "zod/mini";
@@ -35,6 +36,22 @@ export async function findUpward(
 		if (parent.href === dir.href) {
 			return undefined;
 		}
+
+		dir = parent;
+	}
+}
+
+export function findUpwardSync(name: string, config: { start?: URL } = {}): URL | undefined {
+	const { start = pathToFileURL(process.cwd()) } = config;
+
+	let dir = appendTrailingSlash(start);
+
+	while (true) {
+		const path = new URL(name, dir);
+		if (existsSync(path)) return path;
+
+		const parent = new URL("..", dir);
+		if (parent.href === dir.href) return undefined;
 
 		dir = parent;
 	}

--- a/src/lib/packageJson.ts
+++ b/src/lib/packageJson.ts
@@ -75,6 +75,18 @@ const INSTALL_COMMANDS = {
 	bun: ["bun", "install"],
 };
 
+const ADD_COMMANDS: Record<keyof typeof INSTALL_COMMANDS, string> = {
+	npm: "npm install",
+	yarn: "yarn add",
+	pnpm: "pnpm add",
+	bun: "bun add",
+};
+
+export async function getAddCommand(pkg: string): Promise<string> {
+	const packageManager = await detectPackageManager();
+	return `${ADD_COMMANDS[packageManager]} ${pkg}`;
+}
+
 export async function installDependencies(): Promise<void> {
 	const packageJsonPath = await findPackageJson();
 	const cwd = new URL(".", packageJsonPath);

--- a/src/lib/update-notifier.ts
+++ b/src/lib/update-notifier.ts
@@ -6,7 +6,7 @@ import * as z from "zod/mini";
 
 import packageJson from "../../package.json" with { type: "json" };
 import { stringify } from "./json";
-import { getNpmPackageVersion } from "./packageJson";
+import { getAddCommand, getNpmPackageVersion, readPackageJson } from "./packageJson";
 
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
@@ -29,7 +29,14 @@ export async function initUpdateNotifier(options: UpdateNotifierOptions): Promis
 		const currentVersion = packageJson.version;
 
 		if (state?.latestKnownVersion && isNewer(state.latestKnownVersion, currentVersion)) {
-			const message = `Update available: ${currentVersion} → ${state.latestKnownVersion}. Run \`npx ${options.npmPackageName}@latest --version\` to update.`;
+			const isInstalled = await isInstalledAsDependency(options.npmPackageName);
+
+			let updateCommand = `npx ${options.npmPackageName}@latest --version`;
+			if (isInstalled) {
+				updateCommand = await getAddCommand(`${options.npmPackageName}@latest`);
+			}
+
+			const message = `Update available: ${currentVersion} → ${state.latestKnownVersion}. Run \`${updateCommand}\` to update.`;
 			process.on("exit", () => {
 				try {
 					console.error(`\n${message}`);
@@ -46,6 +53,19 @@ export async function initUpdateNotifier(options: UpdateNotifierOptions): Promis
 		}
 	} catch {
 		// Never throw.
+	}
+}
+
+async function isInstalledAsDependency(name: string): Promise<boolean> {
+	try {
+		const packageJson = await readPackageJson();
+		return Boolean(
+			packageJson.dependencies?.[name] ||
+			packageJson.devDependencies?.[name] ||
+			packageJson.peerDependencies?.[name],
+		);
+	} catch {
+		return false;
 	}
 }
 

--- a/src/project.ts
+++ b/src/project.ts
@@ -4,6 +4,7 @@ import { readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as z from "zod/mini";
 
+import { getActiveEnvironment } from "./active-environment";
 import { getRepository } from "./clients/repository";
 import { env } from "./env";
 import { exists, findUpward } from "./lib/file";
@@ -212,6 +213,9 @@ export async function safeGetRepositoryName(): Promise<string | undefined> {
 }
 
 export async function getRepositoryName(): Promise<string> {
+	const activeEnvironment = getActiveEnvironment();
+	if (activeEnvironment) return activeEnvironment;
+
 	try {
 		const config = await readConfig();
 		return config.repositoryName;

--- a/test/env-active.test.ts
+++ b/test/env-active.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["active", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env active [options]");
+});
+
+it("prints the production environment by default", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["active"]);
+	expect(exitCode).toBe(0);
+	expect(stdout.trim()).toBe(repo);
+});

--- a/test/env-list.test.ts
+++ b/test/env-list.test.ts
@@ -1,0 +1,23 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["list", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env list [options]");
+});
+
+it("lists environments and marks the active one", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["list"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+	expect(stdout).toContain("(active)");
+});
+
+it("lists environments as JSON", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["list", "--json"]);
+	expect(exitCode).toBe(0);
+	const parsed = JSON.parse(stdout);
+	expect(parsed).toEqual(
+		expect.arrayContaining([expect.objectContaining({ domain: repo, active: true })]),
+	);
+});

--- a/test/env-set.test.ts
+++ b/test/env-set.test.ts
@@ -1,0 +1,23 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["set", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env set <name> [options]");
+});
+
+it("rejects an unknown environment", async ({ expect, prismic, repo }) => {
+	const { stderr, exitCode } = await prismic("env", ["set", "does-not-exist"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain(`No environments available on repository "${repo}".`);
+});
+
+it("resets to production when set to the production environment", async ({
+	expect,
+	prismic,
+	repo,
+}) => {
+	const { stdout, exitCode } = await prismic("env", ["set", repo]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Reset to the production environment "${repo}".`);
+});

--- a/test/env-unset.test.ts
+++ b/test/env-unset.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["unset", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env unset [options]");
+});
+
+it("resets to the production environment", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["unset"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Reset to the production environment "${repo}".`);
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,8 @@ const TEST = MODE === "test";
 export default defineConfig({
 	entry: {
 		index: "./src/index.ts",
+		env: "./src/exports/env.ts",
+		"env/register": "./src/exports/register.ts",
 		"subprocesses/refreshToken": "./src/subprocesses/refreshToken.ts",
 		"subprocesses/sendSegmentEvents": "./src/subprocesses/sendSegmentEvents.ts",
 		"subprocesses/updateVersionState": "./src/subprocesses/updateVersionState.ts",


### PR DESCRIPTION
Resolves: #209

### Description

Adds `prismic env set/unset/active/list` to pick a project's active environment. The choice lives in CLI-owned state keyed by project, so nothing lands in the repo. `getRepositoryName` resolves it, so every command honors it (`--env`/`--repo` still override).

Sites read the active environment at build time via two exports:

- `prismic/env` — a sync `getActiveEnvironment()`
- `prismic/env/register` — a side-effect import that sets the framework's environment variable

`prismic init` wires the `register` import into the framework config and updates the generated `prismicio` file for Next.js and SvelteKit, and adds `prismic` as a project dependency. Nuxt is out of scope here — `@nuxtjs/prismic` will read the state itself.

This implements the approach from the last comment on #209 (CLI-owned state), not the `.env.local` approach from #210.

Not included, by design: stripping the stale Slice Machine `NEXT_PUBLIC_PRISMIC_ENVIRONMENT` from existing projects' `.env.local`.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

In a Next.js or SvelteKit project:

1. `prismic env list` shows the environments; production is marked `(active)`.
2. `prismic env set <staging-domain>` then `prismic env active` prints the staging domain, and CLI commands (e.g. `prismic pull`) target it.
3. Start the dev server — the site resolves the staging repository via the generated `prismicio` file.
4. `prismic env unset` returns everything to production.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
