### PR TITLE
fix: support locale-scoped repository roles

### DIFF
--- a/src/clients/user.ts
+++ b/src/clients/user.ts
@@ -10,7 +10,10 @@ const ProfileSchema = z.object({
 		z.object({
 			domain: z.string(),
 			name: z.optional(z.string()),
-			role: z.nullish(z.string()),
+			// A role is a string (e.g. "Owner") for repositories with a single
+			// role, or a record of locale to role (e.g. { "de-de": "Writer" })
+			// for repositories with locale-scoped roles.
+			role: z.optional(z.union([z.string(), z.record(z.string(), z.string())])),
 		}),
 	),
 });

--- a/src/commands/repo-list.ts
+++ b/src/commands/repo-list.ts
@@ -53,7 +53,19 @@ export default createCommand(config, async ({ values }) => {
 
 	const rows = repos.map((repo) => {
 		const name = repo.name || "(no name)";
-		return [repo.domain, name, repo.role ?? ""];
+		return [repo.domain, name, formatRole(repo.role)];
 	});
 	console.info(formatTable(rows, { headers: ["DOMAIN", "NAME", "ROLE"] }));
 });
+
+// A role can be locale-scoped, in which case it is a record of locale to role.
+// Display each role next to its locale, e.g. "Writer (en-us), Editor (de-de)".
+function formatRole(role: string | Record<string, string> | undefined): string {
+	if (typeof role === "string") return role;
+	if (role) {
+		return Object.entries(role)
+			.map(([locale, r]) => `${r} (${locale})`)
+			.join(", ");
+	}
+	return "";
+}


### PR DESCRIPTION
Resolves:

### Description

The user-service profile endpoint returns a repository's `role` as a record of locale to role (e.g. `{ "de-de": "Writer" }`) when the role is locale-scoped, not just a plain string. The schema only allowed a string, so `getProfile` threw a ZodError and crashed every command that reads the profile — `status`, `repo list`, `init`, and others.

The schema now accepts both shapes. In `repo list`, the table renders each role next to its locale (e.g. `Writer (en-us), Editor (de-de)`), and `--json` keeps the raw shape so scripts get the structured locale-to-role mapping.

This supersedes #212, which assumed the crash came from a null role. The real payload had no null — the crashing repository had a locale-keyed record.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

```
DOMAIN          NAME          ROLE
my-blog         My Blog       Owner
demo-maya       Maya's Demo   Writer (de-de)
multi-locale    Multi Locale  Writer (en-us), Editor (de-de)
```

### How to QA

Run `prismic repo list` (and `prismic status`) with an account that has a locale-scoped role on at least one repository. Before this change the command crashed with a ZodError; now it lists repositories, showing the locale next to each scoped role.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible schema widening and CLI display only; no auth or write-path changes.
> 
> **Overview**
> Fixes profile parsing when the user-service returns **locale-scoped** repository roles as a locale→role object instead of a single string, which previously caused `getProfile` to fail Zod validation and break commands that load the profile (`repo list`, `status`, `init`, etc.).
> 
> **`ProfileSchema`** in `user.ts` now accepts `role` as either a string or `Record<string, string>`, with comments documenting both shapes.
> 
> **`repo list`** table output uses a new `formatRole` helper so scoped roles render like `Writer (en-us), Editor (de-de)`; `--json` still emits the raw `role` value for scripting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eff528257d24fe8eb749dacbe437d15f14d6055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->