### PR TITLE
test: make evals judge outcomes and self-explain failures

### DIFF
--- a/evals/edit-models-precisely.eval.ts
+++ b/evals/edit-models-precisely.eval.ts
@@ -146,13 +146,16 @@ it.for(trials)(
 			`On the "product" type, add a "size" dropdown with the options S, M, and L, and an "author" link that can only point to "author" documents.`,
 		);
 
-		expect(result).toHaveRun("prismic", ["field", "add", "select"]);
-		expect(result).toHaveRun("prismic", ["field", "add", "content-relationship"]);
+		// Both `field add content-relationship` and `field add link --allow document`
+		// model a constrained relationship; judge the resulting model, not the command.
+		expect(result).toHaveRun("prismic", ["field", "add"]);
 		const model = await readLocalCustomType(project, product.id);
 		expect(model.json.Main.size.type).toBe("Select");
 		expect((model.json.Main.size.config as { options: string[] }).options).toEqual(["S", "M", "L"]);
 		expect(model.json.Main.author.type).toBe("Link");
-		expect(JSON.stringify(model.json.Main.author.config)).toContain("author");
+		const authorConfig = model.json.Main.author.config as { select?: string };
+		expect(authorConfig.select).toBe("document");
+		expect(JSON.stringify(authorConfig)).toContain("author");
 	},
 );
 

--- a/evals/it.ts
+++ b/evals/it.ts
@@ -122,7 +122,8 @@ expect.extend({
 				const wanted = [bin, ...positionals].join(" ");
 				if (pass) return `expected no command matching \`${wanted}\`, but one ran`;
 				const seen = result.commands.map((c) => `  ${c}`).join("\n") || "  (no commands ran)";
-				return `expected a command matching \`${wanted}\`, but saw:\n${seen}`;
+				const final = "result" in result.result ? result.result.result : "";
+				return `expected a command matching \`${wanted}\`, but saw:\n${seen}\n\nagent's final message:\n${final}`;
 			},
 		};
 	},

--- a/evals/sync-models.eval.ts
+++ b/evals/sync-models.eval.ts
@@ -43,7 +43,12 @@ it.for(trials)(
 		await exec("git", ["init"]);
 		await exec("git", ["add", "-A"]);
 		await exec("git", ["commit", "-m", "Initial commit"]);
-		const article = buildCustomType({ id: "article", label: "Article" });
+		// A field so the type looks finished; the agent balks at pushing an empty type.
+		const article = buildCustomType({
+			id: "article",
+			label: "Article",
+			json: { Main: { title: { type: "Text", config: { label: "Title" } } } },
+		});
 		await writeLocalCustomType(project, article);
 
 		const result = await agent(


### PR DESCRIPTION
Resolves:

### Description

Two evals scored 0/3 in the first CI run for reasons that were not agent failures. "adds constrained fields" required the `field add content-relationship` command, but the agent used `field add link --allow document`, which models the same constrained relationship; the eval now asserts the resulting model shape instead of the command. "commits and pushes local model changes" seeded an article type with no fields, so the agent reasonably asked for confirmation instead of publishing an empty type; the fixture now seeds a title field.

`toHaveRun` failures now also print the agent's final message, which is how the empty-type problem was found. Future CI failures explain themselves in the log without a local rerun.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

```sh
# Run the two adjusted evals:
# PRISMIC_ALLOW_EVALS=true node --run evals -- edit-models-precisely -t "adds constrained fields"
# PRISMIC_ALLOW_EVALS=true node --run evals -- sync-models -t "commits and pushes"
```

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to eval assertions and fixtures; no production runtime behavior.
> 
> **Overview**
> **Evals now grade agent results by outcome instead of exact CLI spelling**, so CI failures reflect real regressions rather than equivalent command choices.
> 
> In **adds constrained fields**, the test no longer requires `field add content-relationship` or `field add link`; it only checks that some `field add` ran and that the product model has the select options and a document link constrained to `author` (including `select: "document"`).
> 
> In **commits and pushes local model changes**, the article fixture includes a **Title** text field so the agent is not stuck confirming an empty type before `push`.
> 
> When **`toHaveRun`** fails, the assertion message now includes the **agent’s final message** alongside the command list, making CI logs easier to debug without a local rerun.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f8c2d46c3fc51e5e36044fdd7f6282ba3207d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->