### PR TITLE
feat: rewrite non-canonical model files on pull

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -88,8 +88,7 @@ export default createCommand(config, async ({ values }) => {
 		localCustomTypes.map((customType) => customType.model),
 		{
 			getKey: (model) => model.id,
-			equals: (a, b) =>
-				JSON.stringify(canonicalizeCustomType(a)) === JSON.stringify(canonicalizeCustomType(b)),
+			equals: (remote, local) => JSON.stringify(canonicalizeCustomType(remote)) === JSON.stringify(local),
 		},
 	);
 	const sliceOps = diffArrays(
@@ -97,8 +96,7 @@ export default createCommand(config, async ({ values }) => {
 		localSlices.map((slice) => slice.model),
 		{
 			getKey: (model) => model.id,
-			equals: (a, b) =>
-				JSON.stringify(canonicalizeSlice(a)) === JSON.stringify(canonicalizeSlice(b)),
+			equals: (remote, local) => JSON.stringify(canonicalizeSlice(remote)) === JSON.stringify(local),
 		},
 	);
 

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -1,5 +1,5 @@
 import { pascalCase } from "change-case";
-import { writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { x } from "tinyexec";
@@ -248,6 +248,31 @@ it.sequential("removes route when page type is deleted", async ({
 	const second = await prismic("pull", ["--repo", repo, "--force"]);
 	expect(second.exitCode, second.stderr).toBe(0);
 	await expect(project).not.toHaveRoute({ type: customType.id });
+});
+
+it.sequential("rewrites model files whose key order is not canonical", async ({
+	expect,
+	project,
+	prismic,
+	repo,
+	token,
+	host,
+}) => {
+	const customType = buildCustomType();
+	await insertCustomType(customType, { repo, token, host });
+
+	const first = await prismic("pull", ["--repo", repo]);
+	expect(first.exitCode, first.stderr).toBe(0);
+
+	const modelPath = new URL(`customtypes/${customType.id}/index.json`, project);
+	const canonical = await readFile(modelPath, "utf8");
+	const reversed = Object.fromEntries(Object.entries(JSON.parse(canonical)).reverse());
+	await writeFile(modelPath, JSON.stringify(reversed, null, 2));
+
+	const second = await prismic("pull", ["--repo", repo, "--force"]);
+	expect(second.exitCode, second.stderr).toBe(0);
+	expect(second.stdout).toContain("updated 1");
+	expect(await readFile(modelPath, "utf8")).toBe(canonical);
 });
 
 it.sequential("blocks pull when local model files have uncommitted changes", async ({


### PR DESCRIPTION
Resolves:

### Description

Stacked on #243.

Files that matched remote semantically but had non-canonical key order were never rewritten by `prismic pull`. They stayed non-canonical until a real change arrived, which then buried that change in a full-file reformat diff.

The fix: pull no longer canonicalizes the local side of the comparison. The remote model's canonical form is compared against the local file as parsed. Non-canonical files now count as updates and get rewritten, so files self-heal on the next pull.

`status` and `push` keep the semantic comparison. Push has no file bytes to compare against, and reorder-tolerance there prevents no-op version bumps.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

In a project with committed model files in non-canonical key order (e.g. written by Slice Machine), run `prismic pull`. The files should be rewritten in canonical form and reported as updated. A second pull should report "Already up to date."

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)