### PR TITLE
chore: env commands integration build (do not merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "prismic",
-	"version": "1.12.2",
+	"version": "1.12.0",
 	"description": "Prismic's official command line tool",
 	"keywords": [
 		"prismic",
@@ -19,6 +19,10 @@
 		"./dist"
 	],
 	"type": "module",
+	"exports": {
+		"./env/register": "./dist/env/register.mjs",
+		"./package.json": "./package.json"
+	},
 	"publishConfig": {
 		"access": "public"
 	},

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,12 +1,12 @@
 import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { pascalCase } from "change-case";
-import { rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import { generateTypes } from "prismic-ts-codegen";
 import { glob } from "tinyglobby";
 
-import { readJsonFile, writeFileRecursive } from "../lib/file";
+import { findFirstFile, readJsonFile, writeFileRecursive } from "../lib/file";
 import { stringify } from "../lib/json";
 import { readPackageJson } from "../lib/packageJson";
 import { appendTrailingSlash } from "../lib/url";
@@ -205,4 +205,26 @@ export abstract class Adapter {
 		await writeFileRecursive(output, types);
 		return output;
 	}
+}
+
+export async function addEnvRegisterImport(configFilenames: string[]): Promise<void> {
+	const projectRoot = await findProjectRoot();
+	const configUrl = await findFirstFile(
+		configFilenames.map((filename) => new URL(filename, projectRoot)),
+	);
+	if (!configUrl) return;
+
+	// The register module uses top-level await, so it can only be
+	// imported from an ESM config file.
+	let isEsm = configUrl.pathname.endsWith(".mjs") || configUrl.pathname.endsWith(".ts");
+	if (!isEsm) {
+		const packageJson = await readPackageJson();
+		isEsm = packageJson.type === "module";
+	}
+	if (!isEsm) return;
+
+	const statement = 'import "prismic/env/register";';
+	const contents = await readFile(configUrl, "utf8");
+	if (contents.includes(statement)) return;
+	await writeFile(configUrl, `${statement}\n\n${contents}`);
 }

--- a/src/adapters/nextjs.ts
+++ b/src/adapters/nextjs.ts
@@ -5,7 +5,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter } from ".";
+import { Adapter, addEnvRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -38,6 +38,7 @@ export class NextJsAdapter extends Adapter {
 		await createPreviewRoute();
 		await createExitPreviewRoute();
 		await createRevalidateRoute();
+		await addEnvRegisterImport(["next.config.mjs", "next.config.ts", "next.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/adapters/nuxt.ts
+++ b/src/adapters/nuxt.ts
@@ -6,7 +6,7 @@ import { readFile, rm } from "node:fs/promises";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter } from ".";
+import { Adapter, addEnvRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -31,6 +31,7 @@ export class NuxtAdapter extends Adapter {
 		await createSliceSimulatorPage();
 		await moveOrDeleteAppVue();
 		await modifySliceLibraryPath(this);
+		await addEnvRegisterImport(["nuxt.config.ts", "nuxt.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -7,7 +7,7 @@ import { createRequire } from "node:module";
 import { relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { Adapter } from ".";
+import { Adapter, addEnvRegisterImport } from ".";
 import { getHost, getToken } from "../auth";
 import { addPreview, getPreviews, getSimulatorUrl, setSimulatorUrl } from "../clients/core";
 import { exists, writeFileRecursive } from "../lib/file";
@@ -42,6 +42,7 @@ export class SvelteKitAdapter extends Adapter {
 		await createRootLayoutServerFile();
 		await createRootLayoutFile();
 		await modifyViteConfig();
+		await addEnvRegisterImport(["vite.config.ts", "vite.config.js"]);
 	}
 
 	async onProjectInitialized(): Promise<void> {

--- a/src/commands/env-active.ts
+++ b/src/commands/env-active.ts
@@ -1,0 +1,13 @@
+import { getEnvironment } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env active",
+	description: "Print the active environment.",
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const activeEnvironment = (await getEnvironment()) ?? (await getRepositoryName());
+	console.info(activeEnvironment);
+});

--- a/src/commands/env-list.ts
+++ b/src/commands/env-list.ts
@@ -1,0 +1,44 @@
+import { getHost, getToken } from "../auth";
+import { getEnvironment, getUserEnvironments } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { stringify } from "../lib/json";
+import { formatTable } from "../lib/string";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env list",
+	description: "List the environments available for the project.",
+	options: {
+		json: { type: "boolean", description: "Output as JSON" },
+		repo: { type: "string", short: "r", description: "Repository domain" },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ values }) => {
+	const { json, repo = await getRepositoryName() } = values;
+
+	const token = await getToken();
+	const host = await getHost();
+	const environments = await getUserEnvironments({ repo, token, host });
+
+	const activeEnvironment = (await getEnvironment()) ?? (await getRepositoryName());
+
+	if (json) {
+		const results = environments.map((environment) => ({
+			domain: environment.domain,
+			kind: environment.kind,
+			active: environment.domain === activeEnvironment,
+		}));
+		console.info(stringify(results));
+		return;
+	}
+
+	const rows = environments.map((environment) => {
+		return [
+			environment.domain,
+			environment.kind,
+			environment.domain === activeEnvironment ? "*" : "",
+		];
+	});
+	console.info(formatTable(rows, { headers: ["DOMAIN", "KIND", "ACTIVE"] }));
+});

--- a/src/commands/env-set.ts
+++ b/src/commands/env-set.ts
@@ -1,0 +1,33 @@
+import { getHost, getToken } from "../auth";
+import { getUserEnvironments, InvalidEnvironmentError, saveEnvironment } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env set",
+	description: "Set the active environment.",
+	positionals: {
+		env: { description: "Environment domain", required: true },
+	},
+} satisfies CommandConfig;
+
+export default createCommand(config, async ({ positionals }) => {
+	const [env] = positionals;
+
+	const repo = await getRepositoryName();
+	const token = await getToken();
+	const host = await getHost();
+	const environments = await getUserEnvironments({ repo, token, host });
+
+	const validEnvironment = environments.some((environment) => environment.domain === env);
+	if (!validEnvironment) throw new InvalidEnvironmentError(env, environments, repo);
+
+	if (env === repo) {
+		await saveEnvironment(undefined);
+		console.info(`Reset to the production environment "${repo}".`);
+		return;
+	}
+
+	await saveEnvironment(env);
+	console.info(`Set the active environment to "${env}".`);
+});

--- a/src/commands/env-unset.ts
+++ b/src/commands/env-unset.ts
@@ -1,0 +1,14 @@
+import { saveEnvironment } from "../environments";
+import { createCommand, type CommandConfig } from "../lib/command";
+import { getRepositoryName } from "../project";
+
+const config = {
+	name: "prismic env unset",
+	description: "Reset the active environment to the production environment.",
+} satisfies CommandConfig;
+
+export default createCommand(config, async () => {
+	const repo = await getRepositoryName();
+	await saveEnvironment(undefined);
+	console.info(`Reset to the production environment "${repo}".`);
+});

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -1,0 +1,28 @@
+import { createCommandRouter } from "../lib/command";
+import envActive from "./env-active";
+import envList from "./env-list";
+import envSet from "./env-set";
+import envUnset from "./env-unset";
+
+export default createCommandRouter({
+	name: "prismic env",
+	description: "Manage the active environment for a Prismic project.",
+	commands: {
+		set: {
+			handler: envSet,
+			description: "Set the active environment",
+		},
+		unset: {
+			handler: envUnset,
+			description: "Reset to the production environment",
+		},
+		active: {
+			handler: envActive,
+			description: "Print the active environment",
+		},
+		list: {
+			handler: envList,
+			description: "List environments",
+		},
+	},
+});

--- a/src/commands/locale-add.ts
+++ b/src/commands/locale-add.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -19,18 +19,22 @@ const config = {
 	options: {
 		master: { type: "boolean", description: "Set as the master locale" },
 		name: { type: "string", short: "n", description: "Custom display name (for custom locales)" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, master = false, name } = values;
+	const {
+		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
+		master = false,
+		name,
+	} = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await upsertLocale({ id: code, isMaster: master, customName: name }, { repo, token, host });

--- a/src/commands/locale-list.ts
+++ b/src/commands/locale-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/locale-remove.ts
+++ b/src/commands/locale-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { removeLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await removeLocale(code, { repo, token, host });

--- a/src/commands/locale-set-master.ts
+++ b/src/commands/locale-set-master.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getLocales, upsertLocale } from "../clients/locale";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		code: { description: "Locale code (e.g. en-us, fr-fr)", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [code] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let locales;
 	try {

--- a/src/commands/preview-add.ts
+++ b/src/commands/preview-add.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { addPreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,14 +18,17 @@ const config = {
 	},
 	options: {
 		name: { type: "string", short: "n", description: "Display name (defaults to hostname)" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name } = values;
+	const { env, name, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
+
+	const token = await getToken();
+	const host = await getHost();
 
 	let parsed: URL;
 	try {
@@ -37,10 +40,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 	const displayName = name || parsed.hostname;
 	const websiteURL = `${parsed.protocol}//${parsed.host}`;
 	const resolverPath = parsed.pathname === "/" ? undefined : parsed.pathname;
-
-	const token = await getToken();
-	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await addPreview({ name: displayName, websiteURL, resolverPath }, { repo, token, host });

--- a/src/commands/preview-list.ts
+++ b/src/commands/preview-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, getSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	let simulatorUrl;

--- a/src/commands/preview-remove.ts
+++ b/src/commands/preview-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getPreviews, removePreview } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Preview URL to remove", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [previewUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let previews;
 	try {

--- a/src/commands/preview-set-simulator.ts
+++ b/src/commands/preview-set-simulator.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { setSimulatorUrl } from "../clients/core";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -23,14 +23,14 @@ const config = {
 		},
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [urlArg] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	let parsed: URL;
 	try {
@@ -46,7 +46,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	try {
 		await setSimulatorUrl(simulatorUrl, { repo, token, host });

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -2,7 +2,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -20,22 +20,20 @@ const config = {
 	`,
 	options: {
 		force: { type: "boolean", short: "f", description: "Overwrite local changes" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, force = false, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
-
-	console.info(`Pulling from repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
+	console.info(`Pulling from repository: ${repo}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),
@@ -140,7 +138,7 @@ export default createCommand(config, async ({ values }) => {
 	await adapter.generateTypes();
 
 	await completeOnboardingStepsSilently({
-		repo: parentRepo,
+		repo,
 		token,
 		host,
 		stepIds: ["connectPrismic"],

--- a/src/commands/push.ts
+++ b/src/commands/push.ts
@@ -1,6 +1,6 @@
-import { pascalCase } from "change-case";
-
 import type { CustomType } from "@prismicio/types-internal/lib/customtypes";
+
+import { pascalCase } from "change-case";
 
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
@@ -16,12 +16,9 @@ import {
 	updateCustomType,
 	updateSlice,
 } from "../clients/custom-types";
-import {
-	completeOnboardingStepsSilently,
-	type OnboardingStep,
-} from "../clients/repository";
+import { completeOnboardingStepsSilently, type OnboardingStep } from "../clients/repository";
 import { getWorkingDocumentsUrlForCustomType, getCustomTypeListUrl } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -40,22 +37,20 @@ const config = {
 	`,
 	options: {
 		force: { type: "boolean", short: "f", description: "Skip safety checks" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { force = false, repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, force = false, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
 	const projectRoot = await findProjectRoot();
 
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
-
-	console.info(`Pushing to repository: ${parentRepo}${env ? ` (env: ${env})` : ""}`);
+	console.info(`Pushing to repository: ${repo}`);
 
 	const [gitRoot, customTypeLibraries, sliceLibraries] = await Promise.all([
 		getGitRoot(projectRoot),
@@ -166,7 +161,7 @@ export default createCommand(config, async ({ values }) => {
 	}
 	if (onboardingSteps.length > 0) {
 		await completeOnboardingStepsSilently({
-			repo: parentRepo,
+			repo,
 			token,
 			host,
 			stepIds: onboardingSteps,
@@ -201,9 +196,9 @@ async function removeCustomTypeWithDocumentHandling(
 		if (!(await isDocumentsInUseError(error))) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 			throw new CommandError(
-				`Could not delete type "${id}": ${errorMessage}"` + 
-					"\nPlease try again, or manually deleting the type at: " + 
-					getCustomTypeListUrl({ repo, host, format: format ?? "custom" })
+				`Could not delete type "${id}": ${errorMessage}"` +
+					"\nPlease try again, or manually deleting the type at: " +
+					getCustomTypeListUrl({ repo, host, format: format ?? "custom" }),
 			);
 		}
 
@@ -213,7 +208,7 @@ async function removeCustomTypeWithDocumentHandling(
 		} catch {
 			throw new CommandError(
 				`Could not check whether type "${id}" has associated pages. ` +
-					"\nPlease try again, or manually delete any associated pages at: " + 
+					"\nPlease try again, or manually delete any associated pages at: " +
 					getWorkingDocumentsUrlForCustomType({ repo, host, customTypeId: id }),
 			);
 		}
@@ -222,7 +217,7 @@ async function removeCustomTypeWithDocumentHandling(
 		const pluralPages = documentCount === 1 ? "page" : "pages";
 		throw new CommandError(
 			`Could not delete type "${id}" because it has${countLabel} associated ${pluralPages}. ` +
-				`\nDelete any associated pages manually before pushing at: ` + 
+				`\nDelete any associated pages manually before pushing at: ` +
 				getWorkingDocumentsUrlForCustomType({ repo, host, customTypeId: id }),
 		);
 	}

--- a/src/commands/repo-set-api-access.ts
+++ b/src/commands/repo-set-api-access.ts
@@ -1,5 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { type RepositoryAccessLevel, setRepositoryAccess } from "../clients/wroom";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -18,13 +19,13 @@ const config = {
 		level: { description: `Access level (${VALID_LEVELS.join(", ")})`, required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [level] = positionals;
-	const { repo = await getRepositoryName() } = values;
+	const { repo = (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	if (!VALID_LEVELS.includes(level as RepositoryAccessLevel)) {
 		throw new CommandError(

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -4,7 +4,7 @@ import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { getProfile } from "../clients/user";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays, type ArrayDiff } from "../lib/diff";
 import { getDirtyPaths, getGitRoot } from "../lib/git";
@@ -22,13 +22,17 @@ const config = {
 		model files with uncommitted git changes that would block pull and push.
 	`,
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo: repoArg } = values;
+	const repoFlag = repoArg ?? env;
+	const environment = repoFlag ? undefined : await getEnvironment();
+	const baseRepo = repoFlag ?? (await getRepositoryName());
+	const repo = environment ?? baseRepo;
 
 	const token = await getToken();
 	const host = await getHost();
@@ -44,14 +48,10 @@ export default createCommand(config, async ({ values }) => {
 			adapter.getSlices(),
 		]);
 
-	let repo = parentRepo;
 	let userEmail: string | undefined;
 	let customTypeOps: ArrayDiff<CustomType> | undefined;
 	let sliceOps: ArrayDiff<SharedSlice> | undefined;
 	if (token) {
-		if (env) {
-			repo = await resolveEnvironment(env, { repo: parentRepo, token, host });
-		}
 		const [profile, remoteCustomTypes, remoteSlices] = await Promise.all([
 			getProfile({ token, host }),
 			getCustomTypes({ repo, token, host }),
@@ -92,9 +92,9 @@ export default createCommand(config, async ({ values }) => {
 			.map((path) => relativePathname(projectRoot, path));
 	}
 
-	console.info(`Repository: ${parentRepo}`);
-	if (env) {
-		console.info(`Environment: ${env}`);
+	console.info(`Repository: ${baseRepo}`);
+	if (environment) {
+		console.info(`Environment: ${environment}`);
 	}
 	if (userEmail) {
 		console.info(`Authenticated as: ${userEmail}`);

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -6,7 +6,7 @@ import { getHost, getToken } from "../auth";
 import { getCustomTypes, getSlices } from "../clients/custom-types";
 import { completeOnboardingStepsSilently } from "../clients/repository";
 import { env } from "../env";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
 import { getRepositoryName } from "../project";
@@ -29,21 +29,17 @@ const config = {
 			description: "Watch for changes and sync continuously",
 			required: true,
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env: envFlag } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
 	const adapter = await getAdapter();
-
-	const repo = envFlag
-		? await resolveEnvironment(envFlag, { repo: parentRepo, token, host })
-		: parentRepo;
 
 	trackCommandStart("sync", { watch: true });
 	process.on("SIGINT", () => {
@@ -53,7 +49,7 @@ export default createCommand(config, async ({ values }) => {
 	});
 
 	console.info(
-		`Watching repository: ${parentRepo}${envFlag ? ` (env: ${envFlag})` : ""} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
+		`Watching repository: ${repo} (polling every ${POLL_INTERVAL_MS / 1000}s, Ctrl+C to stop)`,
 	);
 
 	let lastHash = "";
@@ -118,7 +114,7 @@ export default createCommand(config, async ({ values }) => {
 
 				if (isInitial) {
 					await completeOnboardingStepsSilently({
-						repo: parentRepo,
+						repo,
 						token,
 						host,
 						stepIds: ["connectPrismic"],

--- a/src/commands/token-create.ts
+++ b/src/commands/token-create.ts
@@ -5,7 +5,7 @@ import {
 	createWriteToken,
 	getOAuthApps,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -33,15 +33,15 @@ const config = {
 			description: `Name to identify the token (default: "${CLI_APP_NAME}")`,
 		},
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
 	const {
-		repo: parentRepo = await getRepositoryName(),
 		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
 		write,
 		"allow-releases": allowReleases,
 		name = CLI_APP_NAME,
@@ -54,7 +54,6 @@ export default createCommand(config, async ({ values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let createdToken: string;
 	let scope: string | undefined;

--- a/src/commands/token-delete.ts
+++ b/src/commands/token-delete.ts
@@ -5,7 +5,7 @@ import {
 	getOAuthApps,
 	getWriteTokens,
 } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -22,18 +22,17 @@ const config = {
 		token: { description: "Token value", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [tokenValue] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/token-list.ts
+++ b/src/commands/token-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getOAuthApps, getWriteTokens } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	let apps;
 	let writeTokensInfo;

--- a/src/commands/webhook-create.ts
+++ b/src/commands/webhook-create.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { createWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -25,8 +25,8 @@ const config = {
 			short: "t",
 			description: "Trigger events (can be repeated)",
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -54,7 +54,13 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, name, secret, trigger = [] } = values;
+	const {
+		env,
+		repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()),
+		name,
+		secret,
+		trigger = [],
+	} = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -67,7 +73,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 
 	const defaultValue = trigger.length > 0 ? false : true;
 

--- a/src/commands/webhook-disable.ts
+++ b/src/commands/webhook-disable.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-enable.ts
+++ b/src/commands/webhook-enable.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-list.ts
+++ b/src/commands/webhook-list.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { stringify } from "../lib/json";
 import { UnknownRequestError } from "../lib/request";
@@ -17,17 +17,16 @@ const config = {
 	`,
 	options: {
 		json: { type: "boolean", description: "Output as JSON" },
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ values }) => {
-	const { repo: parentRepo = await getRepositoryName(), env, json } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), json } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-remove.ts
+++ b/src/commands/webhook-remove.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { deleteWebhook, getWebhooks } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-set-triggers.ts
+++ b/src/commands/webhook-set-triggers.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, updateWebhook, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -24,8 +24,8 @@ const config = {
 			description: "Trigger events (can be repeated)",
 			required: true,
 		},
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 	sections: {
 		TRIGGERS: `
@@ -41,7 +41,7 @@ const config = {
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env, trigger = [] } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()), trigger = [] } = values;
 
 	// Validate triggers
 	for (const t of trigger) {
@@ -54,7 +54,6 @@ export default createCommand(config, async ({ positionals, values }) => {
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/commands/webhook-view.ts
+++ b/src/commands/webhook-view.ts
@@ -1,6 +1,6 @@
 import { getHost, getToken } from "../auth";
 import { getWebhooks, WEBHOOK_TRIGGERS } from "../clients/wroom";
-import { resolveEnvironment } from "../environments";
+import { getEnvironment } from "../environments";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { UnknownRequestError } from "../lib/request";
 import { getRepositoryName } from "../project";
@@ -17,18 +17,17 @@ const config = {
 		url: { description: "Webhook URL", required: true },
 	},
 	options: {
-		repo: { type: "string", short: "r", description: "Repository domain" },
-		env: { type: "string", short: "e", description: "Environment domain" },
+		repo: { type: "string", short: "r", description: "Repository or environment domain" },
+		env: { type: "string", short: "e", description: "(deprecated) Alias for --repo" },
 	},
 } satisfies CommandConfig;
 
 export default createCommand(config, async ({ positionals, values }) => {
 	const [webhookUrl] = positionals;
-	const { repo: parentRepo = await getRepositoryName(), env } = values;
+	const { env, repo = env ?? (await getEnvironment()) ?? (await getRepositoryName()) } = values;
 
 	const token = await getToken();
 	const host = await getHost();
-	const repo = env ? await resolveEnvironment(env, { repo: parentRepo, token, host }) : parentRepo;
 	let webhooks;
 	try {
 		webhooks = await getWebhooks({ repo, token, host });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,4 +4,5 @@ import { getConfigDir } from "./lib/config-dir";
 export const CONFIG_DIR = getConfigDir("prismic", env.PRISMIC_CONFIG_DIR);
 
 export const CREDENTIALS_PATH = new URL("credentials.json", CONFIG_DIR);
+export const ENVIRONMENTS_PATH = new URL("environments.json", CONFIG_DIR);
 export const UPDATE_NOTIFIER_STATE_PATH = new URL("update-notifier.json", CONFIG_DIR);

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -1,26 +1,70 @@
+import { readFile } from "node:fs/promises";
+import * as z from "zod/mini";
+
 import { type Environment, getEnvironments } from "./clients/core";
 import { getProfile } from "./clients/user";
+import { ENVIRONMENTS_PATH } from "./config";
+import { writeFileRecursive } from "./lib/file";
+import { stringify } from "./lib/json";
+import { findProjectRoot } from "./project";
+
+const EnvironmentsSchema = z.partialRecord(z.string(), z.string());
+type Environments = z.infer<typeof EnvironmentsSchema>;
+
+export async function getEnvironment(): Promise<string | undefined> {
+	const projectRoot = await findProjectRoot();
+	const environments = await readEnvironments();
+	return environments[projectRoot.toString()];
+}
+
+export async function saveEnvironment(environment: string | undefined): Promise<void> {
+	const projectRoot = await findProjectRoot();
+	const environments = await readEnvironments();
+	if (environment) {
+		environments[projectRoot.toString()] = environment;
+	} else {
+		delete environments[projectRoot.toString()];
+	}
+	await writeFileRecursive(ENVIRONMENTS_PATH, stringify(environments));
+}
+
+async function readEnvironments(): Promise<Environments> {
+	try {
+		const contents = await readFile(ENVIRONMENTS_PATH, "utf-8");
+		const json = JSON.parse(contents);
+		return z.parse(EnvironmentsSchema, json);
+	} catch {
+		return {};
+	}
+}
+
+export async function getUserEnvironments(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<Environment[]> {
+	const { repo, token, host } = config;
+	const [profile, environments] = await Promise.all([
+		getProfile({ token, host }),
+		getEnvironments({ repo, token, host }),
+	]);
+	const userEnvironments = environments.filter(
+		(environment) =>
+			(environment.kind === "prod" || environment.kind === "stage") &&
+			environment.users.some((user) => user.id === profile.shortId),
+	);
+	return userEnvironments;
+}
 
 export async function resolveEnvironment(
 	env: string,
 	config: { repo: string; token: string | undefined; host: string },
 ): Promise<string> {
-	const { repo, token, host } = config;
-
-	const [profile, environments] = await Promise.all([
-		getProfile({ token, host }),
-		getEnvironments({ repo, token, host }),
-	]);
-
-	const availableEnvironments = environments.filter(
-		(environment) =>
-			(environment.kind === "prod" || environment.kind === "stage") &&
-			environment.users.some((user) => user.id === profile.shortId),
-	);
+	const availableEnvironments = await getUserEnvironments(config);
 	const match = availableEnvironments.find((environment) => environment.domain === env);
 	if (match) return match.domain;
 
-	throw new InvalidEnvironmentError(env, availableEnvironments, repo);
+	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
 }
 
 export class InvalidEnvironmentError extends Error {

--- a/src/environments.ts
+++ b/src/environments.ts
@@ -56,17 +56,6 @@ export async function getUserEnvironments(config: {
 	return userEnvironments;
 }
 
-export async function resolveEnvironment(
-	env: string,
-	config: { repo: string; token: string | undefined; host: string },
-): Promise<string> {
-	const availableEnvironments = await getUserEnvironments(config);
-	const match = availableEnvironments.find((environment) => environment.domain === env);
-	if (match) return match.domain;
-
-	throw new InvalidEnvironmentError(env, availableEnvironments, config.repo);
-}
-
 export class InvalidEnvironmentError extends Error {
 	name = "InvalidEnvironmentError";
 	repo: string;

--- a/src/exports/env/register.ts
+++ b/src/exports/env/register.ts
@@ -1,0 +1,8 @@
+import { getEnvironment } from "../../environments";
+
+const environment = await getEnvironment();
+if (environment) {
+	process.env.NEXT_PUBLIC_PRISMIC_ENVIRONMENT ??= environment;
+	process.env.PUBLIC_PRISMIC_ENVIRONMENT ??= environment;
+	process.env.NUXT_PUBLIC_PRISMIC_ENVIRONMENT ??= environment;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { getAdapter, NoSupportedFrameworkError } from "./adapters";
 import { cleanupLegacyAuthFile, getHost, getToken, spawnTokenRefresh } from "./auth";
 import { getProfile } from "./clients/user";
 import docs from "./commands/docs";
+import envCommand from "./commands/env";
 import field from "./commands/field";
 import gen from "./commands/gen";
 import init from "./commands/init";
@@ -93,6 +94,10 @@ const router = createCommandRouter({
 		status: {
 			handler: status,
 			description: "Show local vs remote model differences",
+		},
+		env: {
+			handler: envCommand,
+			description: "Manage the active environment",
 		},
 		locale: {
 			handler: locale,

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -49,6 +49,12 @@ export async function exists(path: URL): Promise<boolean> {
 	}
 }
 
+export async function findFirstFile(candidates: URL[]): Promise<URL | undefined> {
+	for (const candidate of candidates) {
+		if (await exists(candidate)) return candidate;
+	}
+}
+
 export async function writeFileRecursive(
 	path: URL,
 	data: Parameters<typeof writeFile>[1],

--- a/src/lib/packageJson.ts
+++ b/src/lib/packageJson.ts
@@ -12,6 +12,7 @@ const PackageJsonSchema = z.object({
 	devDependencies: z.optional(z.record(z.string(), z.string())),
 	peerDependencies: z.optional(z.record(z.string(), z.string())),
 	packageManager: z.optional(z.string()),
+	type: z.optional(z.string()),
 });
 type PackageJson = z.infer<typeof PackageJsonSchema>;
 

--- a/test/env-active.test.ts
+++ b/test/env-active.test.ts
@@ -1,0 +1,26 @@
+import { writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["active", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env active [options]");
+});
+
+it("prints a configured environment", async ({ expect, prismic, home, project }) => {
+	await writeFile(
+		new URL(".config/prismic/environments.json", home),
+		JSON.stringify({ [project.toString()]: "my-stage-env" }),
+	);
+
+	const { stdout, exitCode } = await prismic("env", ["active"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("my-stage-env");
+});
+
+it("defaults to the production environment", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["active"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+});

--- a/test/env-list.test.ts
+++ b/test/env-list.test.ts
@@ -1,0 +1,25 @@
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["list", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env list [options]");
+});
+
+it("lists environments", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["list"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(repo);
+});
+
+it("lists environments as JSON", async ({ expect, prismic, repo }) => {
+	const { stdout, exitCode } = await prismic("env", ["list", "--json"]);
+	expect(exitCode).toBe(0);
+	const parsed = JSON.parse(stdout);
+	expect(parsed).toEqual(
+		expect.arrayContaining([expect.objectContaining({ domain: repo, kind: "prod" })]),
+	);
+});
+
+// TODO: test listing with a stage environment present and marked active once we
+// can create environments on the test repo.

--- a/test/env-register.serial.test.ts
+++ b/test/env-register.serial.test.ts
@@ -1,0 +1,34 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { vi } from "vitest";
+
+import { it } from "./it";
+
+const REGISTER = fileURLToPath(new URL("../dist/env/register.mjs", import.meta.url));
+
+const ENV_VARS = [
+	"NEXT_PUBLIC_PRISMIC_ENVIRONMENT",
+	"PUBLIC_PRISMIC_ENVIRONMENT",
+	"NUXT_PUBLIC_PRISMIC_ENVIRONMENT",
+] as const;
+
+it("does not set env vars when no environment is configured", async ({ expect, home, project }) => {
+	process.chdir(fileURLToPath(project));
+	vi.stubEnv("PRISMIC_CONFIG_DIR", fileURLToPath(new URL(".config/prismic/", home)));
+	vi.resetModules();
+	await import(REGISTER);
+	for (const key of ENV_VARS) expect(process.env[key]).toBeUndefined();
+});
+
+it("sets env vars when an environment is configured", async ({ expect, home, project }) => {
+	process.chdir(fileURLToPath(project));
+	vi.stubEnv("PRISMIC_CONFIG_DIR", fileURLToPath(new URL(".config/prismic/", home)));
+	await mkdir(new URL(".config/prismic/", home), { recursive: true });
+	await writeFile(
+		new URL(".config/prismic/environments.json", home),
+		JSON.stringify({ [project.toString()]: "my-stage-env" }),
+	);
+	vi.resetModules();
+	await import(REGISTER);
+	for (const key of ENV_VARS) expect(process.env[key]).toBe("my-stage-env");
+});

--- a/test/env-set.test.ts
+++ b/test/env-set.test.ts
@@ -1,0 +1,34 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["set", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env set <env> [options]");
+});
+
+// TODO: test setting the active environment to a stage environment (the common
+// happy path) once we can create environments on the test repo.
+
+it("resets to the production environment", async ({ expect, prismic, repo, home, project }) => {
+	await writeFile(
+		new URL(".config/prismic/environments.json", home),
+		JSON.stringify({ [project.toString()]: "my-stage-env" }),
+	);
+
+	const { stdout, exitCode } = await prismic("env", ["set", repo]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Reset to the production environment "${repo}".`);
+
+	const after = await readFile(new URL(".config/prismic/environments.json", home), "utf8").catch(
+		() => "{}",
+	);
+	expect(after).not.toContain("my-stage-env");
+});
+
+it("errors on an invalid environment", async ({ expect, prismic, repo }) => {
+	const { stderr, exitCode } = await prismic("env", ["set", "not-a-real-env"]);
+	expect(exitCode).toBe(1);
+	expect(stderr).toContain(repo);
+});

--- a/test/env-unset.test.ts
+++ b/test/env-unset.test.ts
@@ -1,0 +1,25 @@
+import { readFile, writeFile } from "node:fs/promises";
+
+import { it } from "./it";
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["unset", "--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env unset [options]");
+});
+
+it("resets to the production environment", async ({ expect, prismic, repo, home, project }) => {
+	await writeFile(
+		new URL(".config/prismic/environments.json", home),
+		JSON.stringify({ [project.toString()]: "my-stage-env" }),
+	);
+
+	const { stdout, exitCode } = await prismic("env", ["unset"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain(`Reset to the production environment "${repo}".`);
+
+	const after = await readFile(new URL(".config/prismic/environments.json", home), "utf8").catch(
+		() => "{}",
+	);
+	expect(after).not.toContain("my-stage-env");
+});

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,13 @@
+import { it } from "./it";
+
+it("prints help by default", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env");
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});
+
+it("supports --help", async ({ expect, prismic }) => {
+	const { stdout, exitCode } = await prismic("env", ["--help"]);
+	expect(exitCode).toBe(0);
+	expect(stdout).toContain("prismic env <command> [options]");
+});

--- a/test/gen-setup.test.ts
+++ b/test/gen-setup.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 
 import { it } from "./it";
 
@@ -59,6 +59,37 @@ it("generates valid script tags for SvelteKit", { timeout: 30_000 }, async ({
 	await expect(project).toHaveFile("src/routes/slice-simulator/+page.svelte", {
 		contains: "</script>",
 	});
+});
+
+it("adds the env register import to the framework config", { timeout: 30_000 }, async ({
+	expect,
+	project,
+	prismic,
+}) => {
+	const configPath = new URL("next.config.mjs", project);
+	await writeFile(configPath, "export default {};\n");
+
+	const { exitCode } = await prismic("gen", ["setup", "--no-install"]);
+	expect(exitCode).toBe(0);
+
+	const contents = await readFile(configPath, "utf8");
+	expect(contents).toBe('import "prismic/env/register";\n\nexport default {};\n');
+});
+
+it("skips the env register import for a CommonJS config", { timeout: 30_000 }, async ({
+	expect,
+	project,
+	prismic,
+}) => {
+	// The fixture's package.json has no "type": "module", so a .js config is CommonJS.
+	const configPath = new URL("next.config.js", project);
+	await writeFile(configPath, "module.exports = {};\n");
+
+	const { exitCode } = await prismic("gen", ["setup", "--no-install"]);
+	expect(exitCode).toBe(0);
+
+	const contents = await readFile(configPath, "utf8");
+	expect(contents).toBe("module.exports = {};\n");
 });
 
 it("skips installation with --no-install", async ({ expect, project, prismic }) => {

--- a/test/it.ts
+++ b/test/it.ts
@@ -2,7 +2,7 @@ import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/cust
 import type { Result } from "tinyexec";
 
 import { pascalCase } from "change-case";
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -33,8 +33,8 @@ export const it = test.extend<Fixtures>({
 	},
 	// oxlint-disable-next-line no-empty-pattern
 	home: async ({}, use) => {
-		const dir = await mkdtemp(join(tmpdir(), "prismic-test-"));
-		await use(pathToFileURL(dir + "/"));
+		const dir = await realpath(await mkdtemp(join(tmpdir(), "prismic-test-")));
+		await use(pathToFileURL(`${dir}/`));
 		try {
 			await rm(dir, { recursive: true, force: true });
 		} catch {

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -20,12 +20,6 @@ it.sequential("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic pull [options]");
 });
 
-it.sequential("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("pull", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
 it.sequential("pulls slices and custom types from remote", async ({
 	expect,
 	project,

--- a/test/push.serial.test.ts
+++ b/test/push.serial.test.ts
@@ -15,12 +15,6 @@ it("supports --help", async ({ expect, prismic }) => {
 	expect(stdout).toContain("prismic push [options]");
 });
 
-it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("push", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
 it("pushes a new local custom type to remote", async ({
 	expect,
 	project,

--- a/test/status.serial.test.ts
+++ b/test/status.serial.test.ts
@@ -57,20 +57,6 @@ it("reports remote-only models when added remotely but not pulled", async ({
 	expect(stdout).toContain("prismic pull");
 });
 
-it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
-	const { stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "does-not-exist"]);
-	expect(exitCode).toBe(1);
-	expect(stderr).toContain(`No environments available on repository "${repo}".`);
-});
-
-it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {
-	await logout();
-	const { stdout, exitCode } = await prismic("status", ["--repo", repo, "--env", "anything"]);
-	expect(exitCode).toBe(0);
-	expect(stdout).toContain(`Repository: ${repo}`);
-	expect(stdout).toContain("Environment: anything");
-});
-
 it("reports differing models when local and remote disagree", async ({
 	expect,
 	project,

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ const TEST = MODE === "test";
 export default defineConfig({
 	entry: {
 		index: "./src/index.ts",
+		"env/register": "./src/exports/env/register.ts",
 		"subprocesses/refreshToken": "./src/subprocesses/refreshToken.ts",
 		"subprocesses/sendSegmentEvents": "./src/subprocesses/sendSegmentEvents.ts",
 		"subprocesses/updateVersionState": "./src/subprocesses/updateVersionState.ts",


### PR DESCRIPTION
Resolves:

> [!WARNING]
> **Do not merge.** Throwaway branch for end-to-end testing only. It combines the full environments stack (#218 + #219 + #220) into one branch so the per-PR prerelease has the whole flow. Close this PR when testing is done — the real changes ship via #218 → #219 / #220.

### Description

Integration of the environments work split across #218, #219, and #220, combined here only so a single `prismic@pr-<n>` prerelease can be installed to test the whole flow (env commands + command wiring + `prismic/env/register`).

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Install the prerelease published for this PR, then run the full flow:

```sh
npm i prismic@pr-<this-PR-number>
prismic env set my-repo-staging
prismic status            # targets the environment
# add `import "prismic/env/register"` (or run `prismic gen setup`), then `npm run dev`
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.