### PR TITLE
test(eval): actually isolate eval repositories

### DIFF
--- a/evals/it.ts
+++ b/evals/it.ts
@@ -41,10 +41,8 @@ declare module "vitest" {
 }
 
 export const it = base.extend<{
-	isolateRepo: boolean;
 	agent: (prompt: string) => Promise<AgentResult>;
 }>({
-	isolateRepo: true,
 	agent: async ({ home, project, login, task, repo, token, host, password }, use) => {
 		await login();
 
@@ -101,6 +99,8 @@ export const it = base.extend<{
 		} catch {}
 	},
 });
+
+it.scoped({ isolateRepo: true });
 
 expect.extend({
 	toHaveRun(result: AgentResult, bin: string, positionals: string[] = []) {


### PR DESCRIPTION
Resolves:

### Description

Evals were sharing a repo inadvertently. Each eval should be using its own repo. This fixes it.

### Checklist

- [ ] A comprehensive Linear ticket, providing sufficient context and details to facilitate the review of the PR, is linked to the PR.
- [x] If my changes require tests, I added them.
- [ ] If my changes affect backward compatibility, it has been discussed.
- [ ] If my changes require an update to the CONTRIBUTING.md guide, I updated it.

### Preview

### How to QA [^1]

Run the evals and check that each test creates a `prismic-cli-isolated-*` repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[^1]:
	Please use these labels when submitting a review:
	:question: #ask:&ensp;Ask a question.
	:bulb: #idea:&ensp;Suggest an idea.
	:warning: #issue:&ensp;Strongly suggest a change.
	:tada: #nice:&ensp;Share a compliment.