### PR TITLE
ci: run only a single Windows check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: blacksmith-4vcpu-windows-2025
     strategy:
       matrix:
-        node: [20, 22, 24]
+        node: [20]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: blacksmith-4vcpu-windows-2025
     strategy:
       matrix:
-        node: [20]
+        node: [24]
       fail-fast: false
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: https://prismic-team.slack.com/archives/C014VAACCQL/p1784933535521479

### Description

<!-- Describe your changes in detail. -->
<!-- Why is this change required? -->
<!-- What problem does it solve? -->

This PR reduces the Windows `test` CI jobs from three (Node.js 20, 22, 24) to one (Node.js 24). As a result, we cut down on failures and wait time.

**Reasoning**: We only need to run Node 20, 22, 24 on *some* OS and one Windows sanity-check.

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only matrix change with no application or runtime behavior changes; slightly less Node version coverage on Windows only.
> 
> **Overview**
> Narrows the **`test-win32`** job in `validate.yml` so Windows unit tests run only on **Node.js 24**, instead of a matrix across **20, 22, and 24**.
> 
> Linux **`test`** still exercises all three Node versions; Windows remains a single sanity check with less CI time and fewer flaky Windows-only failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6f0218be22d165823e75abea2d98c610076c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->