### PR TITLE
ci: add format check and apply oxfmt

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,22 @@ name: validate
 on: push
 
 jobs:
+  format:
+    runs-on: blacksmith-2vcpu-ubuntu-2404-arm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - id: format
+        continue-on-error: true
+        run: npm run format -- --check
+      - name: Report format failures
+        if: steps.format.outcome == 'failure'
+        run: echo "::warning::Code is not formatted. Run \`npm run format\` locally."
+
   lint:
     runs-on: blacksmith-2vcpu-ubuntu-2404-arm
     steps:

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -69,10 +69,7 @@ export abstract class Adapter {
 	abstract readonly localPreviewConfig: LocalDevelopmentPreview;
 
 	get localPreviewUrl(): string {
-		return new URL(
-			this.localPreviewConfig.resolverPath,
-			this.localPreviewConfig.websiteURL,
-		).href;
+		return new URL(this.localPreviewConfig.resolverPath, this.localPreviewConfig.websiteURL).href;
 	}
 
 	get localSimulatorUrl(): string {

--- a/src/adapters/sveltekit.ts
+++ b/src/adapters/sveltekit.ts
@@ -1,7 +1,4 @@
-import type {
-	CustomType,
-	SharedSlice,
-} from "@prismicio/types-internal/lib/customtypes";
+import type { CustomType, SharedSlice } from "@prismicio/types-internal/lib/customtypes";
 
 import { pascalCase } from "change-case";
 import { loadFile } from "magicast";

--- a/src/commands/field-add-rich-text.ts
+++ b/src/commands/field-add-rich-text.ts
@@ -65,7 +65,10 @@ export default createCommand(config, async ({ positionals, values }) => {
 			label: label ?? capitalCase(fieldId),
 			placeholder,
 			...(isSingle ? { single: allow } : { multi: allow }),
-			labels: labels?.split(",").map(label => label.trim()).filter(Boolean),
+			labels: labels
+				?.split(",")
+				.map((label) => label.trim())
+				.filter(Boolean),
 			allowTargetBlank,
 		},
 	};

--- a/src/commands/field-edit.ts
+++ b/src/commands/field-edit.ts
@@ -185,7 +185,9 @@ export default createCommand(config, async ({ positionals, values }) => {
 						"--allow accepts a single link type. Prismic links allow either one type or all types.",
 					);
 				} else {
-					throw new CommandError("--allow for link fields must be one of: document, media, web, any");
+					throw new CommandError(
+						"--allow for link fields must be one of: document, media, web, any",
+					);
 				}
 			}
 			if ("field" in values) {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,7 +8,12 @@ import { DEFAULT_PRISMIC_HOST, env } from "../env";
 import { openBrowser } from "../lib/browser";
 import { CommandError, createCommand, type CommandConfig } from "../lib/command";
 import { diffArrays } from "../lib/diff";
-import { installDependencies, readPackageJson, removeDependencies, updatePackageJsonName } from "../lib/packageJson";
+import {
+	installDependencies,
+	readPackageJson,
+	removeDependencies,
+	updatePackageJsonName,
+} from "../lib/packageJson";
 import {
 	addPreview,
 	getPreviews,
@@ -17,9 +22,9 @@ import {
 } from "../lib/prismic/clients/core";
 import { getCustomTypes, getSlices } from "../lib/prismic/clients/custom-types";
 import { getRepository, type Repository } from "../lib/prismic/clients/repository";
-import { completeOnboardingSteps } from "../lib/prismic/onboarding";
 import { getProfile } from "../lib/prismic/clients/user";
 import { canonicalizeCustomType, canonicalizeSlice } from "../lib/prismic/models";
+import { completeOnboardingSteps } from "../lib/prismic/onboarding";
 import { ForbiddenRequestError, UnauthorizedRequestError } from "../lib/request";
 import { sentryCaptureError } from "../lib/sentry";
 import { dedent } from "../lib/string";
@@ -241,9 +246,7 @@ export default createCommand(config, async ({ values }) => {
 
 	const hasStarterModelChanges =
 		isExistingProjectHandoff &&
-		[customTypeOps, sliceOps].some(
-			(ops) => ops.update.length > 0 || ops.delete.length > 0,
-		);
+		[customTypeOps, sliceOps].some((ops) => ops.update.length > 0 || ops.delete.length > 0);
 
 	if (!hasStarterModelChanges) {
 		for (const slice of sliceOps.update) {
@@ -314,17 +317,17 @@ async function completeStarterHandoff(
 	config: { repo: string; token: string | undefined; host: string },
 ): Promise<void> {
 	try {
-		const hostedPreviewURL = new URL(
-			adapter.localPreviewConfig.resolverPath,
-			starter.deploymentUrl,
-		).href;
+		const hostedPreviewURL = new URL(adapter.localPreviewConfig.resolverPath, starter.deploymentUrl)
+			.href;
 		const previews = await getPreviews(config);
 		await Promise.all(
 			previews
 				.filter((preview) => preview.url === hostedPreviewURL)
 				.map((preview) => removePreview(preview.id, config)),
 		);
-		const hasDevelopmentPreview = previews.some((preview) => preview.url === adapter.localPreviewUrl);
+		const hasDevelopmentPreview = previews.some(
+			(preview) => preview.url === adapter.localPreviewUrl,
+		);
 		if (!hasDevelopmentPreview) {
 			await addPreview(adapter.localPreviewConfig, config);
 		}

--- a/test/field-add-content-relationship.test.ts
+++ b/test/field-add-content-relationship.test.ts
@@ -9,7 +9,11 @@ import {
 } from "./it";
 
 it("supports --help", async ({ expect, prismic }) => {
-	const { stdout, stderr, exitCode } = await prismic("field", ["add", "content-relationship", "--help"]);
+	const { stdout, stderr, exitCode } = await prismic("field", [
+		"add",
+		"content-relationship",
+		"--help",
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("prismic field add content-relationship <id> [options]");
 });

--- a/test/field-add-uid.test.ts
+++ b/test/field-add-uid.test.ts
@@ -10,7 +10,12 @@ it("adds a uid field to a custom type", async ({ expect, prismic, project }) => 
 	const customType = buildCustomType();
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, stderr, exitCode } = await prismic("field", ["add", "uid", "--to-type", customType.id]);
+	const { stdout, stderr, exitCode } = await prismic("field", [
+		"add",
+		"uid",
+		"--to-type",
+		customType.id,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 
@@ -23,7 +28,12 @@ it("adds a uid field to a page type", async ({ expect, prismic, project }) => {
 	const pageType = buildCustomType({ format: "page" });
 	await writeLocalCustomType(project, pageType);
 
-	const { stdout, stderr, exitCode } = await prismic("field", ["add", "uid", "--to-type", pageType.id]);
+	const { stdout, stderr, exitCode } = await prismic("field", [
+		"add",
+		"uid",
+		"--to-type",
+		pageType.id,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Field added: uid");
 

--- a/test/field-view.test.ts
+++ b/test/field-view.test.ts
@@ -14,7 +14,12 @@ it("views a field in a slice", async ({ expect, prismic, project }) => {
 	};
 	await writeLocalSlice(project, slice);
 
-	const { stdout, stderr, exitCode } = await prismic("field", ["view", "title", "--from-slice", slice.id]);
+	const { stdout, stderr, exitCode } = await prismic("field", [
+		"view",
+		"title",
+		"--from-slice",
+		slice.id,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Type: StructuredText");
 	expect(stdout).toContain("Label: Title");

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -1,7 +1,13 @@
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { describe } from "vitest";
 
-import { buildCustomType, captureOutput, it, readLocalCustomType, writeLocalCustomType } from "./it";
+import {
+	buildCustomType,
+	captureOutput,
+	it,
+	readLocalCustomType,
+	writeLocalCustomType,
+} from "./it";
 import {
 	addPreview,
 	createInstantStartRepository,
@@ -379,9 +385,7 @@ it("fails when the starter repository has no models", async ({
 			await deleteDocumentsByCustomType(customType.id, { repo, token, host });
 			await deleteCustomType(customType.id, { repo, token, host });
 		}
-		await Promise.all(
-			slices.map((slice) => deleteSlice(slice.id, { repo, token, host })),
-		);
+		await Promise.all(slices.map((slice) => deleteSlice(slice.id, { repo, token, host })));
 
 		const { stderr, exitCode } = await prismic("init", ["--repo", repo, "--no-setup"]);
 		expect(exitCode).toBe(1);

--- a/test/preview-set-simulator.test.ts
+++ b/test/preview-set-simulator.test.ts
@@ -21,7 +21,10 @@ it.sequential("sets simulator URL", async ({ expect, prismic, repo, token, host 
 
 // Must be sequential because the repo only has one simulator URL.
 it.sequential("appends /slice-simulator to URL", async ({ expect, prismic }) => {
-	const { stdout, stderr, exitCode } = await prismic("preview", ["set-simulator", "https://example.com"]);
+	const { stdout, stderr, exitCode } = await prismic("preview", [
+		"set-simulator",
+		"https://example.com",
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain("Simulator URL set: https://example.com/slice-simulator");
 });

--- a/test/prismic.ts
+++ b/test/prismic.ts
@@ -41,9 +41,7 @@ export async function createInstantStartRepository(config: AuthConfig): Promise<
 		headers: { Authorization: `Bearer ${config.token}` },
 	});
 	if (!res.ok)
-		throw new Error(
-			`Failed to create Instant Start repository: ${res.status} ${await res.text()}`,
-		);
+		throw new Error(`Failed to create Instant Start repository: ${res.status} ${await res.text()}`);
 	const data = await res.json();
 	return data.repositoryId;
 }
@@ -55,8 +53,7 @@ export async function getOnboardingCompletedSteps(config: RepoConfig): Promise<s
 	const res = await fetch(url, {
 		headers: { Authorization: `Bearer ${config.token}`, repository: config.repo },
 	});
-	if (!res.ok)
-		throw new Error(`Failed to get onboarding state: ${res.status} ${await res.text()}`);
+	if (!res.ok) throw new Error(`Failed to get onboarding state: ${res.status} ${await res.text()}`);
 	const data = await res.json();
 	return data.completedSteps;
 }
@@ -132,8 +129,7 @@ export async function deleteDocumentsByCustomType(
 		},
 		body: JSON.stringify({ customtype_ids: [customTypeId] }),
 	});
-	if (!res.ok)
-		throw new Error(`Failed to delete documents: ${res.status} ${await res.text()}`);
+	if (!res.ok) throw new Error(`Failed to delete documents: ${res.status} ${await res.text()}`);
 }
 
 export async function getSlices(config: RepoConfig): Promise<SharedSlice[]> {

--- a/test/slice-connect.test.ts
+++ b/test/slice-connect.test.ts
@@ -33,7 +33,12 @@ it("connects a slice to a type", async ({ expect, prismic, project }) => {
 	await writeLocalSlice(project, slice);
 	await writeLocalCustomType(project, customType);
 
-	const { stdout, stderr, exitCode } = await prismic("slice", ["connect", slice.id, "--to", customType.id]);
+	const { stdout, stderr, exitCode } = await prismic("slice", [
+		"connect",
+		slice.id,
+		"--to",
+		customType.id,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Connected slice "${slice.id}" to "${customType.id}"`);
 

--- a/test/slice-edit.test.ts
+++ b/test/slice-edit.test.ts
@@ -12,7 +12,12 @@ it("edits a slice name", async ({ expect, prismic, project }) => {
 
 	const newName = `SliceS${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, stderr, exitCode } = await prismic("slice", ["edit", slice.id, "--name", newName]);
+	const { stdout, stderr, exitCode } = await prismic("slice", [
+		"edit",
+		slice.id,
+		"--name",
+		newName,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Slice updated: "${newName}"`);
 

--- a/test/type-add-tab.test.ts
+++ b/test/type-add-tab.test.ts
@@ -12,7 +12,12 @@ it("adds a tab to a type", async ({ expect, prismic, project }) => {
 
 	const tabName = `Tab${crypto.randomUUID().split("-")[0]}`;
 
-	const { stdout, stderr, exitCode } = await prismic("type", ["add-tab", tabName, "--to", customType.id]);
+	const { stdout, stderr, exitCode } = await prismic("type", [
+		"add-tab",
+		tabName,
+		"--to",
+		customType.id,
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Added tab "${tabName}" to "${customType.id}"`);
 

--- a/test/type-create.test.ts
+++ b/test/type-create.test.ts
@@ -24,7 +24,12 @@ it("creates a custom type", async ({ expect, prismic, project }) => {
 it("creates a page type with --format page", async ({ expect, prismic, project }) => {
 	const { label } = buildCustomType({ format: "page" });
 
-	const { stdout, stderr, exitCode } = await prismic("type", ["create", label!, "--format", "page"]);
+	const { stdout, stderr, exitCode } = await prismic("type", [
+		"create",
+		label!,
+		"--format",
+		"page",
+	]);
 	expect(exitCode, stderr).toBe(0);
 	expect(stdout).toContain(`Created type "${label}"`);
 


### PR DESCRIPTION
## Summary
- Apply `oxfmt` across the codebase to standardize formatting
- Add a non-blocking `format` job to the validate workflow that runs `npm run format -- --check` and reports warnings without failing the pipeline

Made with [Cursor](https://cursor.com)