### PR TITLE
test: show stderr when an exit code assertion fails

### DIFF
--- a/test/field-add-boolean.test.ts
+++ b/test/field-add-boolean.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "boolean", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "boolean", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add boolean <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a boolean field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"boolean",
 		"my_field",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_field");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a boolean field to a custom type", async ({ expect, prismic, project })
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"boolean",
 		"is_active",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: is_active");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-color.test.ts
+++ b/test/field-add-color.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "color", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "color", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add color <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a color field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"color",
 		"my_color",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_color");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a color field to a custom type", async ({ expect, prismic, project }) =
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"color",
 		"my_color",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_color");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-content-relationship.test.ts
+++ b/test/field-add-content-relationship.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "content-relationship", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "content-relationship", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add content-relationship <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a content relationship field to a slice", async ({ expect, prismic, pro
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"content-relationship",
 		"my_link",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a content relationship field to a custom type", async ({ expect, prismi
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"content-relationship",
 		"my_link",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -60,7 +60,7 @@ it("adds a content relationship field with --field", async ({ expect, prismic, p
 	const owner = buildCustomType();
 	await writeLocalCustomType(project, owner);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"content-relationship",
 		"my_link",
@@ -71,7 +71,7 @@ it("adds a content relationship field with --field", async ({ expect, prismic, p
 		"--field",
 		"title",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
 	const updated = await readLocalCustomType(project, owner.id);
@@ -106,7 +106,7 @@ it("adds a content relationship field with grouped fields", async ({
 	const owner = buildCustomType();
 	await writeLocalCustomType(project, owner);
 
-	const { exitCode } = await prismic("field", [
+	const { stderr, exitCode } = await prismic("field", [
 		"add",
 		"content-relationship",
 		"my_link",
@@ -119,7 +119,7 @@ it("adds a content relationship field with grouped fields", async ({
 		"--field",
 		"authors.role",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 
 	const updated = await readLocalCustomType(project, owner.id);
 	expect(updated.json.Main.my_link).toMatchObject({
@@ -165,7 +165,7 @@ it("adds a content relationship field with a nested relationship field", async (
 	const owner = buildCustomType();
 	await writeLocalCustomType(project, owner);
 
-	const { exitCode } = await prismic("field", [
+	const { stderr, exitCode } = await prismic("field", [
 		"add",
 		"content-relationship",
 		"my_link",
@@ -176,7 +176,7 @@ it("adds a content relationship field with a nested relationship field", async (
 		"--field",
 		"authors.author.title",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 
 	const updated = await readLocalCustomType(project, owner.id);
 	expect(updated.json.Main.my_link).toMatchObject({

--- a/test/field-add-date.test.ts
+++ b/test/field-add-date.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "date", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "date", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add date <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a date field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"date",
 		"my_date",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_date");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a date field to a custom type", async ({ expect, prismic, project }) =>
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"date",
 		"my_date",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_date");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-embed.test.ts
+++ b/test/field-add-embed.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "embed", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "embed", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add embed <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds an embed field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"embed",
 		"my_embed",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds an embed field to a custom type", async ({ expect, prismic, project }) 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"embed",
 		"my_embed",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_embed");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-geopoint.test.ts
+++ b/test/field-add-geopoint.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "geopoint", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "geopoint", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add geopoint <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a geopoint field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"geopoint",
 		"my_location",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_location");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a geopoint field to a custom type", async ({ expect, prismic, project }
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"geopoint",
 		"my_location",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_location");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-group.test.ts
+++ b/test/field-add-group.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "group", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "group", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add group <id> [options]");
 });
 
@@ -20,14 +20,14 @@ it("adds a group field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"group",
 		"my_group",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -39,14 +39,14 @@ it("adds a group field to a custom type", async ({ expect, prismic, project }) =
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"group",
 		"my_group",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_group");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -59,14 +59,14 @@ it("adds a field inside a group using dot syntax", async ({ expect, prismic, pro
 	slice.variations[0].primary!.my_group = { type: "Group", config: { label: "My Group" } };
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"text",
 		"my_group.subtitle",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_group.subtitle");
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/field-add-image.test.ts
+++ b/test/field-add-image.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "image", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "image", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add image <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds an image field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"image",
 		"my_image",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_image");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds an image field to a custom type", async ({ expect, prismic, project }) 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"image",
 		"my_image",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_image");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-integration.test.ts
+++ b/test/field-add-integration.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "integration", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "integration", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add integration <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds an integration field to a slice", async ({ expect, prismic, project }) 
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"integration",
 		"my_integration",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds an integration field to a custom type", async ({ expect, prismic, proje
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"integration",
 		"my_integration",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_integration");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-link.test.ts
+++ b/test/field-add-link.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "link", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "link", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add link <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a link field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"link",
 		"my_link",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a link field to a custom type", async ({ expect, prismic, project }) =>
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"link",
 		"my_link",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_link");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -56,7 +56,7 @@ it("adds a media link field with --allow media", async ({ expect, prismic, proje
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"link",
 		"my_media",
@@ -65,7 +65,7 @@ it("adds a media link field with --allow media", async ({ expect, prismic, proje
 		"--allow",
 		"media",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_media");
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/field-add-number.test.ts
+++ b/test/field-add-number.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "number", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "number", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add number <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a number field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"number",
 		"my_number",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_number");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a number field to a custom type", async ({ expect, prismic, project }) 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"number",
 		"my_number",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_number");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-rich-text.test.ts
+++ b/test/field-add-rich-text.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "rich-text", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "rich-text", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add rich-text <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a rich text field to a slice", async ({ expect, prismic, project }) => 
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"rich-text",
 		"my_content",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_content");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a rich text field to a custom type", async ({ expect, prismic, project 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"rich-text",
 		"my_content",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_content");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-select.test.ts
+++ b/test/field-add-select.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "select", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "select", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add select <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a select field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"select",
 		"my_select",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_select");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a select field to a custom type", async ({ expect, prismic, project }) 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"select",
 		"my_select",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_select");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-table.test.ts
+++ b/test/field-add-table.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "table", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "table", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add table <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a table field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"table",
 		"my_table",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_table");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a table field to a custom type", async ({ expect, prismic, project }) =
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"table",
 		"my_table",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_table");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-text.test.ts
+++ b/test/field-add-text.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "text", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "text", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add text <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a text field to a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"text",
 		"subtitle",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a text field to a custom type", async ({ expect, prismic, project }) =>
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"text",
 		"subtitle",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -56,14 +56,14 @@ it("adds a text field to a page type", async ({ expect, prismic, project }) => {
 	const pageType = buildCustomType({ format: "page" });
 	await writeLocalCustomType(project, pageType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"text",
 		"subtitle",
 		"--to-type",
 		pageType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: subtitle");
 
 	const updated = await readLocalCustomType(project, pageType.id);

--- a/test/field-add-timestamp.test.ts
+++ b/test/field-add-timestamp.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "timestamp", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "timestamp", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add timestamp <id> [options]");
 });
 
@@ -18,14 +18,14 @@ it("adds a timestamp field to a slice", async ({ expect, prismic, project }) => 
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"timestamp",
 		"my_timestamp",
 		"--to-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -37,14 +37,14 @@ it("adds a timestamp field to a custom type", async ({ expect, prismic, project 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"add",
 		"timestamp",
 		"my_timestamp",
 		"--to-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: my_timestamp");
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/field-add-uid.test.ts
+++ b/test/field-add-uid.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "uid", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add uid [options]");
 });
 
@@ -10,8 +10,8 @@ it("adds a uid field to a custom type", async ({ expect, prismic, project }) => 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--to-type", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "uid", "--to-type", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -23,8 +23,8 @@ it("adds a uid field to a page type", async ({ expect, prismic, project }) => {
 	const pageType = buildCustomType({ format: "page" });
 	await writeLocalCustomType(project, pageType);
 
-	const { stdout, exitCode } = await prismic("field", ["add", "uid", "--to-type", pageType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "uid", "--to-type", pageType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 
 	const updated = await readLocalCustomType(project, pageType.id);

--- a/test/field-add.test.ts
+++ b/test/field-add.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["add", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["add", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add <command> [options]");
 });

--- a/test/field-edit.test.ts
+++ b/test/field-edit.test.ts
@@ -9,8 +9,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["edit", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["edit", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field edit <id> [options]");
 });
 
@@ -19,7 +19,7 @@ it("edits a field label on a slice", async ({ expect, prismic, project }) => {
 	slice.variations[0].primary!.my_field = { type: "Boolean", config: { label: "Old Label" } };
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"my_field",
 		"--from-slice",
@@ -27,7 +27,7 @@ it("edits a field label on a slice", async ({ expect, prismic, project }) => {
 		"--label",
 		"New Label",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: my_field");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -48,7 +48,7 @@ it("edits a field label on a custom type", async ({ expect, prismic, project }) 
 	});
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"title",
 		"--from-type",
@@ -56,7 +56,7 @@ it("edits a field label on a custom type", async ({ expect, prismic, project }) 
 		"--label",
 		"Page Title",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: title");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -71,7 +71,7 @@ it("edits boolean field options", async ({ expect, prismic, project }) => {
 	slice.variations[0].primary!.is_active = { type: "Boolean", config: { label: "Active" } };
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"is_active",
 		"--from-slice",
@@ -83,7 +83,7 @@ it("edits boolean field options", async ({ expect, prismic, project }) => {
 		"--false-label",
 		"No",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: is_active");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -103,7 +103,7 @@ it("edits number field options", async ({ expect, prismic, project }) => {
 	slice.variations[0].primary!.quantity = { type: "Number", config: { label: "Quantity" } };
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"quantity",
 		"--from-slice",
@@ -113,7 +113,7 @@ it("edits number field options", async ({ expect, prismic, project }) => {
 		"--max",
 		"100",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: quantity");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -132,7 +132,7 @@ it("edits select field options", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"color",
 		"--from-slice",
@@ -146,7 +146,7 @@ it("edits select field options", async ({ expect, prismic, project }) => {
 		"--option",
 		"blue",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: color");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -173,7 +173,7 @@ it("edits content relationship field with --field", async ({ expect, prismic, pr
 	};
 	await writeLocalCustomType(project, owner);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"my_link",
 		"--from-type",
@@ -181,7 +181,7 @@ it("edits content relationship field with --field", async ({ expect, prismic, pr
 		"--field",
 		"title",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: my_link");
 
 	const updated = await readLocalCustomType(project, owner.id);
@@ -202,14 +202,14 @@ it("edits link field options", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"edit",
 		"cta_link",
 		"--from-slice",
 		slice.id,
 		"--allow-target-blank",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field updated: cta_link");
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/field-remove.test.ts
+++ b/test/field-remove.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field remove <id> [options]");
 });
 
@@ -34,13 +34,13 @@ it("removes a field from a slice", async ({ expect, prismic, project }) => {
 	});
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"remove",
 		"my_field",
 		"--from-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field removed: my_field");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -57,13 +57,13 @@ it("removes a field from a custom type", async ({ expect, prismic, project }) =>
 	});
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"remove",
 		"title",
 		"--from-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field removed: title");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -96,13 +96,13 @@ it("removes a nested field using dot notation", async ({ expect, prismic, projec
 	});
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"remove",
 		"my_group.subtitle",
 		"--from-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field removed: my_group.subtitle");
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/field-reorder.test.ts
+++ b/test/field-reorder.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["reorder", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["reorder", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field reorder <id> [options]");
 });
 
@@ -23,7 +23,7 @@ it("reorders a field in a slice", async ({ expect, prismic, project }) => {
 	slice.variations[0].primary!.field_c = { type: "Boolean", config: { label: "C" } };
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"reorder",
 		"field_a",
 		"--after",
@@ -31,7 +31,7 @@ it("reorders a field in a slice", async ({ expect, prismic, project }) => {
 		"--from-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field reordered: field_a");
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -45,7 +45,7 @@ it("reorders a field in a custom type", async ({ expect, prismic, project }) => 
 	customType.json.Main.image = { type: "Image", config: { label: "Image" } };
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"reorder",
 		"image",
 		"--before",
@@ -53,7 +53,7 @@ it("reorders a field in a custom type", async ({ expect, prismic, project }) => 
 		"--from-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field reordered: image");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -70,7 +70,7 @@ it("moves a field across tabs in a custom type", async ({ expect, prismic, proje
 	};
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"reorder",
 		"body",
 		"--after",
@@ -78,7 +78,7 @@ it("moves a field across tabs in a custom type", async ({ expect, prismic, proje
 		"--from-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field reordered: body");
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -101,7 +101,7 @@ it("reorders a nested field in a group", async ({ expect, prismic, project }) =>
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"reorder",
 		"my_group.sub_c",
 		"--before",
@@ -109,7 +109,7 @@ it("reorders a nested field in a group", async ({ expect, prismic, project }) =>
 		"--from-slice",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field reordered: my_group.sub_c");
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, buildSlice, it, writeLocalCustomType, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["view", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["view", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field view <id> [options]");
 });
 
@@ -14,8 +14,8 @@ it("views a field in a slice", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", ["view", "title", "--from-slice", slice.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["view", "title", "--from-slice", slice.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Type: StructuredText");
 	expect(stdout).toContain("Label: Title");
 	expect(stdout).toContain("Placeholder: Enter title");
@@ -29,13 +29,13 @@ it("views a field in a custom type", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"view",
 		"count",
 		"--from-type",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Type: Number");
 	expect(stdout).toContain("Label: Count");
 	expect(stdout).toContain("Min: 0");
@@ -50,14 +50,14 @@ it("outputs JSON with --json", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("field", [
+	const { stdout, stderr, exitCode } = await prismic("field", [
 		"view",
 		"is_active",
 		"--from-slice",
 		slice.id,
 		"--json",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 
 	const field = JSON.parse(stdout);
 	expect(field.id).toBe("is_active");

--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("field", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("field", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field <command> [options]");
 });

--- a/test/gen-setup.test.ts
+++ b/test/gen-setup.test.ts
@@ -3,14 +3,14 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("gen", ["setup", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("gen", ["setup", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic gen setup [options]");
 });
 
 it("generates setup files", { timeout: 30_000 }, async ({ expect, project, prismic }) => {
-	const { exitCode, stdout } = await prismic("gen", ["setup"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode, stdout } = await prismic("gen", ["setup"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Generated setup files");
 
 	// Test fixture is a Next.js App Router project without tsconfig.json,
@@ -29,8 +29,8 @@ it("skips existing files", { timeout: 30_000 }, async ({ expect, project, prismi
 	const customContent = "// custom client file\n";
 	await writeFile(new URL("prismicio.js", project), customContent);
 
-	const { exitCode } = await prismic("gen", ["setup"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("gen", ["setup"]);
+	expect(exitCode, stderr).toBe(0);
 
 	await expect(project).toHaveFile("prismicio.js", { contains: "// custom client file" });
 });
@@ -51,8 +51,8 @@ it(
 			JSON.stringify({ version: "5.0.0" }),
 		);
 
-		const { exitCode } = await prismic("gen", ["setup", "--no-install"]);
-		expect(exitCode).toBe(0);
+		const { stderr, exitCode } = await prismic("gen", ["setup", "--no-install"]);
+		expect(exitCode, stderr).toBe(0);
 
 		// The closing tag must be "</script>", not the bundler-escaped "<\/script>".
 		await expect(project).toHaveFile("src/routes/slice-simulator/+page.svelte", {
@@ -62,8 +62,8 @@ it(
 );
 
 it("skips installation with --no-install", async ({ expect, project, prismic }) => {
-	const { exitCode, stdout } = await prismic("gen", ["setup", "--no-install"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode, stdout } = await prismic("gen", ["setup", "--no-install"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).not.toContain("Installing dependencies");
 	expect(stdout).toContain("Generated setup files");
 

--- a/test/gen-types.test.ts
+++ b/test/gen-types.test.ts
@@ -3,8 +3,8 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { buildCustomType, buildSlice, it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("gen", ["types", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("gen", ["types", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic gen types [options]");
 });
 
@@ -19,8 +19,8 @@ it("generates types from local models", async ({ expect, project, prismic }) => 
 	await mkdir(new URL(".", slicePath), { recursive: true });
 	await writeFile(slicePath, JSON.stringify(slice));
 
-	const { exitCode, stdout } = await prismic("gen", ["types"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode, stdout } = await prismic("gen", ["types"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Generated types");
 
 	await expect(project).toHaveFile("prismicio-types.d.ts", {
@@ -29,8 +29,8 @@ it("generates types from local models", async ({ expect, project, prismic }) => 
 });
 
 it("generates types with no models", async ({ expect, project, prismic }) => {
-	const { exitCode, stdout } = await prismic("gen", ["types"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode, stdout } = await prismic("gen", ["types"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Generated types");
 
 	await expect(project).toHaveFile("prismicio-types.d.ts");

--- a/test/gen.test.ts
+++ b/test/gen.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("gen", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("gen", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic gen <command> [options]");
 });
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("gen");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("gen");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic gen <command> [options]");
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,14 +4,14 @@ import packageJson from "../package.json" with { type: "json" };
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic <command> [options]");
 });
 
 it("prints help text by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic <command> [options]");
 });
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("init", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("init", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic init [options]");
 });
 
@@ -32,13 +32,13 @@ it("creates a repo if --repo is not provided and no legacy config exists", async
 	onTestFinished,
 }) => {
 	await rm(new URL("prismic.config.json", project));
-	const { exitCode, stdout } = await prismic("init");
+	const { stderr, exitCode, stdout } = await prismic("init");
 	const createdRepositoryMatch = stdout.match(/^Created repository: ([a-z0-9-]+)$/m);
 	const name = createdRepositoryMatch?.[1];
 	if (!name) throw new Error(`Could not find created repository name in output:\n${stdout}`);
 	onTestFinished(() => deleteRepository(name, { token, password, host }));
 
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Created repository:");
 	expect(stdout).toContain("Initialized Prismic for repository");
 
@@ -77,8 +77,8 @@ it("preserves existing preview config", async ({
 	});
 
 	await rm(new URL("prismic.config.json", project));
-	const { exitCode } = await prismic("init", ["--repo", rawName]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("init", ["--repo", rawName]);
+	expect(exitCode, stderr).toBe(0);
 
 	const repository = await getRepository({ repo: name, token, host });
 	expect(repository.simulatorUrl).toBe(presetSimulator);
@@ -95,8 +95,8 @@ it("initializes a project with --repo when logged in", async ({
 }) => {
 	await rm(new URL("prismic.config.json", project));
 
-	const { exitCode, stdout } = await prismic("init", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode, stdout } = await prismic("init", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Initialized Prismic for repository "${repo}"`);
 
 	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
@@ -107,8 +107,8 @@ it("initializes a project with --repo when logged in", async ({
 it("skips framework scaffolding with --no-setup", async ({ expect, project, prismic, repo }) => {
 	await rm(new URL("prismic.config.json", project));
 
-	const { exitCode } = await prismic("init", ["--repo", repo, "--no-setup"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("init", ["--repo", repo, "--no-setup"]);
+	expect(exitCode, stderr).toBe(0);
 
 	// The config file is still written.
 	const configRaw = await readFile(new URL("prismic.config.json", project), "utf-8");
@@ -212,8 +212,8 @@ it("fails when Type Builder is not enabled", async ({ expect, project, prismic, 
 it("installs dependencies", { timeout: 30_000 }, async ({ expect, project, prismic, repo }) => {
 	await rm(new URL("prismic.config.json", project));
 
-	const { exitCode } = await prismic("init", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("init", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	// Verify the stubbed npm was invoked (it creates package-lock.json)
 	await expect(access(new URL("package-lock.json", project))).resolves.toBeUndefined();

--- a/test/locale-add.test.ts
+++ b/test/locale-add.test.ts
@@ -4,8 +4,8 @@ import { it } from "./it";
 import { getLocales } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale", ["add", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale", ["add", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale add <code> [options]");
 });
 
@@ -13,8 +13,8 @@ describe("with an isolated repository", () => {
 	it.scoped({ isolateRepo: true });
 
 	it("adds a locale", async ({ expect, prismic, repo, token, host }) => {
-		const { stdout, exitCode } = await prismic("locale", ["add", "fr-fr"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["add", "fr-fr"]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Locale added: fr-fr");
 
 		const locales = await getLocales({ repo, token, host });
@@ -23,13 +23,13 @@ describe("with an isolated repository", () => {
 	});
 
 	it("adds a locale with a custom name", async ({ expect, prismic, repo, token, host }) => {
-		const { stdout, exitCode } = await prismic("locale", [
+		const { stdout, stderr, exitCode } = await prismic("locale", [
 			"add",
 			"ab-cd",
 			"--name",
 			"Custom Locale",
 		]);
-		expect(exitCode).toBe(0);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Locale added: ab-cd");
 
 		const locales = await getLocales({ repo, token, host });
@@ -38,8 +38,8 @@ describe("with an isolated repository", () => {
 	});
 
 	it("adds a locale as master", async ({ expect, prismic, repo, token, host }) => {
-		const { stdout, exitCode } = await prismic("locale", ["add", "fr-fr", "--master"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["add", "fr-fr", "--master"]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Locale added: fr-fr");
 
 		const locales = await getLocales({ repo, token, host });

--- a/test/locale-list.test.ts
+++ b/test/locale-list.test.ts
@@ -4,8 +4,8 @@ import { it } from "./it";
 import { upsertLocale } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale list [options]");
 });
 
@@ -15,16 +15,16 @@ describe("with an isolated repository", () => {
 	it("lists locales", async ({ expect, prismic, repo, token, host }) => {
 		await upsertLocale("fr-fr", { repo, token, host });
 
-		const { stdout, exitCode } = await prismic("locale", ["list"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["list"]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("fr-fr");
 	});
 
 	it("lists locales as JSON", async ({ expect, prismic, repo, token, host }) => {
 		await upsertLocale("fr-fr", { repo, token, host });
 
-		const { stdout, exitCode } = await prismic("locale", ["list", "--json"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["list", "--json"]);
+		expect(exitCode, stderr).toBe(0);
 		const parsed = JSON.parse(stdout);
 		expect(parsed).toEqual(expect.arrayContaining([expect.objectContaining({ id: "fr-fr" })]));
 	});

--- a/test/locale-remove.test.ts
+++ b/test/locale-remove.test.ts
@@ -4,8 +4,8 @@ import { it } from "./it";
 import { upsertLocale, getLocales } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale remove <code> [options]");
 });
 
@@ -15,8 +15,8 @@ describe("with an isolated repository", () => {
 	it("removes a locale", async ({ expect, prismic, repo, token, host }) => {
 		await upsertLocale("fr-fr", { repo, token, host });
 
-		const { stdout, exitCode } = await prismic("locale", ["remove", "fr-fr"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["remove", "fr-fr"]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Locale removed: fr-fr");
 
 		const locales = await getLocales({ repo, token, host });

--- a/test/locale-set-master.test.ts
+++ b/test/locale-set-master.test.ts
@@ -4,8 +4,8 @@ import { it } from "./it";
 import { upsertLocale, getLocales } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale", ["set-master", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale", ["set-master", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale set-master <code> [options]");
 });
 
@@ -21,8 +21,8 @@ describe("with an isolated repository", () => {
 	it("sets the master locale", async ({ expect, prismic, repo, token, host }) => {
 		await upsertLocale("fr-fr", { repo, token, host });
 
-		const { stdout, exitCode } = await prismic("locale", ["set-master", "fr-fr"]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("locale", ["set-master", "fr-fr"]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Master locale set: fr-fr");
 
 		const locales = await getLocales({ repo, token, host });

--- a/test/locale.test.ts
+++ b/test/locale.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("locale", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("locale", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic locale <command> [options]");
 });

--- a/test/login.test.ts
+++ b/test/login.test.ts
@@ -3,8 +3,8 @@ import { readFile } from "node:fs/promises";
 import { captureOutput, it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("login", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("login", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic login [options]");
 });
 

--- a/test/logout.test.ts
+++ b/test/logout.test.ts
@@ -3,14 +3,14 @@ import { readFile } from "node:fs/promises";
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("logout", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("logout", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic logout [options]");
 });
 
 it("logs out and deletes auth file", async ({ expect, home, prismic }) => {
-	const { stdout, exitCode } = await prismic("logout");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("logout");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Logged out of Prismic");
 	await expect(
 		readFile(new URL(".config/prismic/credentials.json", home), "utf-8"),
@@ -19,7 +19,7 @@ it("logs out and deletes auth file", async ({ expect, home, prismic }) => {
 
 it("succeeds when not logged in", async ({ expect, prismic, logout }) => {
 	await logout();
-	const { stdout, exitCode } = await prismic("logout");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("logout");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Logged out of Prismic");
 });

--- a/test/preview-add.test.ts
+++ b/test/preview-add.test.ts
@@ -2,16 +2,16 @@ import { it } from "./it";
 import { getPreviews } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["add", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["add", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview add <url> [options]");
 });
 
 it("adds a preview", async ({ expect, prismic, repo, token, host }) => {
 	const previewUrl = `https://test-${crypto.randomUUID()}.example.com/api/preview`;
 
-	const { stdout, exitCode } = await prismic("preview", ["add", previewUrl]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["add", previewUrl]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Preview added: ${previewUrl}`);
 
 	const previews = await getPreviews({ repo, token, host });
@@ -22,13 +22,13 @@ it("adds a preview", async ({ expect, prismic, repo, token, host }) => {
 it("adds a preview with a custom name", async ({ expect, prismic, repo, token, host }) => {
 	const previewUrl = `https://test-${crypto.randomUUID()}.example.com/api/preview`;
 
-	const { stdout, exitCode } = await prismic("preview", [
+	const { stdout, stderr, exitCode } = await prismic("preview", [
 		"add",
 		previewUrl,
 		"--name",
 		"My Preview",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Preview added: ${previewUrl}`);
 
 	const previews = await getPreviews({ repo, token, host });

--- a/test/preview-list.test.ts
+++ b/test/preview-list.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { addPreview } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview list [options]");
 });
 
@@ -12,8 +12,8 @@ it("lists previews", async ({ expect, prismic, repo, token, host }) => {
 
 	await addPreview(previewUrl, "Test Preview", { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("preview", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(previewUrl);
 });
 
@@ -22,8 +22,8 @@ it("lists previews as JSON", async ({ expect, prismic, repo, token, host }) => {
 
 	await addPreview(previewUrl, "Test Preview", { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("preview", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed.previews).toEqual(
 		expect.arrayContaining([expect.objectContaining({ url: previewUrl })]),

--- a/test/preview-remove.test.ts
+++ b/test/preview-remove.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { addPreview, getPreviews } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview remove <url> [options]");
 });
 
@@ -12,8 +12,8 @@ it("removes a preview", async ({ expect, prismic, repo, token, host }) => {
 
 	await addPreview(previewUrl, "Test Preview", { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("preview", ["remove", previewUrl]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["remove", previewUrl]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Preview removed: ${previewUrl}`);
 
 	const previews = await getPreviews({ repo, token, host });

--- a/test/preview-set-simulator.test.ts
+++ b/test/preview-set-simulator.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { getRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["set-simulator", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["set-simulator", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview set-simulator <url> [options]");
 });
 
@@ -11,8 +11,8 @@ it("supports --help", async ({ expect, prismic }) => {
 it.sequential("sets simulator URL", async ({ expect, prismic, repo, token, host }) => {
 	const simulatorUrl = `https://test-${crypto.randomUUID()}.example.com/slice-simulator`;
 
-	const { stdout, exitCode } = await prismic("preview", ["set-simulator", simulatorUrl]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["set-simulator", simulatorUrl]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Simulator URL set: ${simulatorUrl}`);
 
 	const repository = await getRepository({ repo, token, host });
@@ -21,7 +21,7 @@ it.sequential("sets simulator URL", async ({ expect, prismic, repo, token, host 
 
 // Must be sequential because the repo only has one simulator URL.
 it.sequential("appends /slice-simulator to URL", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["set-simulator", "https://example.com"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["set-simulator", "https://example.com"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Simulator URL set: https://example.com/slice-simulator");
 });

--- a/test/preview.test.ts
+++ b/test/preview.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("preview", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("preview", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic preview <command> [options]");
 });

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -15,8 +15,8 @@ import {
 } from "./prismic";
 
 it.sequential("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("pull", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("pull", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic pull [options]");
 });
 
@@ -42,8 +42,8 @@ it.sequential("pulls slices and custom types from remote", async ({
 		insertSlice(slice, { repo, token, host }),
 	]);
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	await expect(project).toContainCustomType(customType);
 	await expect(project).toContainSlice(slice);
@@ -65,8 +65,8 @@ it.sequential("pulls multiple slices with correct structure", async ({
 		insertSlice(sliceB, { repo, token, host }),
 	]);
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	await expect(project).toContainSlice(sliceA);
 	await expect(project).toContainSlice(sliceB);
@@ -85,7 +85,7 @@ it.sequential("adds new slice to existing library on re-pull", async ({
 
 	// First pull — creates slice A
 	const first = await prismic("pull", ["--repo", repo]);
-	expect(first.exitCode).toBe(0);
+	expect(first.exitCode, first.stderr).toBe(0);
 	await expect(project).toContainSlice(sliceA);
 
 	// Insert a second slice remotely
@@ -97,7 +97,7 @@ it.sequential("adds new slice to existing library on re-pull", async ({
 
 	// Second pull — should add slice B without breaking slice A
 	const second = await prismic("pull", ["--repo", repo]);
-	expect(second.exitCode).toBe(0);
+	expect(second.exitCode, second.stderr).toBe(0);
 	await expect(project).toContainSlice(sliceA);
 	await expect(project).toContainSlice(sliceB);
 });
@@ -122,8 +122,8 @@ it.sequential("pulls new slices into the first configured library", async ({
 
 	await insertSlice(slice, { repo, token, host });
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	const sliceDirectoryName = pascalCase(slice.name);
 	await expect(project).toContainSlice(slice);
@@ -149,7 +149,7 @@ it.sequential("removes deleted slice and updates index on re-pull", async ({
 
 	// First pull — creates both slices
 	const first = await prismic("pull", ["--repo", repo]);
-	expect(first.exitCode).toBe(0);
+	expect(first.exitCode, first.stderr).toBe(0);
 	await expect(project).toContainSlice(sliceA);
 	await expect(project).toContainSlice(sliceB);
 
@@ -161,7 +161,7 @@ it.sequential("removes deleted slice and updates index on re-pull", async ({
 
 	// Second pull — deletes local slice B to match remote
 	const second = await prismic("pull", ["--repo", repo, "--force"]);
-	expect(second.exitCode).toBe(0);
+	expect(second.exitCode, second.stderr).toBe(0);
 	await expect(project).toContainSlice(sliceA);
 	await expect(project).not.toContainSlice(sliceB);
 });
@@ -177,8 +177,8 @@ it.sequential("pulls repeatable page type", async ({
 	const customType = buildCustomType({ format: "page", repeatable: true });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).toHaveRoute({ type: customType.id, path: `/${expectedSegment}/:uid` });
@@ -198,8 +198,8 @@ it.sequential("pulls non-repeatable page type", async ({
 	const customType = buildCustomType({ format: "page", repeatable: false });
 	await insertCustomType(customType, { repo, token, host });
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).toHaveRoute({ type: customType.id, path: `/${expectedSegment}` });
@@ -219,8 +219,8 @@ it.sequential("pulls non-page custom type", async ({
 	const customType = buildCustomType();
 	await insertCustomType(customType, { repo, token, host });
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	const expectedSegment = customType.id.replaceAll("_", "-").toLowerCase();
 	await expect(project).not.toHaveRoute({ type: customType.id });
@@ -240,7 +240,7 @@ it.sequential("removes route when page type is deleted", async ({
 
 	// First pull — adds the route
 	const first = await prismic("pull", ["--repo", repo]);
-	expect(first.exitCode).toBe(0);
+	expect(first.exitCode, first.stderr).toBe(0);
 	await expect(project).toHaveRoute({ type: customType.id });
 
 	await deleteCustomType(customType.id, { repo, token, host });
@@ -252,7 +252,7 @@ it.sequential("removes route when page type is deleted", async ({
 
 	// Second pull — deletes local type to match remote
 	const second = await prismic("pull", ["--repo", repo, "--force"]);
-	expect(second.exitCode).toBe(0);
+	expect(second.exitCode, second.stderr).toBe(0);
 	await expect(project).not.toHaveRoute({ type: customType.id });
 });
 
@@ -268,7 +268,7 @@ it.sequential("blocks pull when local model files have uncommitted changes", asy
 	await insertCustomType(customType, { repo, token, host });
 
 	const first = await prismic("pull", ["--repo", repo]);
-	expect(first.exitCode).toBe(0);
+	expect(first.exitCode, first.stderr).toBe(0);
 
 	const cwd = fileURLToPath(project);
 	await x("git", ["init", "-q", "-b", "main"], { nodeOptions: { cwd } });
@@ -303,7 +303,7 @@ it.sequential("refuses to delete local models without --force when not tracked b
 	]);
 
 	const first = await prismic("pull", ["--repo", repo]);
-	expect(first.exitCode).toBe(0);
+	expect(first.exitCode, first.stderr).toBe(0);
 	await expect(project).toContainSlice(sliceB);
 
 	await deleteSlice(sliceB.id, { repo, token, host });
@@ -335,8 +335,8 @@ it.sequential("does not overwrite existing page file", async ({
 	await mkdir(new URL(".", pagePath), { recursive: true });
 	await writeFile(pagePath, originalContent);
 
-	const { exitCode } = await prismic("pull", ["--repo", repo]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("pull", ["--repo", repo]);
+	expect(exitCode, stderr).toBe(0);
 
 	await expect(project).toHaveFile(`app/${expectedSegment}/page.jsx`, {
 		contains: originalContent,

--- a/test/push.test.ts
+++ b/test/push.test.ts
@@ -11,8 +11,8 @@ import {
 } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("push", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("push", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic push [options]");
 });
 
@@ -34,13 +34,13 @@ describe("with an isolated repository", () => {
 		host,
 	}) => {
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		const customType = buildCustomType();
 		await writeLocalCustomType(project, customType);
 
-		const { exitCode } = await prismic("push", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stderr, exitCode } = await prismic("push", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 
 		const remote = await getCustomTypes({ repo, token, host });
 		expect(remote.map((t) => t.id)).toContain(customType.id);
@@ -58,12 +58,12 @@ describe("with an isolated repository", () => {
 		await insertCustomType(customType, { repo, token, host });
 
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		await writeLocalCustomType(project, { ...customType, label: "Modified" });
 
-		const { exitCode } = await prismic("push", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stderr, exitCode } = await prismic("push", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 
 		const remote = await getCustomTypes({ repo, token, host });
 		const updated = remote.find((t) => t.id === customType.id);
@@ -79,13 +79,13 @@ describe("with an isolated repository", () => {
 		host,
 	}) => {
 		const pull = await prismic("pull", ["--repo", repo, "--force"]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		const slice = buildSlice();
 		await writeLocalSlice(project, slice);
 
 		const insert = await prismic("push", ["--repo", repo]);
-		expect(insert.exitCode).toBe(0);
+		expect(insert.exitCode, insert.stderr).toBe(0);
 
 		const screenshotPath = fileURLToPath(
 			new URL("./fixtures/slice-screenshot.png", import.meta.url),
@@ -99,10 +99,10 @@ describe("with an isolated repository", () => {
 			"--screenshot",
 			screenshotPath,
 		]);
-		expect(editVariation.exitCode).toBe(0);
+		expect(editVariation.exitCode, editVariation.stderr).toBe(0);
 
 		const update = await prismic("push", ["--repo", repo]);
-		expect(update.exitCode).toBe(0);
+		expect(update.exitCode, update.stderr).toBe(0);
 
 		const screenshotPrefix = getScreenshotPrefix({ repo, token, host }, slice.id);
 		await expect
@@ -113,10 +113,10 @@ describe("with an isolated repository", () => {
 			.toBe(true);
 
 		const remove = await prismic("slice", ["remove", slice.id]);
-		expect(remove.exitCode).toBe(0);
+		expect(remove.exitCode, remove.stderr).toBe(0);
 
 		const pushDelete = await prismic("push", ["--repo", repo, "--force"]);
-		expect(pushDelete.exitCode).toBe(0);
+		expect(pushDelete.exitCode, pushDelete.stderr).toBe(0);
 
 		await expect
 			.poll(async () => (await getSlices({ repo, token, host })).map((s) => s.id), {

--- a/test/repo-create.test.ts
+++ b/test/repo-create.test.ts
@@ -2,14 +2,14 @@ import { it } from "./it";
 import { deleteRepository, getLocales, getMCPActivationStatus, getRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["create", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["create", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo create [options]");
 });
 
 it("creates a repository", async ({ expect, prismic, token, host, password, onTestFinished }) => {
-	const { stdout, exitCode } = await prismic("repo", ["create"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["create"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Repository created:");
 
 	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
@@ -22,8 +22,8 @@ it("creates a repository", async ({ expect, prismic, token, host, password, onTe
 });
 
 it("activates the MCP server", async ({ expect, prismic, token, host }) => {
-	const { stdout, exitCode } = await prismic("repo", ["create"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["create"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
 	expect(domain).toBeDefined();
@@ -43,8 +43,8 @@ it("creates a repository with a name", async ({
 	onTestFinished,
 }) => {
 	const name = `Test ${crypto.randomUUID().slice(0, 8)}`;
-	const { stdout, exitCode } = await prismic("repo", ["create", "--name", name]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["create", "--name", name]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Repository created:");
 
 	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
@@ -64,8 +64,8 @@ it("sets the master locale with --lang", async ({
 	password,
 	onTestFinished,
 }) => {
-	const { stdout, exitCode } = await prismic("repo", ["create", "--lang", "fr-fr"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["create", "--lang", "fr-fr"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const domain = stdout.match(/Repository created: (\S+)/)?.[1];
 	expect(domain).toBeDefined();

--- a/test/repo-list.test.ts
+++ b/test/repo-list.test.ts
@@ -1,20 +1,20 @@
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo list [options]");
 });
 
 it("lists repositories", async ({ expect, prismic, repo }) => {
-	const { stdout, exitCode } = await prismic("repo", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(repo);
 });
 
 it("lists repositories as JSON", async ({ expect, prismic, repo }) => {
-	const { stdout, exitCode } = await prismic("repo", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toEqual(expect.arrayContaining([expect.objectContaining({ domain: repo })]));
 });

--- a/test/repo-set-api-access.test.ts
+++ b/test/repo-set-api-access.test.ts
@@ -2,14 +2,14 @@ import { it } from "./it";
 import { getRepositoryAccess } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["set-api-access", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["set-api-access", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo set-api-access <level> [options]");
 });
 
 it("sets the repository API access level", async ({ expect, prismic, repo, token, host }) => {
-	const { exitCode } = await prismic("repo", ["set-api-access", "open"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("repo", ["set-api-access", "open"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const access = await getRepositoryAccess({ repo, token, host });
 	expect(access).toBe("open");

--- a/test/repo-set-name.test.ts
+++ b/test/repo-set-name.test.ts
@@ -2,15 +2,15 @@ import { it } from "./it";
 import { getRepository } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["set-name", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["set-name", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo set-name <name> [options]");
 });
 
 it("sets the repository display name", async ({ expect, prismic, repo, token, host }) => {
 	const name = `Test ${crypto.randomUUID().slice(0, 8)}`;
-	const { stdout, exitCode } = await prismic("repo", ["set-name", name]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["set-name", name]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Repository name set to:");
 
 	const repository = await getRepository({ repo, token, host });

--- a/test/repo-view.test.ts
+++ b/test/repo-view.test.ts
@@ -1,20 +1,20 @@
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["view", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["view", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo view [options]");
 });
 
 it("views repository details", async ({ expect, prismic, repo }) => {
-	const { stdout, exitCode } = await prismic("repo", ["view"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["view"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(repo);
 });
 
 it("views repository details as JSON", async ({ expect, prismic, repo }) => {
-	const { stdout, exitCode } = await prismic("repo", ["view", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["view", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toEqual(
 		expect.objectContaining({

--- a/test/repo.test.ts
+++ b/test/repo.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("repo", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("repo", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic repo <command> [options]");
 });

--- a/test/slice-add-variation.test.ts
+++ b/test/slice-add-variation.test.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "node:url";
 import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["add-variation", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["add-variation", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice add-variation <name> [options]");
 });
 
@@ -15,13 +15,13 @@ it("adds a variation to a slice", async ({ expect, prismic, project }) => {
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"add-variation",
 		variationName,
 		"--to",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 	expect(stdout).toContain(`to slice "${slice.id}"`);
 
@@ -36,7 +36,7 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, project }
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"add-variation",
 		variationName,
 		"--to",
@@ -44,7 +44,7 @@ it("adds a variation with a screenshot URL", async ({ expect, prismic, project }
 		"--screenshot",
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -68,7 +68,7 @@ it("adds a variation with a local screenshot file", async ({ expect, prismic, pr
 
 	const variationName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"add-variation",
 		variationName,
 		"--to",
@@ -76,7 +76,7 @@ it("adds a variation with a local screenshot file", async ({ expect, prismic, pr
 		"--screenshot",
 		screenshotPath,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added variation "${variationName}"`);
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/slice-connect.test.ts
+++ b/test/slice-connect.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["connect", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["connect", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice connect <id> [options]");
 });
 
@@ -33,8 +33,8 @@ it("connects a slice to a type", async ({ expect, prismic, project }) => {
 	await writeLocalSlice(project, slice);
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("slice", ["connect", slice.id, "--to", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["connect", slice.id, "--to", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Connected slice "${slice.id}" to "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/slice-create.test.ts
+++ b/test/slice-create.test.ts
@@ -4,16 +4,16 @@ import { writeFile } from "node:fs/promises";
 import { buildSlice, it, readLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["create", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["create", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice create <name> [options]");
 });
 
 it("creates a slice", async ({ expect, prismic, project }) => {
 	const { name } = buildSlice();
 
-	const { stdout, exitCode } = await prismic("slice", ["create", name]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["create", name]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created slice "${name}"`);
 
 	const id = snakeCase(name);
@@ -26,8 +26,8 @@ it("creates a slice with a custom id", async ({ expect, prismic, project }) => {
 	const { name } = buildSlice();
 	const id = `slice_${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", ["create", name, "--id", id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["create", name, "--id", id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created slice "${name}" (id: "${id}")`);
 
 	const created = await readLocalSlice(project, id);
@@ -51,8 +51,8 @@ it("creates a slice in the first configured library", async ({
 	const { name } = buildSlice();
 	const id = snakeCase(name);
 
-	const { exitCode } = await prismic("slice", ["create", name]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("slice", ["create", name]);
+	expect(exitCode, stderr).toBe(0);
 
 	const created = await readLocalSlice(project, id);
 	expect(created).toBeDefined();

--- a/test/slice-disconnect.test.ts
+++ b/test/slice-disconnect.test.ts
@@ -10,8 +10,8 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["disconnect", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["disconnect", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice disconnect <id> [options]");
 });
 
@@ -33,13 +33,13 @@ it("disconnects a slice from a type", async ({ expect, prismic, project }) => {
 	await writeLocalSlice(project, slice);
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"disconnect",
 		slice.id,
 		"--from",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Disconnected slice "${slice.id}" from "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/slice-edit-variation.test.ts
+++ b/test/slice-edit-variation.test.ts
@@ -4,8 +4,8 @@ import { fileURLToPath } from "node:url";
 import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["edit-variation", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["edit-variation", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice edit-variation <id> [options]");
 });
 
@@ -32,7 +32,7 @@ it("edits a variation name", async ({ expect, prismic, project }) => {
 
 	const newName = `Variation${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"edit-variation",
 		variationId,
 		"--from-slice",
@@ -40,7 +40,7 @@ it("edits a variation name", async ({ expect, prismic, project }) => {
 		"--name",
 		newName,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Variation updated: "${variationId}" in slice "${slice.id}"`);
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -52,7 +52,7 @@ it("sets a screenshot on a variation", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"edit-variation",
 		"default",
 		"--from-slice",
@@ -60,7 +60,7 @@ it("sets a screenshot on a variation", async ({ expect, prismic, project }) => {
 		"--screenshot",
 		"https://images.prismic.io/slice-machine/621a5ec4-0387-4bc5-9860-2dd46cbc07cd_default_ss.png",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
 
 	const updated = await readLocalSlice(project, slice.id);
@@ -81,7 +81,7 @@ it("sets a local screenshot file on a variation", async ({ expect, prismic, proj
 	await writeFile(screenshotFileUrl, data);
 	const screenshotPath = fileURLToPath(screenshotFileUrl);
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"edit-variation",
 		"default",
 		"--from-slice",
@@ -89,7 +89,7 @@ it("sets a local screenshot file on a variation", async ({ expect, prismic, proj
 		"--screenshot",
 		screenshotPath,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Variation updated: "default" in slice "${slice.id}"`);
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/slice-edit.test.ts
+++ b/test/slice-edit.test.ts
@@ -1,8 +1,8 @@
 import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["edit", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["edit", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice edit <id> [options]");
 });
 
@@ -12,8 +12,8 @@ it("edits a slice name", async ({ expect, prismic, project }) => {
 
 	const newName = `SliceS${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("slice", ["edit", slice.id, "--name", newName]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["edit", slice.id, "--name", newName]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Slice updated: "${newName}"`);
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/slice-list.test.ts
+++ b/test/slice-list.test.ts
@@ -1,8 +1,8 @@
 import { buildSlice, it, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice list [options]");
 });
 
@@ -10,8 +10,8 @@ it("lists slices", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toMatch(new RegExp(`${slice.name}\\s+${slice.id}`));
 });
 
@@ -19,8 +19,8 @@ it("lists slices as JSON", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toEqual(expect.arrayContaining([expect.objectContaining({ id: slice.id })]));
 });

--- a/test/slice-remove-variation.test.ts
+++ b/test/slice-remove-variation.test.ts
@@ -1,8 +1,8 @@
 import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["remove-variation", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["remove-variation", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice remove-variation <id> [options]");
 });
 
@@ -27,13 +27,13 @@ it("removes a variation from a slice", async ({ expect, prismic, project }) => {
 
 	await writeLocalSlice(project, sliceWithVariation);
 
-	const { stdout, exitCode } = await prismic("slice", [
+	const { stdout, stderr, exitCode } = await prismic("slice", [
 		"remove-variation",
 		variationId,
 		"--from",
 		slice.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Removed variation "${variationId}" from slice "${slice.id}"`);
 
 	const updated = await readLocalSlice(project, slice.id);

--- a/test/slice-remove.test.ts
+++ b/test/slice-remove.test.ts
@@ -1,8 +1,8 @@
 import { buildSlice, it, readLocalSlice, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice remove <id> [options]");
 });
 
@@ -10,8 +10,8 @@ it("removes a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["remove", slice.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["remove", slice.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Slice removed: ${slice.id}`);
 
 	const removed = await readLocalSlice(project, slice.id);

--- a/test/slice-view.test.ts
+++ b/test/slice-view.test.ts
@@ -1,8 +1,8 @@
 import { buildSlice, it, writeLocalSlice } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["view", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["view", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice view <id> [options]");
 });
 
@@ -10,8 +10,8 @@ it("views a slice", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["view", slice.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`ID: ${slice.id}`);
 	expect(stdout).toContain(`Name: ${slice.name}`);
 	expect(stdout).toContain("default:");
@@ -47,8 +47,8 @@ it("shows fields per variation", async ({ expect, prismic, project }) => {
 	});
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["view", slice.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("default:");
 	expect(stdout).toMatch(/title\s+StructuredText\s+Title\s+"Enter title"/);
 	expect(stdout).toMatch(/is_active\s+Boolean\s+Is Active/);
@@ -60,8 +60,8 @@ it("views a slice as JSON", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);
 
-	const { stdout, exitCode } = await prismic("slice", ["view", slice.id, "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["view", slice.id, "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toMatchObject({ id: slice.id, name: slice.name });
 });

--- a/test/slice.test.ts
+++ b/test/slice.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("slice", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("slice", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic slice <command> [options]");
 });

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -4,8 +4,8 @@ import { buildCustomType, buildSlice, it, writeLocalCustomType } from "./it";
 import { insertCustomType, insertSlice } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("status", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("status", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic status [options]");
 });
 
@@ -17,8 +17,8 @@ it("rejects an unknown --env", async ({ expect, prismic, repo }) => {
 
 it("warns and skips --env when not logged in", async ({ expect, prismic, logout, repo }) => {
 	await logout();
-	const { stdout, exitCode } = await prismic("status", ["--repo", repo, "--env", "anything"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("status", ["--repo", repo, "--env", "anything"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Repository: ${repo}`);
 	expect(stdout).toContain("Environment: anything");
 });
@@ -28,10 +28,10 @@ describe("with an isolated repository", () => {
 
 	it("reports in-sync when local matches remote", async ({ expect, prismic, repo }) => {
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
-		const { stdout, exitCode } = await prismic("status", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("status", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain(`Repository: ${repo}`);
 		expect(stdout).toContain("Already up to date.");
 	});
@@ -43,13 +43,13 @@ describe("with an isolated repository", () => {
 		repo,
 	}) => {
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		const customType = buildCustomType();
 		await writeLocalCustomType(project, customType);
 
-		const { stdout, exitCode } = await prismic("status", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("status", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Local-only:");
 		expect(stdout).toContain(`${customType.id} (custom type)`);
 		expect(stdout).toContain("Next:");
@@ -64,13 +64,13 @@ describe("with an isolated repository", () => {
 		host,
 	}) => {
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		const slice = buildSlice();
 		await insertSlice(slice, { repo, token, host });
 
-		const { stdout, exitCode } = await prismic("status", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("status", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Remote-only:");
 		expect(stdout).toContain(`${slice.id} (slice)`);
 		expect(stdout).toContain("prismic pull");
@@ -88,12 +88,12 @@ describe("with an isolated repository", () => {
 		await insertCustomType(customType, { repo, token, host });
 
 		const pull = await prismic("pull", ["--repo", repo]);
-		expect(pull.exitCode).toBe(0);
+		expect(pull.exitCode, pull.stderr).toBe(0);
 
 		await writeLocalCustomType(project, { ...customType, label: "Modified" });
 
-		const { stdout, exitCode } = await prismic("status", ["--repo", repo]);
-		expect(exitCode).toBe(0);
+		const { stdout, stderr, exitCode } = await prismic("status", ["--repo", repo]);
+		expect(exitCode, stderr).toBe(0);
 		expect(stdout).toContain("Differ:");
 		expect(stdout).toContain(`${customType.id} (custom type)`);
 	});

--- a/test/sync.test.ts
+++ b/test/sync.test.ts
@@ -4,8 +4,8 @@ import { buildCustomType, buildSlice, captureOutput, it } from "./it";
 import { insertCustomType, insertSlice } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("sync", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("sync", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic sync [options]");
 });
 

--- a/test/token-create.test.ts
+++ b/test/token-create.test.ts
@@ -2,14 +2,14 @@ import { it } from "./it";
 import { getAccessTokens, getWriteTokens } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("token", ["create", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic token create [options]");
 });
 
 it("creates an access token", async ({ expect, prismic, repo, token, host }) => {
-	const { stdout, exitCode } = await prismic("token", ["create"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token created:");
 
 	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
@@ -29,8 +29,8 @@ it("creates an access token with --allow-releases", async ({
 	token,
 	host,
 }) => {
-	const { stdout, exitCode } = await prismic("token", ["create", "--allow-releases"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--allow-releases"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token created:");
 
 	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
@@ -45,8 +45,8 @@ it("creates an access token with --allow-releases", async ({
 });
 
 it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
-	const { stdout, exitCode } = await prismic("token", ["create", "--write"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--write"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token created:");
 
 	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
@@ -58,13 +58,13 @@ it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
 });
 
 it("creates a write token with a custom --name", async ({ expect, prismic, repo, token, host }) => {
-	const { stdout, exitCode } = await prismic("token", [
+	const { stdout, stderr, exitCode } = await prismic("token", [
 		"create",
 		"--write",
 		"--name",
 		"My Seed Token",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 
 	const createdToken = stdout.match(/Token created: (.+)/)?.[1];
 	expect(createdToken).toBeDefined();
@@ -76,8 +76,8 @@ it("creates a write token with a custom --name", async ({ expect, prismic, repo,
 });
 
 it("outputs a write token as JSON with --json", async ({ expect, prismic, repo, token, host }) => {
-	const { stdout, exitCode } = await prismic("token", ["create", "--write", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--write", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const result = JSON.parse(stdout);
 	expect(result.type).toBe("write");
@@ -91,8 +91,8 @@ it("outputs a write token as JSON with --json", async ({ expect, prismic, repo, 
 });
 
 it("outputs an access token as JSON with --json", async ({ expect, prismic, repo }) => {
-	const { stdout, exitCode } = await prismic("token", ["create", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const result = JSON.parse(stdout);
 	expect(result.type).toBe("access");

--- a/test/token-delete.test.ts
+++ b/test/token-delete.test.ts
@@ -2,16 +2,16 @@ import { it } from "./it";
 import { createAccessToken, createWriteToken, getAccessTokens, getWriteTokens } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("token", ["delete", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["delete", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic token delete <token> [options]");
 });
 
 it("deletes an access token", async ({ expect, prismic, repo, token, host }) => {
 	const created = await createAccessToken({ repo, token, host });
 
-	const { stdout, exitCode } = await prismic("token", ["delete", created.token]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["delete", created.token]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token deleted");
 
 	const apps = await getAccessTokens({ repo, token, host });
@@ -22,8 +22,8 @@ it("deletes an access token", async ({ expect, prismic, repo, token, host }) => 
 it("deletes a write token", async ({ expect, prismic, repo, token, host }) => {
 	const created = await createWriteToken({ repo, token, host });
 
-	const { stdout, exitCode } = await prismic("token", ["delete", created.token]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["delete", created.token]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token deleted");
 
 	const writeTokensInfo = await getWriteTokens({ repo, token, host });

--- a/test/token-list.test.ts
+++ b/test/token-list.test.ts
@@ -2,24 +2,24 @@ import { it } from "./it";
 import { createAccessToken } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("token", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic token list [options]");
 });
 
 it("lists tokens", async ({ expect, prismic, repo, token, host }) => {
 	const created = await createAccessToken({ repo, token, host });
 
-	const { stdout, exitCode } = await prismic("token", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(created.token);
 });
 
 it("lists tokens as JSON", async ({ expect, prismic, repo, token, host }) => {
 	const created = await createAccessToken({ repo, token, host });
 
-	const { stdout, exitCode } = await prismic("token", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toHaveProperty("accessTokens");
 	expect(parsed).toHaveProperty("writeTokens");

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("token", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic token <command> [options]");
 });
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("token");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("token");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic token <command> [options]");
 });

--- a/test/type-add-tab.test.ts
+++ b/test/type-add-tab.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["add-tab", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["add-tab", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type add-tab <name> [options]");
 });
 
@@ -12,8 +12,8 @@ it("adds a tab to a type", async ({ expect, prismic, project }) => {
 
 	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("type", ["add-tab", tabName, "--to", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["add-tab", tabName, "--to", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -27,14 +27,14 @@ it("adds a tab with a slice zone", async ({ expect, prismic, project }) => {
 
 	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("type", [
+	const { stdout, stderr, exitCode } = await prismic("type", [
 		"add-tab",
 		tabName,
 		"--to",
 		customType.id,
 		"--with-slice-zone",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/type-create.test.ts
+++ b/test/type-create.test.ts
@@ -3,16 +3,16 @@ import { snakeCase } from "change-case";
 import { buildCustomType, it, readLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["create", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["create", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type create <name> [options]");
 });
 
 it("creates a custom type", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "custom" });
 
-	const { stdout, exitCode } = await prismic("type", ["create", label!]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["create", label!]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created type "${label}"`);
 
 	const id = snakeCase(label!);
@@ -24,8 +24,8 @@ it("creates a custom type", async ({ expect, prismic, project }) => {
 it("creates a page type with --format page", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "page" });
 
-	const { stdout, exitCode } = await prismic("type", ["create", label!, "--format", "page"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["create", label!, "--format", "page"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created type "${label}"`);
 
 	const id = snakeCase(label!);
@@ -39,8 +39,8 @@ it("creates a page type with --format page", async ({ expect, prismic, project }
 it("creates a single custom type", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "custom" });
 
-	const { exitCode } = await prismic("type", ["create", label!, "--single"]);
-	expect(exitCode).toBe(0);
+	const { stderr, exitCode } = await prismic("type", ["create", label!, "--single"]);
+	expect(exitCode, stderr).toBe(0);
 
 	const id = snakeCase(label!);
 	const created = await readLocalCustomType(project, id);
@@ -52,8 +52,8 @@ it("creates a custom type with a custom id", async ({ expect, prismic, project }
 	const { label } = buildCustomType({ format: "custom" });
 	const id = `custom_type_${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("type", ["create", label!, "--id", id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["create", label!, "--id", id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created type "${label}" (id: "${id}"`);
 
 	const created = await readLocalCustomType(project, id);

--- a/test/type-edit-tab.test.ts
+++ b/test/type-edit-tab.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["edit-tab", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["edit-tab", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type edit-tab <name> [options]");
 });
 
@@ -12,7 +12,7 @@ it("edits a tab name", async ({ expect, prismic, project }) => {
 
 	const newName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, exitCode } = await prismic("type", [
+	const { stdout, stderr, exitCode } = await prismic("type", [
 		"edit-tab",
 		"OldName",
 		"--from-type",
@@ -20,7 +20,7 @@ it("edits a tab name", async ({ expect, prismic, project }) => {
 		"--name",
 		newName,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Tab updated: "OldName" in "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -32,14 +32,14 @@ it("adds a slice zone to a tab", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", [
+	const { stdout, stderr, exitCode } = await prismic("type", [
 		"edit-tab",
 		"Main",
 		"--from-type",
 		customType.id,
 		"--with-slice-zone",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -61,14 +61,14 @@ it("removes a slice zone from a tab", async ({ expect, prismic, project }) => {
 	});
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", [
+	const { stdout, stderr, exitCode } = await prismic("type", [
 		"edit-tab",
 		"Main",
 		"--from-type",
 		customType.id,
 		"--without-slice-zone",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Tab updated: "Main" in "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/type-edit.test.ts
+++ b/test/type-edit.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["edit", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["edit", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type edit <id> [options]");
 });
 
@@ -19,7 +19,7 @@ it("edits a type name", async ({ expect, prismic, project }) => {
 		newName,
 	]);
 	expect(stderr).toBe("");
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Type updated: "${newName}" (id: ${customType.id})`);
 
 	const updated = await readLocalCustomType(project, customType.id);
@@ -32,7 +32,7 @@ it("edits a type format", async ({ expect, prismic, project }) => {
 
 	const { stderr, exitCode } = await prismic("type", ["edit", customType.id, "--format", "page"]);
 	expect(stderr).toBe("");
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 
 	const updated = await readLocalCustomType(project, customType.id);
 	expect(updated.format).toBe("page");

--- a/test/type-list.test.ts
+++ b/test/type-list.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type list [options]");
 });
 
@@ -12,8 +12,8 @@ it("lists all types", async ({ expect, prismic, project }) => {
 	await writeLocalCustomType(project, customType);
 	await writeLocalCustomType(project, pageType);
 
-	const { stdout, exitCode } = await prismic("type", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toMatch(new RegExp(`${customType.label}\\s+${customType.id}\\s+custom`));
 	expect(stdout).toMatch(new RegExp(`${pageType.label}\\s+${pageType.id}\\s+page`));
 });
@@ -22,8 +22,8 @@ it("lists types as JSON", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toEqual(
 		expect.arrayContaining([expect.objectContaining({ id: customType.id, format: "custom" })]),

--- a/test/type-remove-tab.test.ts
+++ b/test/type-remove-tab.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomType, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["remove-tab", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["remove-tab", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type remove-tab <name> [options]");
 });
 
@@ -10,13 +10,13 @@ it("removes a tab from a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ json: { Main: {}, Extra: {} } });
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", [
+	const { stdout, stderr, exitCode } = await prismic("type", [
 		"remove-tab",
 		"Extra",
 		"--from",
 		customType.id,
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Removed tab "Extra" from "${customType.id}"`);
 
 	const updated = await readLocalCustomType(project, customType.id);

--- a/test/type-remove.test.ts
+++ b/test/type-remove.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, readLocalCustomTypes, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type remove <id> [options]");
 });
 
@@ -10,8 +10,8 @@ it("removes a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", ["remove", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["remove", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Type removed: ${customType.id}`);
 
 	const customTypes = await readLocalCustomTypes(project);

--- a/test/type-view.test.ts
+++ b/test/type-view.test.ts
@@ -1,8 +1,8 @@
 import { buildCustomType, it, writeLocalCustomType } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["view", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["view", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type view <id> [options]");
 });
 
@@ -10,8 +10,8 @@ it("views a type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["view", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`ID: ${customType.id}`);
 	expect(stdout).toContain(`Name: ${customType.label}`);
 	expect(stdout).toContain("Format: custom");
@@ -33,8 +33,8 @@ it("shows fields per tab", async ({ expect, prismic, project }) => {
 	});
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.id]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["view", customType.id]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Main:");
 	expect(stdout).toMatch(/title\s+StructuredText\s+Title\s+"Enter title"/);
 	expect(stdout).toMatch(/is_active\s+Boolean\s+Is Active/);
@@ -46,8 +46,8 @@ it("views a type as JSON", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType({ format: "custom" });
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, exitCode } = await prismic("type", ["view", customType.id, "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["view", customType.id, "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toMatchObject({ id: customType.id, label: customType.label, format: "custom" });
 });

--- a/test/type.test.ts
+++ b/test/type.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("type", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("type", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic type <command> [options]");
 });

--- a/test/webhook-create.test.ts
+++ b/test/webhook-create.test.ts
@@ -2,16 +2,16 @@ import { it } from "./it";
 import { getWebhooks } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["create", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["create", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook create <url> [options]");
 });
 
 it("creates a webhook", async ({ expect, prismic, repo, token, host }) => {
 	const url = `https://example.com/test-${crypto.randomUUID()}`;
 
-	const { stdout, exitCode } = await prismic("webhook", ["create", url]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["create", url]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Webhook created: ${url}`);
 
 	const webhooks = await getWebhooks({ repo, token, host });

--- a/test/webhook-disable.test.ts
+++ b/test/webhook-disable.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook, getWebhooks } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["disable", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["disable", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook disable <url> [options]");
 });
 
@@ -12,8 +12,8 @@ it("disables a webhook", async ({ expect, prismic, repo, token, host }) => {
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", ["disable", url]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["disable", url]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Webhook disabled: ${url}`);
 
 	const webhooks = await getWebhooks({ repo, token, host });

--- a/test/webhook-enable.test.ts
+++ b/test/webhook-enable.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook, getWebhooks } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["enable", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["enable", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook enable <url> [options]");
 });
 
@@ -14,10 +14,10 @@ it("enables a disabled webhook", async ({ expect, prismic, repo, token, host }) 
 
 	// Disable the webhook first via CLI
 	const disable = await prismic("webhook", ["disable", url]);
-	expect(disable.exitCode).toBe(0);
+	expect(disable.exitCode, disable.stderr).toBe(0);
 
-	const { stdout, exitCode } = await prismic("webhook", ["enable", url]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["enable", url]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Webhook enabled: ${url}`);
 
 	const webhooks = await getWebhooks({ repo, token, host });

--- a/test/webhook-list.test.ts
+++ b/test/webhook-list.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["list", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["list", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook list [options]");
 });
 
@@ -12,8 +12,8 @@ it("lists webhooks", async ({ expect, prismic, repo, token, host }) => {
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", ["list"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["list"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(url);
 });
 
@@ -22,8 +22,8 @@ it("lists webhooks as JSON", async ({ expect, prismic, repo, token, host }) => {
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", ["list", "--json"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["list", "--json"]);
+	expect(exitCode, stderr).toBe(0);
 	const parsed = JSON.parse(stdout);
 	expect(parsed).toEqual(expect.arrayContaining([expect.objectContaining({ url })]));
 });

--- a/test/webhook-remove.test.ts
+++ b/test/webhook-remove.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook, getWebhooks } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["remove", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["remove", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook remove <url> [options]");
 });
 
@@ -12,8 +12,8 @@ it("removes a webhook", async ({ expect, prismic, repo, token, host }) => {
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", ["remove", url]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["remove", url]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Webhook removed: ${url}`);
 
 	const webhooks = await getWebhooks({ repo, token, host });

--- a/test/webhook-set-triggers.test.ts
+++ b/test/webhook-set-triggers.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook, getWebhooks } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["set-triggers", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["set-triggers", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook set-triggers <url> [options]");
 });
 
@@ -12,13 +12,13 @@ it("updates webhook triggers", async ({ expect, prismic, repo, token, host }) =>
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", [
+	const { stdout, stderr, exitCode } = await prismic("webhook", [
 		"set-triggers",
 		url,
 		"-t",
 		"documentsPublished",
 	]);
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Webhook triggers updated: documentsPublished");
 
 	const webhooks = await getWebhooks({ repo, token, host });

--- a/test/webhook-view.test.ts
+++ b/test/webhook-view.test.ts
@@ -2,8 +2,8 @@ import { it } from "./it";
 import { createWebhook } from "./prismic";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["view", "--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["view", "--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook view <url> [options]");
 });
 
@@ -12,8 +12,8 @@ it("views webhook details", async ({ expect, prismic, repo, token, host }) => {
 
 	await createWebhook(url, { repo, token, host });
 
-	const { stdout, exitCode } = await prismic("webhook", ["view", url]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["view", url]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`URL:     ${url}`);
 	expect(stdout).toContain("Status:");
 	expect(stdout).toContain("Triggers:");

--- a/test/webhook.test.ts
+++ b/test/webhook.test.ts
@@ -1,13 +1,13 @@
 import { it } from "./it";
 
 it("prints help by default", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook <command> [options]");
 });
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("webhook", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("webhook", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic webhook <command> [options]");
 });

--- a/test/whoami.test.ts
+++ b/test/whoami.test.ts
@@ -3,15 +3,15 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { it } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, exitCode } = await prismic("whoami", ["--help"]);
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("whoami", ["--help"]);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic whoami [options]");
 });
 
 it("prints email of logged-in user", async ({ expect, prismic, login }) => {
 	const { email } = await login();
-	const { stdout, exitCode } = await prismic("whoami");
-	expect(exitCode).toBe(0);
+	const { stdout, stderr, exitCode } = await prismic("whoami");
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(email);
 });
 
@@ -47,9 +47,9 @@ it("reports stored token auth failure", async ({ expect, prismic, home }) => {
 it("uses PRISMIC_TOKEN env var when set", async ({ expect, prismic, login, logout, token }) => {
 	const { email } = await login();
 	await logout();
-	const { stdout, exitCode } = await prismic("whoami", [], {
+	const { stdout, stderr, exitCode } = await prismic("whoami", [], {
 		nodeOptions: { env: { PRISMIC_TOKEN: token } },
 	});
-	expect(exitCode).toBe(0);
+	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(email);
 });


### PR DESCRIPTION
Resolves:

### Description

`expect(exitCode).toBe(0)` failures only report `expected 1 to be +0`, hiding why the command failed (see [this CI run](https://github.com/prismicio/cli/actions/runs/29952658352/job/89037009237?pr=232)). This passes the command's stderr as the assertion message, so test failures now print the CLI's actual error output:

```
AssertionError: Error: The repository "prismic-cli-test-50a4d002" could not be found.
Run `prismic login` and try again.
: expected 1 to be +0 // Object.is equality
```

Exit code stays the pass/fail signal; stderr is only surfaced in the failure message.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Break a test's command (e.g. point it at a nonexistent repo) and run it — the failure output should include the CLI's stderr.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion messaging; no production or runtime behavior changes.
> 
> **Overview**
> Integration tests that expect CLI commands to succeed now pass **`stderr`** as Vitest’s assertion message on `expect(exitCode, stderr).toBe(0)`, so a non-zero exit no longer surfaces only `expected 1 to be +0`—the failure includes the command’s real error text from stderr.
> 
> The same pattern is applied across the suite (field, gen, init, locale, preview, pull/push, repo, slice, type, webhook, auth, etc.), including cases that only assert `exitCode` after destructuring `stderr`. Tests that **expect** failure still assert `exitCode` and `stderr` separately; behavior under test is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e0626b989b1a0bb160bc937ee8e29af647aec8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->