### PR TITLE
feat: resolve commands against the active environment

### DIFF
--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -19,18 +19,22 @@ const config = {
 	options: {
 		master: { type: "boolean", description: "Set as the master locale" },
 		name: { type: "string", short: "n", description: "Custom display name (for custom locales)" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, master = false, name } = values;
+	const {
+		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
+		master = false,
+		name,
+	} = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await upsertLocale({ id: code, isMaster: master, customName: name }, { repo, token, host });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { removeLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await removeLocale(code, { repo, token, host });

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales, upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { addPreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,14 +18,17 @@ const config = {
 	},
 	options: {
 		name: { type: "string", short: "n", description: "Display name (defaults to hostname)" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name } = values;
+	const { env, name, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
+
+	const token = await getToken();
+	const host = await getHost();
 
 	let parsed: URL;
 	try {
@@ -37,10 +40,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const displayName = name || parsed.hostname;
 	const websiteURL = `${parsed.protocol}//${parsed.host}`;
 	const resolverPath = parsed.pathname === "/" ? undefined : parsed.pathname;
-
-	const token = await getToken();
-	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await addPreview({ name: displayName, websiteURL, resolverPath }, { repo, token, host });

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, getSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	let simulatorUrl;

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, removePreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Preview URL to remove", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	try {

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { setSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -23,14 +23,14 @@ const config = {
 		},
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [urlArg] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	let parsed: URL;
 	try {
@@ -46,7 +46,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await setSimulatorUrl(simulatorUrl, { repo, token, host });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -2,7 +2,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -20,22 +20,20 @@ const config = {
 	`,
 	options: {
 		force: { type: "boolean", short: "f", description: "Overwrite local changes" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, force = false, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
-
-	console.info(`Pulling from repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
+	console.info(`Pulling from repository: ${repo}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),
@@ -140,7 +138,7 @@ export default createCommand(config, async ({ values }) => {
 	await adapter.generateTypes();
 
 	await completeOnboardingStepsSilently({
-		repo: parentRepo,
+		repo,
 		token,
 		host,
 		stepIds: ["connectPrismic"],

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,6 +1,6 @@
-import { pascalCase } from "change-case";
-
 import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
+
+import { pascalCase } from "change-case";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
@@ -16,12 +16,9 @@ import {
 	updateCustomType,
 	updateSlice,
 } from "../clients/custom-types";
-import {
-	completeOnboardingStepsSilently,
-	type OnboardingStep,
-} from "../clients/repository";
+import { completeOnboardingStepsSilently, type OnboardingStep } from "../clients/repository";
 import { getWorkingDocumentsUrlForCustomType, getCustomTypeListUrl } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -40,22 +37,20 @@ const config = {
 	`,
 	options: {
 		force: { type: "boolean", short: "f", description: "Skip safety checks" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, force = false, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
-
-	console.info(`Pushing to repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
+	console.info(`Pushing to repository: ${repo}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),
@@ -166,7 +161,7 @@ export default createCommand(config, async ({ values }) => {
 	}
 	if (onboardingSteps.length > 0) {
 		await completeOnboardingStepsSilently({
-			repo: parentRepo,
+			repo,
 			token,
 			host,
 			stepIds: onboardingSteps,
@@ -201,9 +196,9 @@ async function removeCustomTypeWithDocumentHandling(
 		if (!(await isDocumentsInUseError(error))) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			throw new CommandError(
-				`Could not delete type "${id}": ${errorMessage}"` + 
-					"\nPlease try again, or manually deleting the type at: " + 
-					getCustomTypeListUrl({ repo, host, format: format ?? "custom" })
+				`Could not delete type "${id}": ${errorMessage}"` +
+					"\nPlease try again, or manually deleting the type at: " +
+					getCustomTypeListUrl({ repo, host, format: format ?? "custom" }),
 			);
 		}
 
@@ -213,7 +208,7 @@ async function removeCustomTypeWithDocumentHandling(
 		} catch {
 			throw new CommandError(
 				`Could not check whether type "${id}" has associated pages. ` +
-					"\nPlease try again, or manually delete any associated pages at: " + 
+					"\nPlease try again, or manually delete any associated pages at: " +
 					getWorkingDocumentsUrlForCustomType({ repo, host, customTypeId: id }),
 			);
 		}
@@ -222,7 +217,7 @@ async function removeCustomTypeWithDocumentHandling(
 		const pluralPages = documentCount === 1 ? "page" : "pages";
 		throw new CommandError(
 			`Could not delete type "${id}" because it has${countLabel} associated ${pluralPages}. ` +
-				`\nDelete any associated pages manually before pushing at: ` + 
+				`\nDelete any associated pages manually before pushing at: ` +
 				getWorkingDocumentsUrlForCustomType({ repo, host, customTypeId: id }),
 		);
 	}

--- a/src/commands/repo-set-api-access.ts
+++ b/src/commands/repo-set-api-access.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { type RepositoryAccessLevel, setRepositoryAccess } from "../clients/wroom";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,13 +19,13 @@ const config = {
 		level: { description: `Access level (${VALID_LEVELS.join(", ")})`, required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [level] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo = (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	if (!VALID_LEVELS.includes(level as RepositoryAccessLevel)) {
 		throw new CommandError(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,7 +4,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { getProfile } from "../clients/user";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays, type ArrayDiff } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -22,13 +22,17 @@ const config = {
 		model files with uncommitted git changes that would block pull and push.
 	`,
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo: repoArg } = values;
+	const repoFlag = repoArg ?? env;
+	const environment = repoFlag ? undefined : await getEnvironment();
+	const baseRepo = repoFlag ?? (await getRepositoryName());
+	const repo = environment ?? baseRepo;
 
 	const token = await getToken();
 	const host = await getHost();
@@ -44,14 +48,10 @@ export default createCommand(config, async ({ values }) => {
 			adapter.getSlices(),
 		]);
 
-	let repo = parentRepo;
 	let userEmail: string | undefined;
 	let customTypeOps: ArrayDiff<CustomType> | undefined;
 	let sliceOps: ArrayDiff<SharedSlice> | undefined;
 	if (token) {
-		if (env) {
-			repo = await resolveEnvironment(env, { repo: parentRepo, token, host });
-		}
 		const [profile, remoteCustomTypes, remoteSlices] = await Promise.all([
 			getProfile({ token, host }),
 			getCustomTypes({ repo, token, host }),
@@ -92,9 +92,9 @@ export default createCommand(config, async ({ values }) => {
 			.map((path) => relativePathname(projectRoot, path));
 	}
 
-	console.info(`Repository: ${parentRepo}`);
-	if (env) {
-		console.info(`Environment: ${env}`);
+	console.info(`Repository: ${baseRepo}`);
+	if (environment) {
+		console.info(`Environment: ${environment}`);
 	}
 	if (userEmail) {
 		console.info(`Authenticated as: ${userEmail}`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,7 +6,7 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
 import { env } from "../env";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getRepositoryName } from "../project";
@@ -29,21 +29,17 @@ const config = {
 			description: "Watch for changes and sync continuously",
 			required: true,
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env: envFlag } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
-
-	const repo = envFlag
-		? await resolveEnvironment(envFlag, { repo: parentRepo, token, host })
-		: parentRepo;
 
 	trackCommandStart("sync", { watch: true });
 	process.on("SIGINT", () => {
@@ -53,7 +49,7 @@ export default createCommand(config, async ({ values }) => {
 	});
 
 	console.info(
-		`Watching repository: ${parentRepo}${envFlag ? ` (env: ${envFlag})` : ""} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
+		`Watching repository: ${repo} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
 	);
 
 	let lastHash = "";
@@ -118,7 +114,7 @@ export default createCommand(config, async ({ values }) => {
 
 				if (isInitial) {
 					await completeOnboardingStepsSilently({
-						repo: parentRepo,
+						repo,
 						token,
 						host,
 						stepIds: ["connectPrismic"],

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -5,7 +5,7 @@ import {
 	createWriteToken,
 	getOAuthApps,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -33,15 +33,15 @@ const config = {
 			description: `Name to identify the token (default: "${CLI_APP_NAME}")`,
 		},
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
 	const {
-		repo: parentRepo = await getRepositoryName(),
 		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
 		write,
 		"allow-releases": allowReleases,
 		name = CLI_APP_NAME,
@@ -54,7 +54,6 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let createdToken: string;
 	let scope: string | undefined;

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -5,7 +5,7 @@ import {
 	getOAuthApps,
 	getWriteTokens,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -22,18 +22,17 @@ const config = {
 		token: { description: "Token value", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [tokenValue] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getOAuthApps, getWriteTokens } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { createWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -25,8 +25,8 @@ const config = {
 			short: "t",
 			description: "Trigger events (can be repeated)",
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -54,7 +54,13 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name, secret, trigger = [] } = values;
+	const {
+		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
+		name,
+		secret,
+		trigger = [],
+	} = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -67,7 +73,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	const defaultValue = trigger.length > 0 ? false : true;
 

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { deleteWebhook, getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -24,8 +24,8 @@ const config = {
 			description: "Trigger events (can be repeated)",
 			required: true,
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -41,7 +41,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, trigger = [] } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -54,7 +54,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -56,17 +56,6 @@ export async function getUserEnvironments(config: {
 	return userEnvironments;
 }
 
-export async function resolveEnvironment(
-	env: string,
-	config: { repo: string; token: string | undefined; host: string },
-): Promise<string> {
-	const availableEnvironments = await getUserEnvironments(config);
-	const match = availableEnvironments.find((environment) => environment.domain === env);
-	if (match) return match.domain;
-
-	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
-}
-
 export class InvalidEnvironmentError extends Error {
 	name = "InvalidEnvironmentError";
 	repo: string;

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -20,12 +20,6 @@ it.sequential("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic pull [options]");
 });
 
-it.sequential("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("pull", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
 it.sequential("pulls slices and custom types from remote", async ({
 	expect,
 	project,

--- a/test/push.serial.test.ts
+++ b/test/push.serial.test.ts
@@ -15,12 +15,6 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic push [options]");
 });
 
-it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("push", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
 it("pushes a new local custom type to remote", async ({
 	expect,
 	project,

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -57,20 +57,6 @@ it("reports remote-only models when added remotely but not pulled", async ({
 	expect(stdout).toContain("prismic pull");
 });
 
-it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
-it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {
-	await logout();
-	const { stdout, exitCode } = await prismic("status", ["--repo", repo, "--env", "anything"]);
-	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Repository: ${repo}`);
-	expect(stdout).toContain("Environment: anything");
-});
-
 it("reports differing models when local and remote disagree", async ({
 	expect,
 	project,


### PR DESCRIPTION
Resolves:

> [!NOTE]
> Middle of the stack: #218 → **#219 (this PR)** → #220. Merge #218 first — this PR targets its branch, and #220 targets this one.

### Description

Migrates every repo-facing command (`push`, `pull`, `sync`, `status`, and the `locale`/`preview`/`token`/`webhook` groups) to resolve its target repository in priority order:

1. the `--repo` flag, if passed (`--env` is a deprecated alias, still supported)
2. the active environment, if set (from #218)
3. the project's repository domain (the production default)

`--env` becomes a deprecated alias for `--repo`, and the now-unused `resolveEnvironment` helper is removed.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```sh
prismic env set my-repo-staging
prismic status            # now targets the environment without --env
prismic pull --repo my-other-repo   # --repo still overrides
prismic pull --env my-other-repo    # deprecated alias, still works
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.
