### PR TITLE
ci: run evals weekly and record results on main

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -1,0 +1,63 @@
+name: evals
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Serializes runs, which share one e2e Prismic account.
+concurrency:
+  group: evals
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  evals:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 40
+    steps:
+      # The agent under test runs in this workspace with Bash; keep the
+      # checkout token out of .git/config so it cannot push with it.
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+
+      - name: Run evals
+        env:
+          PRISMIC_ALLOW_EVALS: "true"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          E2E_PRISMIC_EMAIL: ${{ secrets.E2E_PRISMIC_EMAIL }}
+          E2E_PRISMIC_PASSWORD: ${{ secrets.E2E_PRISMIC_PASSWORD }}
+        run: node --run evals || true
+
+      # Results are recorded only from main runs, via a PR the job merges itself.
+      - name: Record results
+        if: github.ref_name == 'main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh auth setup-git
+          {
+            echo '```'
+            node --run evals:report
+            echo '```'
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          } > "$RUNNER_TEMP/report.md"
+          title="test(eval): record eval run at $(git rev-parse --short HEAD)"
+          branch="evals/run-${{ github.run_id }}-${{ github.run_attempt }}"
+          git switch -c "$branch"
+          git -c user.name="github-actions[bot]" \
+            -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "$title" -- evals/results.json
+          git push origin "$branch"
+          gh pr create --base main --head "$branch" --title "$title" \
+            --body-file "$RUNNER_TEMP/report.md"
+          gh pr merge "$branch" --squash --delete-branch


### PR DESCRIPTION
Resolves:

### Description

Runs the eval suite in CI: weekly on Monday 06:00 UTC, and on demand via workflow dispatch. Results land on `main` through a bot-opened PR the job squash-merges immediately, since main's ruleset requires changes to arrive by PR. The results PR body carries the run's report, so watching the repo's PRs doubles as a weekly report; run-over-run history is the git log of `evals/results.json`.

Eval failures do not fail the job; evals are measurements, not gates. The job fails only when `evals/results.json` was not rewritten (the commit is the gate), meaning the harness died before grading. The eval step never receives `GH_TOKEN` because the agent under test can read the step's environment.

Requires one new repository secret: `ANTHROPIC_API_KEY` (already set).

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

After this merges: Actions → evals → Run workflow. The run takes roughly 10–15 minutes and about $31; confirm it opens and squash-merges a `test(eval): record eval run at …` PR whose body shows the per-eval report.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants CI write/PR permissions and uses production API and e2e secrets, but scope is limited to eval automation with deliberate token isolation from the agent step.
> 
> **Overview**
> Adds a new **evals** GitHub Actions workflow that runs the existing `npm run evals` suite on a schedule (Mondays 06:00 UTC), on **workflow_dispatch**, and temporarily on pushes to `aa/evals-workflow` for pre-merge testing.
> 
> The job uses a **concurrency** group so runs don’t overlap on the shared e2e Prismic account, checks out with **`persist-credentials: false`** so the agent under test can’t use the checkout token to push, and keeps **`GH_TOKEN` out of the eval step** (only the record step gets it). Eval failures are **non-blocking** (`|| true`); recording on **`main` only** opens a bot PR that commits `evals/results.json`, embeds the `evals:report` output in the PR body, and **squash-merges** immediately to satisfy branch protection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68bb4abad9c525b8d611a538ca78244617b31b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

