### PR TITLE
test: simplify how the CLI is built for tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
 				"@prismicio/types-internal": "3.16.1",
 				"@types/node": "25.0.9",
 				"change-case": "5.4.4",
-				"concurrently": "^9.2.1",
-				"cross-env": "^10.1.0",
 				"dedent": "^1.7.2",
 				"detect-indent": "^7.0.2",
 				"github-slugger": "2.0.0",
@@ -157,13 +155,6 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
-		},
-		"node_modules/@epic-web/invariant": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
-			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.27.3",
@@ -1780,32 +1771,6 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
-		"node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/ansis": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
@@ -1941,62 +1906,10 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
 		"node_modules/change-case": {
 			"version": "5.4.4",
 			"resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
 			"integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -2008,80 +1921,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/concurrently": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-			"integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "4.1.2",
-				"rxjs": "7.8.2",
-				"shell-quote": "1.8.3",
-				"supports-color": "8.1.1",
-				"tree-kill": "1.2.2",
-				"yargs": "17.7.2"
-			},
-			"bin": {
-				"conc": "dist/bin/concurrently.js",
-				"concurrently": "dist/bin/concurrently.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-			}
-		},
-		"node_modules/concurrently/node_modules/supports-color": {
-			"version": "8.1.1",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/cross-env": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
-			"integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@epic-web/invariant": "^1.0.0",
-				"cross-spawn": "^7.0.6"
-			},
-			"bin": {
-				"cross-env": "dist/bin/cross-env.js",
-				"cross-env-shell": "dist/bin/cross-env-shell.js"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
-		"node_modules/cross-spawn": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"path-key": "^3.1.0",
-				"shebang-command": "^2.0.0",
-				"which": "^2.0.1"
-			},
-			"engines": {
-				"node": ">= 8"
 			}
 		},
 		"node_modules/data-uri-to-buffer": {
@@ -2182,13 +2021,6 @@
 				}
 			}
 		},
-		"node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/empathic": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -2256,16 +2088,6 @@
 				"@esbuild/win32-arm64": "0.27.3",
 				"@esbuild/win32-ia32": "0.27.3",
 				"@esbuild/win32-x64": "0.27.3"
-			}
-		},
-		"node_modules/escalade": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/estree-walker": {
@@ -2415,16 +2237,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
 		"node_modules/get-tsconfig": {
 			"version": "4.13.6",
 			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
@@ -2466,16 +2278,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/hasown": {
@@ -2606,16 +2408,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2648,13 +2440,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/isexe": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/jiti": {
 			"version": "1.21.7",
@@ -3107,16 +2892,6 @@
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			}
 		},
-		"node_modules/path-key": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -3395,16 +3170,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/require-directory": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -3571,16 +3336,6 @@
 				"queue-microtask": "^1.2.2"
 			}
 		},
