### PR TITLE
 test(evals): dedupe test names across test modules

### DIFF
--- a/evals/reporter.ts
+++ b/evals/reporter.ts
@@ -31,23 +31,24 @@ export default class EvalReporter implements Reporter {
 
 		for (const testModule of testModules) {
 			for (const test of testModule.children.allTests()) {
-				const state = test.result().state;
+				const result = test.result();
 				// Vitest reports -t-filtered, .only-suppressed, and it.skip tests
 				// identically (skipped, mode "skip"); only it.todo stays apart. So
 				// permanent disables must be authored as it.todo, and any other
 				// skipped test means the run was filtered.
-				if (state === "skipped" && test.options.mode !== "todo") filtered = true;
-				if (state !== "passed" && state !== "failed") continue;
+				if (result.state === "skipped" && test.options.mode !== "todo") filtered = true;
+				if (result.state !== "passed" && result.state !== "failed") continue;
+				const threw = result.state === "failed" && result.errors.length > 0;
 				const trial = test.meta().agent;
 				// A missing trial means fixture setup failed before the agent got a
 				// prompt: nothing was measured, so the run is not a full snapshot.
-				if (!trial) {
+				if (!trial || threw) {
 					filtered = true;
 					continue;
 				}
 				model = trial.model;
 				(evals[test.name] ??= []).push({
-					pass: state === "passed",
+					pass: result.state === "passed",
 					costUsd: Math.round(trial.costUsd * 100) / 100,
 					durationS: trial.durationS,
 					calls: trial.calls,

--- a/evals/reporter.ts
+++ b/evals/reporter.ts
@@ -47,7 +47,7 @@ export default class EvalReporter implements Reporter {
 					continue;
 				}
 				model = trial.model;
-				(evals[test.name] ??= []).push({
+				(evals[`${testModule.relativeModuleId} / ${test.name}`] ??= []).push({
 					pass: result.state === "passed",
 					costUsd: Math.round(trial.costUsd * 100) / 100,
 					durationS: trial.durationS,

--- a/evals/reporter.ts
+++ b/evals/reporter.ts
@@ -31,24 +31,23 @@ export default class EvalReporter implements Reporter {
 
 		for (const testModule of testModules) {
 			for (const test of testModule.children.allTests()) {
-				const result = test.result();
+				const state = test.result().state;
 				// Vitest reports -t-filtered, .only-suppressed, and it.skip tests
 				// identically (skipped, mode "skip"); only it.todo stays apart. So
 				// permanent disables must be authored as it.todo, and any other
 				// skipped test means the run was filtered.
-				if (result.state === "skipped" && test.options.mode !== "todo") filtered = true;
-				if (result.state !== "passed" && result.state !== "failed") continue;
-				const threw = result.state === "failed" && result.errors.length > 0;
+				if (state === "skipped" && test.options.mode !== "todo") filtered = true;
+				if (state !== "passed" && state !== "failed") continue;
 				const trial = test.meta().agent;
 				// A missing trial means fixture setup failed before the agent got a
 				// prompt: nothing was measured, so the run is not a full snapshot.
-				if (!trial || threw) {
+				if (!trial) {
 					filtered = true;
 					continue;
 				}
 				model = trial.model;
 				(evals[`${testModule.relativeModuleId} / ${test.name}`] ??= []).push({
-					pass: result.state === "passed",
+					pass: state === "passed",
 					costUsd: Math.round(trial.costUsd * 100) / 100,
 					durationS: trial.durationS,
 					calls: trial.calls,


### PR DESCRIPTION
<!-- Please use a Conventional Commit in your PR title -->
<!-- https://conventionalcommits.org -->
<!-- e.g. "feat: support new field type" -->

Resolves: n/a

### Description

- Dedupe eval names by keying them to their module ID (relative file path)

### Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- Don't hesitate to ask for help! -->

- [x] If my changes require tests, I added them.
- [x] If my changes affect backward compatibility, it has been discussed.
- [x] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

n/a

<!-- If your changes are visual, screenshots or videos are welcome! -->

### How to QA [^1]

<!-- When relevant, describe how to QA your changes. -->

<!-- Your favorite emoji is welcome to close your PR! -->

<!-- A note for reviewers: -->

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-reporting-only change; committed `results.json` key names will change on the next full eval run.
> 
> **Overview**
> Eval JSON output (`results.json` / `results.local.json`) now keys each trial under **`{relativeModuleId} / {test name}`** instead of the bare test title.
> 
> That stops collisions when multiple `*.eval.ts` files reuse the same case name (e.g. several **`supports --help`** cases), so each module’s results stay separate in the report and in **`npm run evals:report`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5beb5a64f938883a6f8b1c4f4a07b7b68817e531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->