### PR TITLE
test: fix npm stub on Windows

### DIFF
--- a/test/it.ts
+++ b/test/it.ts
@@ -4,7 +4,7 @@ import type { Result } from "tinyexec";
 import { pascalCase } from "change-case";
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { x } from "tinyexec";
 import { inject, test } from "vitest";
@@ -81,6 +81,10 @@ export const it = test.extend<Fixtures>({
 			`#!/bin/sh\necho '{}' > "${lockfilePath}"\necho "added 0 packages"\n`,
 			{ mode: 0o755 },
 		);
+		await writeFile(
+			new URL("npm.cmd", binDir),
+			`@echo {}> "${lockfilePath}"\n@echo added 0 packages\n`,
+		);
 
 		// Stub Next.js installation
 		const packageJsonPath = new URL("package.json", projectPath);
@@ -128,7 +132,7 @@ export const it = test.extend<Fixtures>({
 					env: {
 						...process.env,
 						...options?.nodeOptions?.env,
-						PATH: `${fileURLToPath(bin)}:${process.env.PATH}`,
+						PATH: `${fileURLToPath(bin)}${delimiter}${process.env.PATH}`,
 						HOME: fileURLToPath(home),
 					},
 				},


### PR DESCRIPTION
Resolves:

### Description

Windows CI times out on the `init` and `gen setup` tests almost every run.

**Reason**: The npm stub in `test/it.ts` never worked on Windows: it is a POSIX shell script with a shebang (Windows only executes `.exe`/`.cmd`/`.bat`), and the stub directory was prepended to `PATH` with `:` instead of `;`. Tests therefore ran the real `npm install next@latest` in a temp dir, which takes 30–180s on Windows runners and blows the 30s test timeout.

**Solution**: Add an `npm.cmd` stub next to the existing sh stub and use `path.delimiter` for the `PATH` prepend.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [ ] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Check that the `test windows` jobs pass without the `init`/`gen setup` timeouts.

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)