-		"node_modules/rxjs": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
-		},
 		"node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3592,42 +3347,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/shebang-command": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"shebang-regex": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shebang-regex": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/siginfo": {
@@ -3697,34 +3416,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-indent": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
@@ -3736,19 +3427,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/tinybench": {
@@ -4546,22 +4224,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/which": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"isexe": "^2.0.0"
-			},
-			"bin": {
-				"node-which": "bin/node-which"
-			},
-			"engines": {
-				"node": ">= 8"
-			}
-		},
 		"node_modules/why-is-node-running": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -4579,59 +4241,12 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"node_modules/yargs-parser": {
 			"version": "21.1.1",

--- a/package.json
+++ b/package.json
@@ -29,16 +29,14 @@
 		"prepare": "npm run build",
 		"lint": "oxlint --deny-warnings",
 		"types": "tsc --noEmit",
-		"unit": "cross-env MODE=test tsdown --logLevel=warn && vitest run",
-		"unit:watch": "concurrently --raw --kill-others \"cross-env MODE=test tsdown --watch --logLevel=warn\" \"vitest watch\"",
+		"unit": "vitest run",
+		"unit:watch": "vitest watch",
 		"test": "npm run lint && npm run types && npm run unit"
 	},
 	"devDependencies": {
 		"@prismicio/types-internal": "3.16.1",
 		"@types/node": "25.0.9",
 		"change-case": "5.4.4",
-		"concurrently": "^9.2.1",
-		"cross-env": "^10.1.0",
 		"dedent": "^1.7.2",
 		"detect-indent": "^7.0.2",
 		"github-slugger": "2.0.0",

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -13,7 +13,7 @@ import { resolveEnvironment } from "../lib/prismic/environments";
 import { getRepositoryName } from "../project";
 import { trackCommandStart, trackCommandEnd } from "../tracking";
 
-const POLL_INTERVAL_MS = env.TEST ? 500 : 5000;
+const POLL_INTERVAL_MS = env.PRISMIC_SYNC_POLL_MS ?? 5000;
 const MAX_CONSECUTIVE_ERRORS = 5;
 
 const config = {

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,10 +6,7 @@ const DEFAULT_PRISMIC_SENTRY_DSN =
 export const DEFAULT_PRISMIC_HOST = "prismic.io";
 
 const Env = z.object({
-	MODE: z.string(),
-	DEV: z.stringbool(),
 	PROD: z.stringbool(),
-	TEST: z.stringbool(),
 	PRISMIC_SENTRY_DSN: z._default(z.httpUrl(), DEFAULT_PRISMIC_SENTRY_DSN),
 	PRISMIC_SENTRY_ENVIRONMENT: z.optional(z.string()),
 	PRISMIC_SENTRY_ENABLED: z.optional(z.stringbool()),
@@ -19,12 +16,10 @@ const Env = z.object({
 	PRISMIC_DOCS_HOST: z.optional(z.string()),
 	PRISMIC_CONFIG_DIR: z.optional(z.string()),
 	PRISMIC_TYPE_BUILDER_ENABLED: z.optional(z.stringbool()),
+	PRISMIC_SYNC_POLL_MS: z.optional(z.coerce.number().check(z.gte(100))),
 });
 
 export const env = z.parse(Env, {
 	...process.env,
-	MODE: process.env.MODE,
-	DEV: process.env.DEV,
 	PROD: process.env.PROD,
-	TEST: process.env.TEST,
 });

--- a/test/it.ts
+++ b/test/it.ts
@@ -121,6 +121,7 @@ export const it = test.extend<Fixtures>({
 				PRISMIC_TYPE_BUILDER_ENABLED: "true",
 				PRISMIC_SENTRY_ENABLED: "false",
 				PRISMIC_TELEMETRY_ENABLED: "false",
+				PRISMIC_SYNC_POLL_MS: "500",
 				NO_UPDATE_NOTIFIER: "1",
 				PRISMIC_CONFIG_DIR: fileURLToPath(configDir),
 				...options?.nodeOptions?.env,

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -12,8 +12,10 @@ declare module "vitest" {
 }
 
 export default async function (project: TestProject): Promise<() => Promise<void>> {
-	await build({ logLevel: "silent" });
-	project.onTestsRerun(async () => void (await build({ logLevel: "silent" })));
+	await build({ logLevel: "silent", unbundle: true, minify: false });
+	project.onTestsRerun(async () => {
+		await build({ logLevel: "silent", unbundle: true, minify: false });
+	});
 
 	try {
 		process.loadEnvFile(".env.test.local");

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -12,8 +12,8 @@ declare module "vitest" {
 }
 
 export default async function (project: TestProject): Promise<() => Promise<void>> {
-	await build();
-	project.onTestsRerun(async () => void (await build()));
+	await build({ logLevel: "silent" });
+	project.onTestsRerun(async () => void (await build({ logLevel: "silent" })));
 
 	try {
 		process.loadEnvFile(".env.test.local");

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -13,9 +13,7 @@ declare module "vitest" {
 
 export default async function (project: TestProject): Promise<() => Promise<void>> {
 	await build();
-	project.onTestsRerun(async () => {
-		await build();
-	});
+	project.onTestsRerun(async () => void (await build()));
 
 	try {
 		process.loadEnvFile(".env.test.local");

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,5 +1,7 @@
 import type { TestProject } from "vitest/node";
 
+import { build } from "tsdown";
+
 import { upsertLocale, createRepository, deleteRepository, login } from "./prismic";
 
 declare module "vitest" {
@@ -9,7 +11,12 @@ declare module "vitest" {
 	}
 }
 
-export default async function ({ provide }: TestProject): Promise<() => Promise<void>> {
+export default async function (project: TestProject): Promise<() => Promise<void>> {
+	await build();
+	project.onTestsRerun(async () => {
+		await build();
+	});
+
 	try {
 		process.loadEnvFile(".env.test.local");
 	} catch {
@@ -24,13 +31,13 @@ export default async function ({ provide }: TestProject): Promise<() => Promise<
 
 	console.info(`Logging in to ${host} with ${email}`);
 	const token = await login(email, password, { host });
-	provide("token", token);
+	project.provide("token", token);
 
 	const repo = `prismic-cli-test-${crypto.randomUUID().replace(/-/g, "").slice(0, 8)}`;
 	console.info(`Creating shared test repository: ${repo}`);
 	await createRepository(repo, { token, host });
 	await upsertLocale("en-us", { isMaster: true, repo, token, host });
-	provide("repo", repo);
+	project.provide("repo", repo);
 
 	return async () => {
 		try {

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,4 +1,4 @@
-import type { Vitest } from "vitest/node";
+import type { TestProject } from "vitest/node";
 
 import { upsertLocale, createRepository, deleteRepository, login } from "./prismic";
 
@@ -9,7 +9,7 @@ declare module "vitest" {
 	}
 }
 
-export default async function ({ provide }: Vitest): Promise<() => Promise<void>> {
+export default async function ({ provide }: TestProject): Promise<() => Promise<void>> {
 	try {
 		process.loadEnvFile(".env.test.local");
 	} catch {

--- a/test/setup.global.ts
+++ b/test/setup.global.ts
@@ -1,8 +1,14 @@
 import type { TestProject } from "vitest/node";
 
-import { build } from "tsdown";
+import { build, type InlineConfig } from "tsdown";
 
 import { upsertLocale, createRepository, deleteRepository, login } from "./prismic";
+
+const TSDOWN_TEST_CONFIG: InlineConfig = {
+	logLevel: "silent",
+	unbundle: true,
+	minify: false,
+};
 
 declare module "vitest" {
 	export interface ProvidedContext {
@@ -12,9 +18,9 @@ declare module "vitest" {
 }
 
 export default async function (project: TestProject): Promise<() => Promise<void>> {
-	await build({ logLevel: "silent", unbundle: true, minify: false });
+	await build(TSDOWN_TEST_CONFIG);
 	project.onTestsRerun(async () => {
-		await build({ logLevel: "silent", unbundle: true, minify: false });
+		await build(TSDOWN_TEST_CONFIG);
 	});
 
 	try {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "tsdown";
 
-const MODE = process.env.MODE || "development";
-const PROD = MODE === "production";
+const PROD = process.env.MODE === "production";
 
 export default defineConfig({
 	entry: {
@@ -12,8 +11,7 @@ export default defineConfig({
 	},
 	format: "esm",
 	platform: "node",
-	unbundle: !PROD,
-	minify: PROD,
+	minify: true,
 	envPrefix: "PRISMIC_",
 	define: {
 		"process.env.PROD": JSON.stringify(String(PROD)),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 const MODE = process.env.MODE || "development";
-const TEST = MODE === "test";
+const PROD = MODE === "production";
 
 export default defineConfig({
 	entry: {
@@ -12,13 +12,10 @@ export default defineConfig({
 	},
 	format: "esm",
 	platform: "node",
-	unbundle: TEST,
-	minify: !TEST,
+	unbundle: !PROD,
+	minify: PROD,
 	envPrefix: "PRISMIC_",
 	define: {
-		"process.env.MODE": JSON.stringify(MODE),
-		"process.env.DEV": JSON.stringify(String(MODE !== "production")),
-		"process.env.PROD": JSON.stringify(String(MODE === "production")),
-		"process.env.TEST": JSON.stringify(String(TEST)),
+		"process.env.PROD": JSON.stringify(String(PROD)),
 	},
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
 	test: {
 		globalSetup: ["./test/setup.global.ts"],
-		forceRerunTriggers: ["**/dist/index.mjs"],
+		forceRerunTriggers: ["**/src/**", "**/tsdown.config.ts"],
 		typecheck: { enabled: true },
 		setupFiles: ["./test/setup.ts"],
 		include: ["./test/**/*.test.ts"],


### PR DESCRIPTION
Resolves:

### Description

We now more efficiently build the CLI before running tests. `cross-env` and `concurrently` are replaced by a Vitest hook, where we call tsdown's `build` function instead.

We also remove a test-specific ternary from the code, ensuring we are testing the real public CLI.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run `node --run unit` — the suite builds the CLI itself and all 288 tests pass in ~80s. For watch mode, run `node --run unit:watch`, edit a file in `src/`, and confirm the CLI rebuilds and tests rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev/test tooling and a documented env override for sync poll interval; no auth or production behavior changes beyond removing unused env flags.
> 
> **Overview**
> **Test runs now build the CLI inside Vitest** instead of pre-building via `unit` scripts with `cross-env` and `concurrently`. Global setup calls `tsdown` with an unminified, unbundled test config, rebuilds on reruns (watch), and `forceRerunTriggers` watch `src/**` rather than `dist/index.mjs`. `unit` / `unit:watch` are plain `vitest run` / `vitest watch`; **`concurrently` and `cross-env` are removed** from devDependencies.
> 
> **Production build config is simplified:** `tsdown` always minifies and no longer injects `MODE` / `DEV` / `TEST`—only `PROD` remains. Matching fields are dropped from **`env` parsing**.
> 
> **`prismic sync` polling** no longer branches on a compile-time test flag. It uses optional **`PRISMIC_SYNC_POLL_MS`** (default 5000); E2E harness sets `500` for faster sync tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e308ec9e14a07567c59bd2e788c9ad86779666c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->