### PR TITLE
feat: activate the Prismic MCP server when creating a repository

### DIFF
--- a/src/clients/mcp.ts
+++ b/src/clients/mcp.ts
@@ -1,0 +1,19 @@
+import { request } from "../lib/request";
+
+export async function activateMCP(config: {
+	repo: string;
+	token: string | undefined;
+	host: string;
+}): Promise<void> {
+	const { repo, token, host } = config;
+	const url = new URL("./activation", getMCPServiceUrl(host));
+	url.searchParams.set("repository", repo);
+	await request(url, {
+		method: "POST",
+		credentials: { "prismic-auth": token },
+	});
+}
+
+function getMCPServiceUrl(host: string): URL {
+	return new URL(`https://api.internal.${host}/mcp/`);
+}

--- a/src/commands/repo-create.ts
+++ b/src/commands/repo-create.ts
@@ -1,6 +1,7 @@
 import { getAdapter } from "../adapters";
 import { getHost, getToken } from "../auth";
 import { upsertLocale } from "../clients/locale";
+import { activateMCP } from "../clients/mcp";
 import { completeOnboardingStepsSilently } from "../clients/repository";
 import { checkIsDomainAvailable, createRepository } from "../clients/wroom";
 import { detectAgent } from "../lib/ai";
@@ -77,6 +78,8 @@ export async function createRepo(config: {
 		host,
 		stepIds: ["createPrismicProject"],
 	});
+
+	await activateMCP({ repo: domain, token, host }).catch(() => {});
 
 	return domain;
 }

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -407,3 +407,16 @@ export async function getRepositoryAccess(config: RepoConfig): Promise<string> {
 	const data = await res.json();
 	return data.repository.api_access;
 }
+
+export async function getMCPActivationStatus(config: RepoConfig): Promise<string> {
+	const host = config.host ?? DEFAULT_HOST;
+	const url = new URL("mcp/activation", `https://api.internal.${host}/`);
+	url.searchParams.set("repository", config.repo);
+	const res = await fetch(url, {
+		headers: { Cookie: `prismic-auth=${config.token}` },
+	});
+	if (!res.ok)
+		throw new Error(`Failed to get MCP activation status: ${res.status} ${await res.text()}`);
+	const data = await res.json();
+	return data.status;
+}

--- a/test/repo-create.test.ts
+++ b/test/repo-create.test.ts
@@ -1,7 +1,12 @@
 import { onTestFinished } from "vitest";
 
 import { it } from "./it";
-import { deleteRepository, getLocales, getRepository } from "./prismic";
+import {
+	deleteRepository,
+	getLocales,
+	getMCPActivationStatus,
+	getRepository,
+} from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
 	const { stdout, exitCode } = await prismic("repo", ["create", "--help"]);
@@ -21,6 +26,19 @@ it("creates a repository", async ({ expect, prismic, token, host, password }) =>
 
 	const repository = await getRepository({ repo: domain!, token, host });
 	expect(repository).toBeDefined();
+});
+
+it("activates the MCP server", async ({ expect, prismic, token, host }) => {
+	const { stdout, exitCode } = await prismic("repo", ["create"]);
+	expect(exitCode).toBe(0);
+
+	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
+	expect(domain).toBeDefined();
+
+	// New repositories are activated for the Prismic MCP server. Once they are
+	// MCP-enabled server-side by default, this will pass regardless of the CLI.
+	const status = await getMCPActivationStatus({ repo: domain!, token, host });
+	expect(["active", "activating"]).toContain(status);
 });
 
 it("creates a repository with a name", async ({ expect, prismic, token, host, password }) => {


### PR DESCRIPTION
Resolves:

### Description

New repositories now have the Prismic MCP server activated automatically when created via `prismic repo create` or `prismic init` (including `init --new`). Agents can work with a new repository's content over MCP right away, with no manual activation step in the dashboard.

The activation call is **best-effort** — any failure is ignored (`.catch(() => {})`), so it can never break repository creation, and it's safe to remove once repositories are MCP-enabled server-side by default.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

Additive and best-effort; existing behavior is unchanged (all existing tests pass).

### Preview

### How to QA

```sh
npx prismic@pr-223 repo create
```

Then confirm MCP is active for the new repo — either in **Settings → Prismic MCP** in the dashboard, or by connecting the repo in an MCP-enabled agent. Creating a repo with a broken/unreachable activation endpoint should still succeed (the call is best-effort).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive post-create side effect with errors ignored; core repo creation paths are unchanged on failure.
> 
> **Overview**
> **Repository creation** now triggers a **best-effort MCP activation** so new repos are ready for agent/MCP use without a dashboard step. This applies to `prismic repo create` and any flow that uses shared `createRepo` (e.g. `prismic init`).
> 
> A new `activateMCP` client POSTs to `https://api.internal.{host}/mcp/activation` with the repo name and `prismic-auth` credentials. It runs after onboarding completion in `createRepo`; failures are swallowed with `.catch(() => {})` so creation never fails if MCP is down.
> 
> Tests add `getMCPActivationStatus` and assert status is `active` or `activating` after `repo create`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4743f9379a7b687d4bfbaa5ebc2c6c4ce21d3ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->