### PR TITLE
fix: accept null role in account repository list

### DIFF
--- a/src/clients/user.ts
+++ b/src/clients/user.ts
@@ -10,7 +10,7 @@ const ProfileSchema = z.object({
 		z.object({
 			domain: z.string(),
 			name: z.optional(z.string()),
-			role: z.optional(z.string()),
+			role: z.nullish(z.string()),
 		}),
 	),
 });


### PR DESCRIPTION
Resolves: #203

### Description

Prismic's user-service can return `role: null` for a repository in an account's repository list. The profile schema declared `role` as `string | undefined`, so `null` fails validation. This affects every command that calls `getProfile`, including `status`, `repo list`, `repo view`, and `init`.

`ZodError` is not a handled error type, so the CLI does not print a friendly message. It crashes with an unhandled error and a stack trace. This is what the user sees:

```
$ZodError: [
  {
    "expected": "string",
    "code": "invalid_type",
    "path": [
      "repositories",
      59,
      "role"
    ],
    "message": "Invalid input"
  }
]
    at Module.<anonymous> (.../node_modules/zod/v4/core/parse.js:12:14)
    at .../dist/index.mjs

Node.js v24.13.1
```

The fix widens the schema to accept `null`. The `role` field is only read in `repo list`. Both the JSON and table output already coalesce a nullish value (`repo.role ?? null` and `repo.role ?? ""`), so allowing `null` is safe with no downstream changes.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `prismic status` or `prismic repo list` on an account that has a repository with a null `role`. Before this change the command crashes with the error above. After, it succeeds and shows an empty role.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
