### PR TITLE
fix: fetch the profile for telemetry only when telemetry is enabled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,12 +115,13 @@ async function main(): Promise<void> {
 	if (!help) {
 		const { token, host } = await getCredentials();
 
-		const telemetryEnabled = await isTelemetryEnabled();
+		const telemetryEnabled = env.PRISMIC_TELEMETRY_ENABLED ?? (await isTelemetryEnabled());
+		const sentryEnabled = env.PRISMIC_SENTRY_ENABLED ?? (telemetryEnabled && env.PROD);
 
-		if (env.PRISMIC_SENTRY_ENABLED ?? (telemetryEnabled && env.PROD)) {
+		if (sentryEnabled) {
 			await initSentry({ host, repo });
 		}
-		if (env.PRISMIC_TELEMETRY_ENABLED ?? telemetryEnabled) {
+		if (telemetryEnabled) {
 			await initTracking({ host, repo });
 		}
 
@@ -132,7 +133,7 @@ async function main(): Promise<void> {
 				process.on("exit", () => spawnTokenRefresh());
 			}
 
-			if (!exp || exp > now) {
+			if ((sentryEnabled || telemetryEnabled) && (!exp || exp > now)) {
 				getProfile({ token, host })
 					.then((profile) => {
 						trackUser(profile);

--- a/test/token-create.test.ts
+++ b/test/token-create.test.ts
@@ -44,7 +44,8 @@ it("creates an access token with --allow-releases", async ({
 	expect(auth!.scope).toBe("master+releases");
 });
 
-it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
+// Wroom 500s under concurrent same-user write-token creates; keep this sequential.
+it.sequential("creates a write token", async ({ expect, prismic, repo, token, host }) => {
 	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--write"]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Token created:");
@@ -57,7 +58,14 @@ it("creates a write token", async ({ expect, prismic, repo, token, host }) => {
 	expect(found).toBeDefined();
 });
 
-it("creates a write token with a custom --name", async ({ expect, prismic, repo, token, host }) => {
+// Wroom 500s under concurrent same-user write-token creates; keep this sequential.
+it.sequential("creates a write token with a custom --name", async ({
+	expect,
+	prismic,
+	repo,
+	token,
+	host,
+}) => {
 	const { stdout, stderr, exitCode } = await prismic("token", [
 		"create",
 		"--write",
@@ -75,7 +83,14 @@ it("creates a write token with a custom --name", async ({ expect, prismic, repo,
 	expect(found!.app_name).toBe("My Seed Token");
 });
 
-it("outputs a write token as JSON with --json", async ({ expect, prismic, repo, token, host }) => {
+// Wroom 500s under concurrent same-user write-token creates; keep this sequential.
+it.sequential("outputs a write token as JSON with --json", async ({
+	expect,
+	prismic,
+	repo,
+	token,
+	host,
+}) => {
 	const { stdout, stderr, exitCode } = await prismic("token", ["create", "--write", "--json"]);
 	expect(exitCode, stderr).toBe(0);
 

--- a/test/token-delete.test.ts
+++ b/test/token-delete.test.ts
@@ -19,7 +19,8 @@ it("deletes an access token", async ({ expect, prismic, repo, token, host }) => 
 	expect(allAuths.find((a) => a.token === created.token)).toBeUndefined();
 });
 
-it("deletes a write token", async ({ expect, prismic, repo, token, host }) => {
+// Wroom 500s under concurrent same-user write-token creates; keep this sequential.
+it.sequential("deletes a write token", async ({ expect, prismic, repo, token, host }) => {
 	const created = await createWriteToken({ repo, token, host });
 
 	const { stdout, stderr, exitCode } = await prismic("token", ["delete", created.token]);


### PR DESCRIPTION
Resolves:

### Description

The CLI fetched the user profile on every command, even when telemetry and Sentry were both disabled. Under concurrent runs against the same user, these calls can 500. The profile is now fetched only when telemetry or Sentry is enabled, and the env var overrides feed the same flags.

Also marks the write-token tests as sequential because Wroom 500s under concurrent same-user write-token creates.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run any command with telemetry disabled and confirm no request to `/profile` is made.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change only skips profile API calls when observability is disabled; token refresh logic is unchanged.
> 
> **Overview**
> **Startup no longer calls `/profile` when both telemetry and Sentry are off**, which avoids extra Wroom traffic and concurrent 500s when many CLI processes share the same user.
> 
> `telemetryEnabled` and `sentryEnabled` are resolved once (including `PRISMIC_TELEMETRY_ENABLED` / `PRISMIC_SENTRY_ENABLED` overrides) and reused for init and for gating `getProfile` → `trackUser` / `sentrySetUser`.
> 
> Write-token integration tests in `token-create` and `token-delete` are **`it.sequential`** with a note that Wroom errors on concurrent same-user write-token creates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe45dddd192517520b2aed24b7b19943ce9a3172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->