### PR TITLE
feat: add `prismic init --new` to create a repository and push local models

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,7 +2,12 @@ import type { Profile } from "../clients/user";
 
 import { getAdapter } from "../adapters";
 import { createLoginSession, getHost, getToken } from "../auth";
-import { getCustomTypes, getSlices } from "../clients/custom-types";
+import {
+	getCustomTypes,
+	getSlices,
+	insertCustomType,
+	insertSlice,
+} from "../clients/custom-types";
 import { getProfile } from "../clients/user";
 import { DEFAULT_PRISMIC_HOST, env } from "../env";
 import { openBrowser } from "../lib/browser";
@@ -18,6 +23,7 @@ import {
 	readConfig,
 	readLegacySliceMachineConfig,
 	UnknownProjectRootError,
+	updateConfig,
 } from "../project";
 import { checkIsTypeBuilderEnabled, TypeBuilderRequiredError } from "../project";
 import { createRepo } from "./repo-create";
@@ -32,9 +38,16 @@ const config = {
 		Use --repo to connect to an existing repository instead. If a
 		slicemachine.config.json exists, its repository and settings will be
 		migrated.
+
+		Use --new to create an empty repository and push the project's local
+		models to it, instead of pulling. Useful for starting from a template.
 	`,
 	options: {
 		repo: { type: "string", short: "r", description: "Repository name" },
+		new: {
+			type: "boolean",
+			description: "Create a new repository and push local models to it",
+		},
 		lang: {
 			type: "string",
 			short: "l",
@@ -57,30 +70,31 @@ export default createCommand(config, async ({ values }) => {
 		lang,
 		"no-browser": noBrowser,
 		"no-setup": noSetup,
+		new: isNew,
 	} = values;
 
-	// Check for existing prismic.config.json
+	if (isNew && explicitRepo) {
+		throw new CommandError(
+			"`--new` creates a new repository and cannot be combined with `--repo`.",
+		);
+	}
+
+	// `--new` repoints an existing config (e.g. a starter's) at a new
+	// repository, so a config is allowed with `--new`. Otherwise, a config
+	// means the project is already initialized.
+	let hasConfig = false;
 	try {
 		await readConfig();
-		throw new CommandError(
-			"A prismic.config.json file exists. This project is already initialized.",
-		);
+		hasConfig = true;
 	} catch (error) {
-		if (error instanceof MissingPrismicConfigError) {
-			// No config found — proceed with initialization.
-		} else {
+		if (!(error instanceof MissingPrismicConfigError)) {
 			throw error;
 		}
 	}
-
-	// Load legacy slicemachine.config.json
-	let legacySliceMachineConfig;
-	try {
-		legacySliceMachineConfig = await readLegacySliceMachineConfig();
-	} catch (error) {
-		if (error instanceof InvalidLegacySliceMachineConfigError) {
-			console.warn("Could not read slicemachine.config.json, ignoring.");
-		}
+	if (hasConfig && !isNew) {
+		throw new CommandError(
+			"A prismic.config.json file exists. This project is already initialized.",
+		);
 	}
 
 	let token = await getToken();
@@ -115,6 +129,91 @@ export default createCommand(config, async ({ values }) => {
 		}
 	}
 
+	const adapter = await getAdapter();
+
+	// `prismic init --new`: create a new empty repository and push the project's
+	// local models to it. `--new` always creates a new repository and pushes —
+	// it never connects to an existing repository or pulls, so it can't delete
+	// local models. An existing config (a starter's) is repointed at the new
+	// repository; otherwise a fresh config is created.
+	if (isNew) {
+		const repo = await createRepo({ lang, token, host });
+		console.info(`Created repository: ${repo}`);
+
+		const documentAPIEndpoint =
+			host !== DEFAULT_PRISMIC_HOST ? `https://${repo}.cdn.${host}/api/v2/` : undefined;
+
+		// Without a config, create one first so the adapter and project setup can
+		// resolve the project. With a config (a starter), it is repointed after
+		// the push so a failed push doesn't leave the config switched.
+		if (!hasConfig) {
+			try {
+				await createConfig({ repositoryName: repo, documentAPIEndpoint, routes: [] });
+			} catch (error) {
+				if (error instanceof UnknownProjectRootError) {
+					throw new CommandError(
+						"Could not find a package.json file. Run this command from a project directory.",
+					);
+				}
+				throw new CommandError("Failed to create prismic.config.json.");
+			}
+		}
+
+		const [localCustomTypes, localSlices] = await Promise.all([
+			adapter.getCustomTypes(),
+			adapter.getSlices(),
+		]);
+		for (const slice of localSlices) {
+			await insertSlice(slice.model, { repo, token, host });
+		}
+		for (const customType of localCustomTypes) {
+			await insertCustomType(customType.model, { repo, token, host });
+		}
+
+		if (hasConfig) {
+			await updateConfig(
+				documentAPIEndpoint
+					? { repositoryName: repo, documentAPIEndpoint }
+					: { repositoryName: repo },
+			);
+		}
+
+		// Configure the project: regenerate the slice index and set the slice
+		// simulator and a preview on the new repository. Scaffold framework files
+		// only when the project doesn't already have them (i.e. there was no
+		// config).
+		await adapter.initProject({ setup: !noSetup && !hasConfig });
+		if (!noSetup) {
+			try {
+				console.info("Installing dependencies...");
+				await installDependencies();
+			} catch {
+				console.warn(
+					"Could not install dependencies automatically. Please install them manually (i.e. `npm install`).",
+				);
+			}
+		}
+
+		await adapter.generateTypes();
+
+		console.info(`\nInitialized Prismic for new repository "${repo}".`);
+		console.info(`Pushed ${localCustomTypes.length} type(s), ${localSlices.length} slice(s).`);
+		return;
+	}
+
+	// Default flow: create a new repository (or connect to one with --repo) and
+	// pull its models.
+
+	// Load legacy slicemachine.config.json
+	let legacySliceMachineConfig;
+	try {
+		legacySliceMachineConfig = await readLegacySliceMachineConfig();
+	} catch (error) {
+		if (error instanceof InvalidLegacySliceMachineConfigError) {
+			console.warn("Could not read slicemachine.config.json, ignoring.");
+		}
+	}
+
 	let repo = (explicitRepo ?? legacySliceMachineConfig?.repositoryName)?.toLowerCase();
 	if (repo) {
 		const hasRepoAccess = profile.repositories.some((repository) => repository.domain === repo);
@@ -129,8 +228,6 @@ export default createCommand(config, async ({ values }) => {
 			throw new TypeBuilderRequiredError();
 		}
 	}
-
-	const adapter = await getAdapter();
 
 	if (!repo) {
 		repo = await createRepo({ lang, token, host });


### PR DESCRIPTION
Resolves:

### Description

Adds a `--new` flag to `prismic init`.

The default `prismic init` creates or connects to a repository and **pulls** its models. `--new` instead:

- creates a new empty repository,
- points `prismic.config.json` at it, preserving an existing config's `libraries` and `routes`,
- **pushes** the project's local models to it,
- skips framework scaffolding (the project already has it).

This enables a fast setup path from a template: clone a starter that already ships models and framework files, then run one command to get a matching repository — instead of scaffolding and modeling everything from scratch.

```sh
npx degit prismicio-community/nextjs-starter-prismic-minimal my-site
cd my-site && npm install
npx prismic init --new
```

`--new` cannot be combined with `--repo` (it always creates a repository).

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

Additive flag only; existing `init` behavior is unchanged (all existing tests pass).

### Preview

### How to QA

Once this PR publishes its `prismic@pr-<number>` prerelease:

```sh
npx degit prismicio-community/nextjs-starter-prismic-minimal my-site
cd my-site && npm install
npx prismic@pr-222 init --new
```

Expected: a new repository is created, `prismic.config.json`'s `repositoryName` is repointed (routes/libraries preserved), and the `page` type + `RichText` slice are pushed to the new repo. `npx prismic@pr-<number> init --new --repo foo` should error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New remote-write path during init can publish local models to a fresh repo and repoint config; mistakes could target the wrong account/repo, though scope is limited to the newly created repository and default init is unchanged.
> 
> **Overview**
> Adds **`prismic init --new`**, an alternate init path for template/starter workflows: it always **creates a new empty repository**, reads **local** custom types and slices from the adapter, and **pushes** them with `insertSlice` / `insertCustomType` instead of pulling remote models.
> 
> Init rules change so an existing **`prismic.config.json` is allowed only with `--new`** (to repoint a starter at a new repo); otherwise init still errors if a config exists. **`--new` cannot be used with `--repo`**. For starters, **`repositoryName` (and optional CDN endpoint) is updated after a successful push** so a failed push does not leave the config switched; greenfield projects get a new config before the push. Framework **`initProject` scaffolding is skipped when a config already exists** (unless `--no-setup`), while types generation and optional dependency install still run.
> 
> The default init flow (create/connect repo and sync models from remote) is unchanged in behavior; legacy Slice Machine migration and pull/sync logic are simply moved behind the non-`--new` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1ec0bd5c92924b26a3fca0a1696c0f034492f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->