### PR TITLE
feat: support link type and custom type restrictions on link fields

### DIFF
--- a/src/commands/field-add-link.ts
+++ b/src/commands/field-add-link.ts
@@ -20,6 +20,9 @@ const config = {
 
 			Add a repeatable link with custom text:
 			  prismic field add link nav_item --to-type navigation --repeatable --allow-text
+
+			Allow any link type, but restrict document links to a type:
+			  prismic field add link cta --to-type landing_page --custom-type page
 		`,
 	},
 	positionals: {
@@ -36,6 +39,11 @@ const config = {
 		"allow-text": { type: "boolean", description: "Allow custom link text" },
 		repeatable: { type: "boolean", description: "Allow multiple links" },
 		variant: { type: "string", multiple: true, description: "Allowed variant (can be repeated)" },
+		"custom-type": {
+			type: "string",
+			multiple: true,
+			description: "Restrict document links to this custom type (can be repeated)",
+		},
 	},
 } satisfies CommandConfig;
 
@@ -50,12 +58,22 @@ export default createCommand(config, async ({ positionals, values }) => {
 		"allow-text": allowText,
 		repeatable: repeat,
 		variant: variants,
+		"custom-type": customtypes,
 	} = values;
 
+	if (allow?.includes(",")) {
+		throw new CommandError(
+			"--allow accepts a single link type. Prismic links allow either one type or all types.",
+		);
+	}
 	if (allow && !ALLOWED_LINK_TYPES.includes(allow as (typeof ALLOWED_LINK_TYPES)[number])) {
 		throw new CommandError(`--allow must be one of: ${ALLOWED_LINK_TYPES.join(", ")}`);
 	}
 	const select = allow as (typeof ALLOWED_LINK_TYPES)[number] | undefined;
+
+	if (customtypes && (select === "media" || select === "web")) {
+		throw new CommandError(`--custom-type cannot be used with --allow ${select}`);
+	}
 
 	const { fields, fieldId, save } = await getNewFieldTarget(id, values);
 
@@ -68,6 +86,7 @@ export default createCommand(config, async ({ positionals, values }) => {
 			allowText,
 			repeat,
 			variants,
+			customtypes,
 		},
 	};
 

--- a/src/commands/field-edit.ts
+++ b/src/commands/field-edit.ts
@@ -80,10 +80,11 @@ const config = {
 			description:
 				"Fetch this field from the related document (content-relationship, can be repeated)",
 		},
-		// Rich Text
+		// Rich Text / Link
 		allow: {
 			type: "string",
-			description: "Comma-separated allowed block types (rich-text)",
+			description:
+				"Comma-separated allowed block types (rich-text), or allowed link type: document, media, web, any (link)",
 		},
 		single: { type: "boolean", description: "Restrict to a single block (rich-text)" },
 		// Integration
@@ -162,6 +163,20 @@ export default createCommand(config, async ({ positionals, values }) => {
 			if ("repeatable" in values) field.config.repeat = values.repeatable;
 			if ("variant" in values) field.config.variants = values.variant;
 			if ("tag" in values) field.config.tags = values.tag;
+			if ("allow" in values) {
+				const allow = values.allow;
+				if (allow === "any") {
+					delete field.config.select;
+				} else if (allow === "document" || allow === "media" || allow === "web") {
+					field.config.select = allow;
+				} else if (allow?.includes(",")) {
+					throw new CommandError(
+						"--allow accepts a single link type. Prismic links allow either one type or all types.",
+					);
+				} else {
+					throw new CommandError("--allow for link fields must be one of: document, media, web, any");
+				}
+			}
 			if ("field" in values) {
 				const cts = "custom-type" in values ? values["custom-type"] : field.config.customtypes;
 				if (!cts || cts.length === 0) {
@@ -180,7 +195,21 @@ export default createCommand(config, async ({ positionals, values }) => {
 					{ id: ctId, fields: resolvedFields },
 				] as typeof field.config.customtypes;
 			} else if ("custom-type" in values) {
-				field.config.customtypes = values["custom-type"];
+				const customtypes = values["custom-type"]!.filter(Boolean);
+				if (customtypes.length === 0) {
+					delete field.config.customtypes;
+				} else {
+					field.config.customtypes = customtypes;
+				}
+			}
+			if (
+				(field.config.select === "media" || field.config.select === "web") &&
+				field.config.customtypes &&
+				field.config.customtypes.length > 0
+			) {
+				throw new CommandError(
+					`Custom type restrictions require document links, but this field is restricted to ${field.config.select} links. Change --allow or clear the restriction with --custom-type "".`,
+				);
 			}
 			break;
 		}

--- a/test/field-add-link.test.ts
+++ b/test/field-add-link.test.ts
@@ -52,6 +52,27 @@ it("adds a link field to a custom type", async ({ expect, prismic, project }) =>
 	expect(field).toMatchObject({ type: "Link" });
 });
 
+it("adds a link field restricted to custom types", async ({ expect, prismic, project }) => {
+	const customType = buildCustomType();
+	await writeLocalCustomType(project, customType);
+
+	const { exitCode } = await prismic("field", [
+		"add",
+		"link",
+		"cta",
+		"--to-type",
+		customType.id,
+		"--custom-type",
+		"page",
+	]);
+	expect(exitCode).toBe(0);
+
+	const updated = await readLocalCustomType(project, customType.id);
+	const field = updated.json.Main.cta;
+	expect(field).toMatchObject({ type: "Link", config: { customtypes: ["page"] } });
+	expect(field.config).not.toHaveProperty("select");
+});
+
 it("adds a media link field with --allow media", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	await writeLocalSlice(project, slice);

--- a/test/field-edit.test.ts
+++ b/test/field-edit.test.ts
@@ -194,6 +194,52 @@ it("edits content relationship field with --field", async ({ expect, prismic, pr
 	});
 });
 
+it("edits a link field's allowed link type", async ({ expect, prismic, project }) => {
+	const slice = buildSlice();
+	slice.variations[0].primary!.cta_link = {
+		type: "Link",
+		config: { label: "CTA Link", select: "document" },
+	};
+	await writeLocalSlice(project, slice);
+
+	const { exitCode } = await prismic("field", [
+		"edit",
+		"cta_link",
+		"--from-slice",
+		slice.id,
+		"--allow",
+		"web",
+	]);
+	expect(exitCode).toBe(0);
+
+	const updated = await readLocalSlice(project, slice.id);
+	expect(updated!.variations[0].primary!.cta_link).toMatchObject({
+		type: "Link",
+		config: { select: "web" },
+	});
+});
+
+it("clears a link field's custom type restriction", async ({ expect, prismic, project }) => {
+	const slice = buildSlice();
+	slice.variations[0].primary!.cta_link = {
+		type: "Link",
+		config: { label: "CTA Link", customtypes: ["page"] },
+	};
+	await writeLocalSlice(project, slice);
+
+	const { exitCode } = await prismic("field", [
+		"edit",
+		"cta_link",
+		"--from-slice",
+		slice.id,
+		"--custom-type=",
+	]);
+	expect(exitCode).toBe(0);
+
+	const updated = await readLocalSlice(project, slice.id);
+	expect(updated!.variations[0].primary!.cta_link.config).not.toHaveProperty("customtypes");
+});
+
 it("edits link field options", async ({ expect, prismic, project }) => {
 	const slice = buildSlice();
 	slice.variations[0].primary!.cta_link = {


### PR DESCRIPTION
Resolves: https://prismic-team.slack.com/archives/C02L3FN3AJK/p1784638204871279?thread_ts=1784535740.363709&cid=C02L3FN3AJK

### Description

Link fields could not be restricted to specific custom types through the CLI, and a link's allowed type could only be set at creation time. This adds a `--custom-type` option to `field add link` and teaches `field edit` to change a link's allowed type:

```sh
# Allow web, media, and document links, but restrict document links to the "page" type
npx prismic field add link cta --to-type page --custom-type page

# Change the allowed link type on an existing field
npx prismic field edit cta --from-type page --allow web

# Allow all link types again
npx prismic field edit cta --from-type page --allow any

# Remove the custom type restriction
npx prismic field edit cta --from-type page --custom-type ""
```

`--custom-type` combined with `--allow media` or `--allow web` is rejected, since the restriction would have no effect. A comma in `--allow` (e.g. `media,document`) is also rejected: links allow either one type or all types. The syntax stays reserved in case the model gains multi-type support (DT-3465).

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

1. `node --run build`
2. `./dist/index.mjs field add link cta --to-type <type> --custom-type page` and check the model JSON has `customtypes` and no `select`.
3. `./dist/index.mjs field edit cta --from-type <type> --allow web` and check it errors about the custom type restriction.
4. `./dist/index.mjs field edit cta --from-type <type> --custom-type ""` then `--allow web` again and check `select` is set.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
