### PR TITLE
feat: add `--labels` option for rich text fields

### DIFF
--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -38,6 +38,10 @@ const config = {
 			description: "Comma-separated allowed block types (e.g. heading1,heading2,paragraph)",
 		},
 		single: { type: "boolean", description: "Restrict to a single block" },
+		labels: {
+			type: "string",
+			description: "Comma-separated custom labels for styling text spans (e.g. highlight,quote)",
+		},
 		"allow-target-blank": { type: "boolean", description: "Allow opening links in new tab" },
 	},
 } satisfies CommandConfig;
@@ -49,6 +53,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 		placeholder,
 		allow = ALL_BLOCKS,
 		single: isSingle,
+		labels,
 		"allow-target-blank": allowTargetBlank,
 	} = values;
 
@@ -60,6 +65,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 			label: label ?? capitalCase(fieldId),
 			placeholder,
 			...(isSingle ? { single: allow } : { multi: allow }),
+			labels: labels?.split(","),
 			allowTargetBlank,
 		},
 	};

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -65,7 +65,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 			label: label ?? capitalCase(fieldId),
 			placeholder,
 			...(isSingle ? { single: allow } : { multi: allow }),
-			labels: labels?.split(","),
+			labels: labels?.split(",").map(label => label.trim()).filter(Boolean),
 			allowTargetBlank,
 		},
 	};

--- a/src/commands/field-edit.ts
+++ b/src/commands/field-edit.ts
@@ -86,6 +86,10 @@ const config = {
 			description: "Comma-separated allowed block types (rich-text)",
 		},
 		single: { type: "boolean", description: "Restrict to a single block (rich-text)" },
+		labels: {
+			type: "string",
+			description: 'Comma-separated custom labels for styling text spans; "" clears (rich-text)',
+		},
 		// Integration
 		catalog: { type: "string", description: "Integration catalog ID (integration)" },
 	},
@@ -137,6 +141,13 @@ export default createCommand(config, async ({ positionals, values }) => {
 		case "StructuredText": {
 			if ("allow-target-blank" in values) {
 				field.config.allowTargetBlank = values["allow-target-blank"];
+			}
+			if ("labels" in values) {
+				if (values.labels) {
+					field.config.labels = values.labels.split(",");
+				} else {
+					delete field.config.labels;
+				}
 			}
 			if ("single" in values) {
 				// Switch from multi to single mode

--- a/test/field-add-rich-text.test.ts
+++ b/test/field-add-rich-text.test.ts
@@ -33,6 +33,28 @@ it("adds a rich text field to a slice", async ({ expect, prismic, project }) => 
 	expect(field).toMatchObject({ type: "StructuredText" });
 });
 
+it("adds a rich text field with labels", async ({ expect, prismic, project }) => {
+	const customType = buildCustomType();
+	await writeLocalCustomType(project, customType);
+
+	const { exitCode } = await prismic("field", [
+		"add",
+		"rich-text",
+		"my_content",
+		"--to-type",
+		customType.id,
+		"--labels",
+		"highlight,inline-code",
+	]);
+	expect(exitCode).toBe(0);
+
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main.my_content).toMatchObject({
+		type: "StructuredText",
+		config: { labels: ["highlight", "inline-code"] },
+	});
+});
+
 it("adds a rich text field to a custom type", async ({ expect, prismic, project }) => {
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);

--- a/test/field-edit.test.ts
+++ b/test/field-edit.test.ts
@@ -66,6 +66,36 @@ it("edits a field label on a custom type", async ({ expect, prismic, project }) 
 	});
 });
 
+it("edits rich text labels", async ({ expect, prismic, project }) => {
+	const customType = buildCustomType({
+		json: {
+			Main: {
+				body: {
+					type: "StructuredText",
+					config: { label: "Body", multi: "paragraph" },
+				},
+			},
+		},
+	});
+	await writeLocalCustomType(project, customType);
+
+	const { exitCode } = await prismic("field", [
+		"edit",
+		"body",
+		"--from-type",
+		customType.id,
+		"--labels",
+		"highlight,inline-code",
+	]);
+	expect(exitCode).toBe(0);
+
+	const updated = await readLocalCustomType(project, customType.id);
+	expect(updated.json.Main.body).toMatchObject({
+		type: "StructuredText",
+		config: { multi: "paragraph", labels: ["highlight", "inline-code"] },
+	});
+});
+
 it("edits boolean field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.is_active = { type: "Boolean", config: { label: "Active" } };


### PR DESCRIPTION
Resolves: https://prismic-team.slack.com/archives/C02L3FN3AJK/p1784545248562659?thread_ts=1784535740.363709&cid=C02L3FN3AJK

### Description

Rich text labels could only be added by hand-editing a model's JSON file. This adds a `--labels` option to `field add rich-text` so they can be managed through the CLI:

```sh
# Add "highlight" and "quote" labels
npx prismic field add rich-text description --to-type page --labels highlight,quote

# Replace the existing labels on a field
npx prismic field edit body --from-type page --labels highlight,quote

# Remove existing labels
npx prismic field edit body --from-type page --labels ""
```

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

1. `node --run build`
2. `./dist/index.mjs field add rich-text body --to-type <type> --labels highlight,quote` and check the model JSON.
3. `./dist/index.mjs field edit body --from-type <type> --labels ""` and check the labels are removed.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized CLI and model-config changes with tests; no auth or runtime content paths affected.
> 
> **Overview**
> Adds a **`--labels`** CLI flag so StructuredText (rich text) span styling labels can be set without hand-editing model JSON.
> 
> **`field add rich-text`** accepts a comma-separated list, trims each entry, and writes `config.labels` on the new field. **`field edit`** supports the same flag for existing rich text fields; an empty string clears `config.labels`. Tests cover add and edit flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33402b1582491538a59690ee6d8779090de90178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

